### PR TITLE
Changed FileNotFoundError to IOError

### DIFF
--- a/modules/agdc-instances/datacube-ensure-user.py
+++ b/modules/agdc-instances/datacube-ensure-user.py
@@ -81,7 +81,7 @@ def append_credentials(pgpass, dbcreds):
     try:
         with pgpass.open() as fin:
             data = fin.read()
-    except FileNotFoundError:
+    except IOError:
         data = ''
 
     with atomic_save(str(pgpass.absolute()), file_perms=0o600, text_mode=True) as fout:


### PR DESCRIPTION
This is to support py2. Currently failing to save credentials on agdc-py2-prod.


**!!!Not sure how to test this!!!**