### PR TITLE
Disable py2 module builds

### DIFF
--- a/modules/package-release.sh
+++ b/modules/package-release.sh
@@ -67,7 +67,7 @@ function build_variant() {
 }
 
 build_variant py3
-build_variant py2
+# build_variant py2
 
 echo
 echo "All done."


### PR DESCRIPTION
Python 2.7 modules have been deprecated for a while, with a deprecation warning printed on module load:
```
15:32:45 [jmh547@raijin2:~]$ module load agdc-py2-prod

Warning: we may discontinue Python 2 support in the near future.

Please consider moving to our Python 3 module: agdc-py3-prod

  -> If you have a hard requirement on Python 2 that makes the change 
     difficult, please notify us at earth.observation@ga.gov.au
  -> The python-modernize command is available to ease conversions, 
     see: https://python-modernize.readthedocs.io
15:32:47 [jmh547@raijin2:~]$ 
```

I haven't heard anything from the Ops team on this subject, so I assume no one has contacted the email address (they _have_ contacted us about other issues sent to the address). 

@omad agreed via Slack that we could cease new builds for python 2, offering support at the current stable build for as long as it works with the same data & index. Users will need to move to py3 to use newer DEA releases.

So this pull request disables py2 module creation.

If we go ahead with this, I'll also update the deprecation warning to mention that newer versions are only available via py3 modules.