### PR TITLE
Remove ffmpeg from agdc-env module

### DIFF
--- a/modules/py-environment/environment.yaml
+++ b/modules/py-environment/environment.yaml
@@ -11,7 +11,6 @@ dependencies:
 - dask
 - distributed
 - ephem
-- ffmpeg
 - fiona
 - flask
 - folium


### PR DESCRIPTION
We currently install ffmpeg from conda-forge, intending it to be useful for generating movies from datacube outputs. However, this version of ffmpeg is compiled without the required libraries adding subtitles, making it relatively useless.

An alternate version of ffmpeg v3.3.4 is now available from `/g/data/v10/public/modules` via `module load ffmpeg/3.3.4`