### PR TITLE
Fix ingest error in module dea-20171018

### DIFF
--- a/digitalearthau/submit/ingest.py
+++ b/digitalearthau/submit/ingest.py
@@ -67,7 +67,7 @@ def do_qsub(product_name, year, queue, project, nodes, walltime, name, allow_pro
     name = name or taskfile.stem
     qsub = 'qsub -q %(queue)s -N %(name)s -P %(project)s ' \
            '-l ncpus=%(ncpus)d,mem=%(mem)dgb,walltime=%(walltime)d:00:00 ' \
-           '-- /bin/bash "%(distr)s" "$(dea_module)s" --ppn 16 ' \
+           '-- /bin/bash "%(distr)s" "%(dea_module)s" --ppn 16 ' \
            'datacube -v ingest %(product_changes_flag)s --load-tasks "%(taskfile)s" ' \
            '--executor distributed DSCHEDULER'
     cmd = qsub % dict(taskfile=taskfile,
@@ -167,7 +167,7 @@ def fix(product_name, year, queue, project, nodes, walltime, name):
     name = name or taskfile.stem
     qsub = 'qsub -q %(queue)s -N %(name)s -P %(project)s ' \
            '-l ncpus=%(ncpus)d,mem=%(mem)dgb,walltime=%(walltime)d:00:00 ' \
-           '-- /bin/bash "%(distr)s" "$(dea_module)s" --ppn 16 ' \
+           '-- /bin/bash "%(distr)s" "%(dea_module)s" --ppn 16 ' \
            'datacube-fixer -v --load-tasks "%(taskfile)s" --executor distributed DSCHEDULER'
     cmd = qsub % dict(taskfile=taskfile,
                       distr=DISTRIBUTED_SCRIPT,


### PR DESCRIPTION
Error when ingesting in dea-prod-20171018
```
datacube -v ingest --allow-product-changes --load-tasks "/g/data1/u46/users/hr8696/temp/ls8_nbar_albers_2016.bin" --dry-run
RUN? [y/N]: 
qsub -q normal -N ls8_nbar_albers_2016 -P v10 -l ncpus=16,mem=31gb,walltime=10:00:00 -- /bin/bash "/g/data/v10/private/modules/dea-prod/20171018/lib/python3.6/site-packages/digitalearthau/run_distributed.sh" "$(dea_module)s" --ppn 16 datacube -v ingest --allow-product-changes --load-tasks "/g/data1/u46/users/hr8696/temp/ls8_nbar_albers_2016.bin" --executor distributed DSCHEDULER
RUN? [Y/n]: /bin/sh: dea_module: command not found
Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password,hostbased).
Traceback (most recent call last):
  File "/g/data/v10/private/modules/dea-prod/20171018/bin/dea-submit-ingest", line 11, in <module>
    sys.exit(cli())
  File "/g/data/v10/public/modules/agdc-py3-env/20171016/envs/agdc/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/g/data/v10/public/modules/agdc-py3-env/20171016/envs/agdc/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/g/data/v10/public/modules/agdc-py3-env/20171016/envs/agdc/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/g/data/v10/public/modules/agdc-py3-env/20171016/envs/agdc/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/g/data/v10/public/modules/agdc-py3-env/20171016/envs/agdc/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/g/data/v10/private/modules/dea-prod/20171018/lib/python3.6/site-packages/digitalearthau/submit/ingest.py", line 84, in do_qsub
    subprocess.check_call(cmd, shell=True)
  File "/g/data/v10/public/modules/agdc-py3-env/20171016/envs/agdc/lib/python3.6/subprocess.py", line 291, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command 'qsub -q normal -N ls8_nbar_albers_2016 -P v10 -l ncpus=16,mem=31gb,walltime=10:00:00 -- /bin/bash "/g/data/v10/private/modules/dea-prod/20171018/lib/python3.6/site-packages/digitalearthau/run_distributed.sh" "$(dea_module)s" --ppn 16 datacube -v ingest --allow-product-changes --load-tasks "/g/data1/u46/users/hr8696/temp/ls8_nbar_albers_2016.bin" --executor distributed DSCHEDULER' returned non-zero exit status 255.
```