### PR TITLE
Store cleanup results consistently & automatically

### DIFF
--- a/digitalearthau/uiutil.py
+++ b/digitalearthau/uiutil.py
@@ -13,7 +13,22 @@ class CleanConsoleRenderer(structlog.dev.ConsoleRenderer):
         self._level_to_color['debug'] = structlog.dev.DIM
 
 
-def init_logging():
+def init_logging(output_file=None):
+    """
+    Setup structlog for structured logging output.
+
+    Note:
+
+     - structured logging (here) defaults to stdout
+     - "unstructured" text logging (eg. datacube core) defaults to stderr
+
+    This is because the former is treated as the actual outputs of the scripts we run: something you may pipe
+    into another program. The unstructured logs are purely informational.
+    """
+
+    if output_file is None:
+        output_file = sys.stdout
+
     # Direct structlog into standard logging.
     structlog.configure(
         processors=[
@@ -22,10 +37,10 @@ def init_logging():
             structlog.processors.StackInfoRenderer(),
             structlog.processors.format_exc_info,
             # Coloured output if to terminal.
-            CleanConsoleRenderer() if sys.stdout.isatty()
+            CleanConsoleRenderer() if output_file.isatty()
             else structlog.processors.JSONRenderer(serializer=partial(serialise.to_lenient_json, compact=True)),
         ],
         context_class=dict,
         cache_logger_on_first_use=True,
-        logger_factory=structlog.PrintLoggerFactory(),
+        logger_factory=structlog.PrintLoggerFactory(file=output_file),
     )


### PR DESCRIPTION
The collection management scripts currently output their results to stdout, leaving it up to the user
to pipe/record the results somewhere.

But they are typically run in an ad-hoc manner by different users, so this previous output has mostly been lost or is disorganised.

These commits change the script to automatically output results to the common work folder structure (as with the new `fc`) without user intervention, and to print readable output to the user (no json) about the status.

(this request only changes `cleanup`, but I expect all of the management scripts to eventually do this too)