### PR TITLE
Clean up sync tests, add move tests

### DIFF
--- a/digitalearthau/collections.py
+++ b/digitalearthau/collections.py
@@ -100,6 +100,9 @@ class Collection(NamedTuple):
         return out
 
     def iter_fs_paths_within(self, p: Path):
+        """
+        Iterate over all filesystem paths of this collection that are inside the given folder
+        """
         return (
             Path(path).absolute()
             for file_pattern in self.constrained_file_patterns(p)

--- a/digitalearthau/collections.py
+++ b/digitalearthau/collections.py
@@ -31,7 +31,9 @@ class Collection(NamedTuple):
     query: dict
     # The file glob patterns to iterate all files on disk (NCI collections are all file:// locations)
     file_patterns: Tuple[str, ...]
-    unique: Tuple[str, ...]
+
+    # The fields that together uniquely identify a dataset (for finding duplicates)
+    unique: Tuple[str, ...] = None
 
     index: DatasetPathIndex = None
 

--- a/digitalearthau/duplicates.py
+++ b/digitalearthau/duplicates.py
@@ -1,9 +1,5 @@
 # coding=utf-8
-"""
-Find duplicate datasets
-(eg. if a dataset has been reprocessed but both versions are indexed and active)
 
-"""
 import csv
 import sys
 from datetime import datetime
@@ -150,6 +146,20 @@ collections.init_nci_collections(None)
 @click.argument('collections_', type=click.Choice(collections.registered_collection_names()), nargs=-1)
 @pass_index(app_name="find-duplicates")
 def cli(index, all_, collections_):
+    """
+    Find duplicate datasets for a collection.
+
+    (eg. if a dataset has been reprocessed but both versions are indexed and active)
+
+    This uses the unique fields defined in a collection to try to group them.
+
+    Note that this is really a prototype: it won't report all duplicates as the unique fields aren't good enough.
+
+      - Scenes group by "day" not "solar day"
+
+      - Tiled products should be grouped by tile_index, but it's not in the metadata.
+
+    """
     collections.init_nci_collections(index)
 
     if all_:

--- a/digitalearthau/move.py
+++ b/digitalearthau/move.py
@@ -38,7 +38,16 @@ def cli(index, dry_run, paths, destination, checksum):
     """
     Move the given folder of datasets into the given destination folder.
 
-    Both the source(s) and destination are expected to be paths containing existing DEA collections.
+    This will checksum the data, copy it to the destination, and mark the original as archived in the DEA index.
+
+
+    Notes:
+
+    * An operator can later run dea-clean to trash the archived original locations.
+
+    * Source datasets with failing checksums will be left as-is, with a warning logged.
+
+    * Both the source(s) and destination paths are expected to be paths containing existing DEA collections.
     (See collections.py)
     """
     uiutil.init_logging()

--- a/digitalearthau/move.py
+++ b/digitalearthau/move.py
@@ -18,6 +18,7 @@ from datacube.model import Dataset
 from datacube.ui import click as ui
 from digitalearthau import collections, uiutil
 from digitalearthau import paths as path_utils
+from digitalearthau.index import AgdcDatasetPathIndex
 
 _LOG = structlog.get_logger()
 
@@ -28,14 +29,21 @@ _LOG = structlog.get_logger()
 @click.option('--checksum/--no-checksum', is_flag=True, default=True)
 @click.option('--destination', '-d',
               required=True,
-              type=click.Path(exists=True, writable=True))
+              type=click.Path(exists=True, writable=True),
+              help="Base folder where datasets will be placed inside")
 @click.argument('paths',
                 type=click.Path(exists=True, readable=True),
                 nargs=-1)
 @ui.pass_index('move')
-def main(index, dry_run, paths, destination, checksum):
+def cli(index, dry_run, paths, destination, checksum):
+    """
+    Move the given folder of datasets into the given destination folder.
+
+    Both the source(s) and destination are expected to be paths containing existing DEA collections.
+    (See collections.py)
+    """
     uiutil.init_logging()
-    collections.init_nci_collections(None)
+    collections.init_nci_collections(AgdcDatasetPathIndex(index))
 
     if not path_utils.is_base_directory(destination):
         raise click.BadArgumentUsage(
@@ -263,4 +271,4 @@ def _expected_checksum_path(dataset_path):
 
 
 if __name__ == '__main__':
-    main()
+    cli()

--- a/digitalearthau/move.py
+++ b/digitalearthau/move.py
@@ -18,7 +18,6 @@ from datacube.model import Dataset
 from datacube.ui import click as ui
 from digitalearthau import collections, uiutil
 from digitalearthau import paths as path_utils
-from digitalearthau.index import AgdcDatasetPathIndex
 
 _LOG = structlog.get_logger()
 
@@ -43,7 +42,7 @@ def cli(index, dry_run, paths, destination, checksum):
     (See collections.py)
     """
     uiutil.init_logging()
-    collections.init_nci_collections(AgdcDatasetPathIndex(index))
+    collections.init_nci_collections(index)
 
     if not path_utils.is_base_directory(destination):
         raise click.BadArgumentUsage(

--- a/digitalearthau/sync/__init__.py
+++ b/digitalearthau/sync/__init__.py
@@ -37,7 +37,7 @@ _LOG = structlog.get_logger()
               type=int,
               default=4,
               help="Number of worker processes to use")
-@click.option('-f',
+@click.option('-f', '--format', 'format_',
               type=click.Path(exists=True, readable=True, dir_okay=False),
               help="Input from file instead of scanning collections")
 @click.option('--index-missing', is_flag=True, default=False,
@@ -53,7 +53,7 @@ _LOG = structlog.get_logger()
 # TODO
 # @click.option('--validate', is_flag=True, default=False,
 #               help="Run any available checksums or validation checks for the file type")
-@click.option('-o',
+@click.option('-o', '--output', 'output_file',
               type=click.Path(writable=True, dir_okay=False),
               help="Output to file instead of stdout")
 @click.argument('collections',
@@ -64,10 +64,8 @@ _LOG = structlog.get_logger()
 def cli(index: Index,
         collections: Iterable[str],
         cache_folder: str,
-        # format
-        f: str,
-        # output file
-        o: str,
+        format_: str,
+        output_file: str,
         min_trash_age_hours: bool,
         jobs: int,
         **fix_settings):
@@ -81,12 +79,12 @@ def cli(index: Index,
     with AgdcDatasetPathIndex(index) as path_index:
         cs.init_nci_collections(path_index)
 
-        mismatches = get_mismatches(cache_folder, collections, f, path_index, jobs)
+        mismatches = get_mismatches(cache_folder, collections, format_, path_index, jobs)
 
         out_f = sys.stdout
         try:
-            if o:
-                out_f = open(o, 'w')
+            if output_file:
+                out_f = open(output_file, 'w')
 
             fixes.fix_mismatches(
                 mismatches,
@@ -95,7 +93,7 @@ def cli(index: Index,
                 **fix_settings
             )
         finally:
-            if o:
+            if output_file:
                 out_f.close()
 
 

--- a/digitalearthau/sync/__init__.py
+++ b/digitalearthau/sync/__init__.py
@@ -67,6 +67,11 @@ def cli(index: Index,
         min_trash_age_hours: bool,
         jobs: int,
         **fix_settings):
+    """
+    Update a datacube index to the state of the filesystem.
+
+    This will update locations, trash or index new datasets, depending on the chosen options.
+    """
     uiutil.init_logging()
 
     if fix_settings['index_missing'] and fix_settings['trash_missing']:

--- a/digitalearthau/sync/scan.py
+++ b/digitalearthau/sync/scan.py
@@ -11,10 +11,11 @@ import structlog
 from boltons import fileutils
 from boltons import strutils
 
+from datacube.index._api import Index
 from datacube.utils import uri_to_local_path, InvalidDocException
 from digitalearthau import paths
 from digitalearthau.collections import Collection
-from digitalearthau.index import DatasetPathIndex, DatasetLite
+from digitalearthau.index import DatasetLite, get_datasets_for_uri
 from digitalearthau.sync import validate
 from digitalearthau.sync.differences import UnreadableDataset, InvalidDataset
 from .differences import ArchivedDatasetOnDisk, Mismatch, LocationMissingOnDisk, LocationNotIndexed, \
@@ -75,7 +76,7 @@ def build_pathset(
 logging.getLogger('datacube.index.postgres._connections').setLevel(logging.ERROR)
 
 
-def _find_uri_mismatches(index: DatasetPathIndex, uri: str, validate_data=True) -> Iterable[Mismatch]:
+def _find_uri_mismatches(index: Index, uri: str, validate_data=True) -> Iterable[Mismatch]:
     """
     Compare the index and filesystem contents for the given uris,
     yielding Mismatches of any differences.
@@ -87,7 +88,7 @@ def _find_uri_mismatches(index: DatasetPathIndex, uri: str, validate_data=True) 
     path = uri_to_local_path(uri)
     log = _LOG.bind(path=path)
     log.debug("index.get_dataset_ids_for_uri")
-    indexed_datasets = set(index.get_datasets_for_uri(uri))
+    indexed_datasets = set(get_datasets_for_uri(index, uri))
 
     datasets_in_file = set()  # type: Set[DatasetLite]
     if path.exists():
@@ -123,16 +124,15 @@ def _find_uri_mismatches(index: DatasetPathIndex, uri: str, validate_data=True) 
 
     for dataset in file_ds_not_in_index:
         # If it's already indexed, we just need to add the location.
-        indexed_dataset = index.get(dataset.id)
+        indexed_dataset = index.datasets.get(dataset.id)
         if indexed_dataset:
-            yield LocationNotIndexed(indexed_dataset, uri)
+            yield LocationNotIndexed(DatasetLite.from_agdc(indexed_dataset), uri)
         else:
             yield DatasetNotIndexed(dataset, uri)
 
 
 def mismatches_for_collection(collection: Collection,
                               cache_folder: Path,
-                              path_index: DatasetPathIndex,
                               # Root folder of all file uris.
                               uri_prefix="file:///",
                               workers=2,
@@ -145,11 +145,11 @@ def mismatches_for_collection(collection: Collection,
     path_dawg = build_pathset(collection, cache_folder, log=log)
 
     # Clean up any open connections before we fork.
-    path_index.close()
+    collection.index_.close()
 
     with multiprocessing.Pool(processes=workers) as pool:
         result = pool.imap_unordered(
-            partial(_find_uri_mismatches_eager, path_index),
+            partial(_find_uri_mismatches_eager, collection.index_),
             path_dawg.iterkeys(uri_prefix),
             chunksize=work_chunksize
         )
@@ -158,7 +158,7 @@ def mismatches_for_collection(collection: Collection,
             yield from r
 
 
-def _find_uri_mismatches_eager(index: DatasetPathIndex, uri: str) -> List[Mismatch]:
+def _find_uri_mismatches_eager(index: Index, uri: str) -> List[Mismatch]:
     return list(_find_uri_mismatches(index, uri))
 
 

--- a/digitalearthau/sync/submit_job.py
+++ b/digitalearthau/sync/submit_job.py
@@ -30,7 +30,6 @@ from click import style
 
 from datacube.index import index_connect
 from digitalearthau import collections
-from digitalearthau.index import AgdcDatasetPathIndex
 from digitalearthau.paths import get_dataset_paths
 from digitalearthau.sync import scan
 
@@ -224,7 +223,7 @@ def main(folders: Iterable[str],
     input_paths = [Path(folder).absolute() for folder in folders]
 
     with index_connect(application_name='sync-submit') as index:
-        collections.init_nci_collections(AgdcDatasetPathIndex(index))
+        collections.init_nci_collections(index)
         submitter = SyncSubmission(cache_folder, project, queue, dry_run, verbose=True, workers=4)
         click.echo(
             "{} input path(s)".format(len(input_paths))

--- a/digitalearthau/sync/submit_job.py
+++ b/digitalearthau/sync/submit_job.py
@@ -1,16 +1,5 @@
 #!/usr/bin/env python
-"""
-Submit sync PBS jobs.
 
-The task_split function is currently specific to tiles, but can be generalised
-
-Example usage: submit_job.py 5fc /g/data/fk4/datacube/002/LS5_TM_FC
-
-5fc is just the name for the job: subsequent resubmissions will not rerun jobs with the same name
-if output files exist.
-
-A run folder is used (defaulting to `runs` in current dir) for output.
-"""
 import datetime
 import logging
 import os
@@ -220,6 +209,19 @@ def main(folders: Iterable[str],
          max_jobs: int,
          concurrent_jobs: int,
          submit_limit: int):
+    """
+    Submit PBS jobs to run dea-sync
+
+    Note that this is currently specific to tiled products, as it expects their folder naming conventions
+    when splitting up jobs. TODO generalise function task_split()
+
+    Example usage: dea-submit-sync 5fc /g/data/fk4/datacube/002/LS5_TM_FC
+
+    5fc is just the name for the job: subsequent resubmissions will not rerun jobs with the same name
+    if output files exist.
+
+    A run folder is used (defaulting to `runs` in current dir) for storing output status.
+    """
     input_paths = [Path(folder).absolute() for folder in folders]
 
     with index_connect(application_name='sync-submit') as index:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,6 +55,7 @@ Publicly available data access and web services are currently in development.
    internal/git_best_practice.rst
    internal/release.rst
    internal/orchestration.rst
+   internal/collection_management.rst
    internal/goalkeeper_instructions.rst
    internal/requirements_met.ipynb
 

--- a/docs/internal/collection_management.rst
+++ b/docs/internal/collection_management.rst
@@ -7,16 +7,16 @@ Collection Management
 
 The DEA repository contains a set of tools for managing the collections on disk at NCI.
 
-See their help commands for information:
+See their help commands for specific information:
 
 .. code-block:: bash
 
-    # Update the index, find problems.
+    # Update the index, find problems with datasets.
     dea-sync --help
     dea-coherence --help
     dea-duplicates --help
 
-    # Move datasets between disks safely and incrementally (keeping the index updated).
+    # Move datasets between disks safely and incrementally (updating the index).
     dea-move --help
 
     # Trash archived datasets
@@ -25,30 +25,29 @@ See their help commands for information:
     # Submit a sync job to PBS
     dea-submit-sync --help
 
-Many of these expect you to operate on collections:
+Note that many of these operate on collections, not products. To perform a move or sync on a new product you
+may first need add it as a collection.
 
 ================================================
-Collections
+Defining Collections
 ================================================
 
-The Open Data Cube keeps track of where individual datasets are, but not where datasets as a whole should be.
+The Open Data Cube core keeps track of where individual datasets are in a product, but not where datasets as a
+whole should be (such as which filesystems).
 
-Knowing where they should be is currently done by this DEA repository, as it's specific to the NCI environment
-(filesystem paths etc).
+Knowing "where they should be" is currently handled in this DEA repository as the list of collections.
 
-A collection defines datacube query arguments and folder patterns that should contain the same set of datasets,
-as well as information on how to treat those datasets.
+A collection defines:
 
-- Tools like the sync tool can then scan the index and disk and fix problems in both directions.
+- datacube query arguments and folder patterns that should contain the same set of datasets. The sync tool, for
+ example, can then iterate the two to find mismatches in both directions.
+- how datasets in the collection should be treated: is an unindexed file found on disk corrupt, or newly arrived?
 
-- The move tool can use it to "safely" perform moves, ensuring they stay in correct structure and that unrelated
-files are not carried with them.
-
-The set of collections are defined in `collections.py`_ which is currently acting like a config file.
+The set of NCI DEA collections is currently in `collections.py`_.
 
 .. _collections.py: https://github.com/GeoscienceAustralia/digitalearthau/blob/develop/digitalearthau/collections.py
 
-Example collections:
+Examples:
 
 .. code-block:: python
 

--- a/docs/internal/collection_management.rst
+++ b/docs/internal/collection_management.rst
@@ -1,0 +1,75 @@
+.. highlight:: console
+.. internal_git_best_practice:
+
+================================================
+Collection Management
+================================================
+
+The DEA repository contains a set of tools for managing the collections on disk at NCI.
+
+See their help commands for information:
+
+.. code-block:: bash
+
+    # Update the index, find problems.
+    dea-sync --help
+    dea-coherence --help
+    dea-duplicates --help
+
+    # Move datasets between disks safely and incrementally (keeping the index updated).
+    dea-move --help
+
+    # Trash archived datasets
+    dea-clean --help
+
+    # Submit a sync job to PBS
+    dea-submit-sync --help
+
+Many of these expect you to operate on collections:
+
+================================================
+Collections
+================================================
+
+The Open Data Cube keeps track of where individual datasets are, but not where datasets as a whole should be.
+
+Knowing where they should be is currently done by this DEA repository, as it's specific to the NCI environment
+(filesystem paths etc).
+
+A collection defines datacube query arguments and folder patterns that should contain the same set of datasets,
+as well as information on how to treat those datasets.
+
+- Tools like the sync tool can then scan the index and disk and fix problems in both directions.
+
+- The move tool can use it to "safely" perform moves, ensuring they stay in correct structure and that unrelated
+files are not carried with them.
+
+The set of collections are defined in `collections.py`_ which is currently acting like a config file.
+
+.. _collections.py: https://github.com/GeoscienceAustralia/digitalearthau/blob/develop/digitalearthau/collections.py
+
+Example collections:
+
+.. code-block:: python
+
+    scene_collection(
+            name='ls8_level1_scene',
+            query={'product': ['ls8_level1_scene', 'ls8_level1_oli_scene']},
+            file_patterns=[
+                '/g/data/v10/reprocess/ls8/level1/[0-9][0-9][0-9][0-9]/[0-9][0-9]/LS*/ga-metadata.yaml',
+            ],
+        ),
+
+    # Telemetry collection
+    Collection(
+            name='telemetry',
+            query={'metadata_type': 'telemetry'},
+            file_patterns=(
+                '/g/data/v10/repackaged/rawdata/0/[0-9][0-9][0-9][0-9]/[0-9][0-9]/*/ga-metadata.yaml',
+            ),
+            # If something is archived, how many days before we can delete it? None means never
+            delete_archived_after_days=None,
+            # Who do we trust in a sync if there's a mismatch?
+            trust=Trust.disk,
+     )
+

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,20 +1,26 @@
 import itertools
 import logging
 import os
+import shutil
+import uuid
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Tuple, NamedTuple, Optional
 
 import pytest
-import shutil
 import yaml
 
 import digitalearthau
+import digitalearthau.system
 from datacube.config import LocalConfig
 from datacube.index._api import Index
 from datacube.index.postgres import PostgresDb
 from datacube.index.postgres import _dynamic
 from datacube.index.postgres.tables import _core
-import digitalearthau.system
+from digitalearthau import paths, collections
+from digitalearthau.collections import Collection
+from digitalearthau.index import DatasetLite, AgdcDatasetPathIndex
+from digitalearthau.paths import register_base_directory
 
 try:
     from yaml import CSafeLoader as SafeLoader
@@ -132,3 +138,133 @@ def index(db):
     :type db: datacube.index.postgres._api.PostgresDb
     """
     return Index(db)
+
+
+ON_DISK2_ID = DatasetLite(uuid.UUID('10c4a9fe-2890-11e6-8ec8-a0000100fe80'))
+
+ON_DISK2_OFFSET = ('LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924', 'ga-metadata.yaml')
+
+
+class TestDataset(NamedTuple):
+    """
+    Information on a test dataset. The properties are recorded here separately so tests can verify them.
+    """
+    collection: Optional[Collection]
+
+    id_: uuid.UUID
+
+    # We separate path from a test base path for calculating trash prefixes etc.
+    # You usually just want to use `self.path` instead.
+    base_path: Path
+    path_offset: Tuple[str, ...]
+
+    # Source dataset that will be indexed if this is indexed (ie. embedded inside it)
+    parent_id: uuid.UUID = None
+
+    @property
+    def path(self):
+        return self.base_path.joinpath(*self.path_offset)
+
+    @property
+    def uri(self):
+        return self.path.as_uri()
+
+    @property
+    def dataset(self):
+        return DatasetLite(self.id_)
+
+    @property
+    def parent(self) -> Optional[DatasetLite]:
+        """Source datasets that will be indexed if on_disk1 is indexed"""
+        return DatasetLite(self.parent_id) if self.parent_id else None
+
+
+# We want one fixture to return all of this data. Returning a tuple was getting unwieldy.
+class SimpleEnv(NamedTuple):
+    collection: Collection
+
+    on_disk1_id: uuid.UUID
+    on_disk_uri: str
+
+    base_test_path: Path
+
+
+@pytest.fixture
+def test_dataset(integration_test_data, dea_index) -> TestDataset:
+    """A dataset on disk, indexed in a collection"""
+    test_data = integration_test_data
+
+    # Tests assume one dataset for the collection, so delete the second.
+    shutil.rmtree(str(test_data.joinpath('LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924')))
+    index = AgdcDatasetPathIndex(dea_index)
+    ls8_collection = Collection(
+        name='ls8_scene_test',
+        query={},
+        file_patterns=[str(test_data.joinpath('LS8*/ga-metadata.yaml'))],
+        unique=[],
+        index=index
+    )
+    collections._add(ls8_collection)
+
+    # Add a decoy collection.
+    ls5_nc_collection = Collection(
+        name='ls5_nc_test',
+        query={},
+        file_patterns=[str(test_data.joinpath('LS5*.nc'))],
+        unique=[],
+        index=index
+    )
+    collections._add(ls8_collection)
+
+    # register this as a base directory so that datasets can be trashed within it.
+    register_base_directory(str(test_data))
+
+    cache_path = test_data.joinpath('cache')
+    cache_path.mkdir()
+
+    return TestDataset(
+        collection=ls8_collection,
+        id_=uuid.UUID('86150afc-b7d5-4938-a75e-3445007256d3'),
+        base_path=test_data,
+        path_offset=('LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926', 'ga-metadata.yaml'),
+        parent_id=uuid.UUID('dee471ed-5aa5-46f5-96b5-1e1ea91ffee4')
+    )
+
+
+@pytest.fixture
+def other_dataset(integration_test_data: Path) -> TestDataset:
+    """
+    A dataset matching the same collection as test_dataset, but not indexed.
+    """
+
+    ds_id = uuid.UUID("5294efa6-348d-11e7-a079-185e0f80a5c0")
+    paths.write_files(
+        {
+            'LS8_INDEXED_ALREADY': {
+                'ga-metadata.yaml': ("""
+id: %s
+platform:
+    code: LANDSAT_8
+instrument:
+    name: OLI_TIRS
+format:
+    name: GeoTIFF
+product_type: level1
+product_level: L1T
+image:
+    bands: {}
+lineage:
+    source_datasets: {}
+    """ % str(ds_id)),
+                'dummy-file.txt': ''
+            }
+        },
+        containing_dir=integration_test_data
+    )
+
+    return TestDataset(
+        collection=None,
+        id_=ds_id,
+        base_path=integration_test_data,
+        path_offset=('LS8_INDEXED_ALREADY', 'ga-metadata.yaml')
+    )

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -166,12 +166,15 @@ ON_DISK2_ID = DatasetLite(uuid.UUID('10c4a9fe-2890-11e6-8ec8-a0000100fe80'))
 ON_DISK2_OFFSET = ('LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924', 'ga-metadata.yaml')
 
 
-class DatasetOnDisk(NamedTuple):
+class DatasetForTests(NamedTuple):
     """
-    Information on a test dataset, including the file location and collection it should belong to.
+    A test dataset, including the file location and collection it should belong to.
 
-    The properties are recorded here separately so tests can verify them.
+    When your test starts the dataset will be on disk but not yet indexed. Call add_to_index() and others as needed.
+
+    All properties are recorded here separately so tests can verify them independently.
     """
+    # The test collection this should belong to
     collection: Collection
 
     id_: uuid.UUID
@@ -224,7 +227,7 @@ class SimpleEnv(NamedTuple):
 
 
 @pytest.fixture
-def test_dataset(integration_test_data, dea_index) -> DatasetOnDisk:
+def test_dataset(integration_test_data, dea_index) -> DatasetForTests:
     """A dataset on disk, with corresponding collection"""
     test_data = integration_test_data
 
@@ -255,7 +258,7 @@ def test_dataset(integration_test_data, dea_index) -> DatasetOnDisk:
     cache_path = test_data.joinpath('cache')
     cache_path.mkdir()
 
-    return DatasetOnDisk(
+    return DatasetForTests(
         collection=ls8_collection,
         id_=uuid.UUID('86150afc-b7d5-4938-a75e-3445007256d3'),
         base_path=test_data,
@@ -265,7 +268,7 @@ def test_dataset(integration_test_data, dea_index) -> DatasetOnDisk:
 
 
 @pytest.fixture
-def other_dataset(integration_test_data: Path, test_dataset: DatasetOnDisk) -> DatasetOnDisk:
+def other_dataset(integration_test_data: Path, test_dataset: DatasetForTests) -> DatasetForTests:
     """
     A dataset matching the same collection as test_dataset, but not indexed.
     """
@@ -295,7 +298,7 @@ lineage:
         containing_dir=integration_test_data
     )
 
-    return DatasetOnDisk(
+    return DatasetForTests(
         collection=test_dataset.collection,
         id_=ds_id,
         base_path=integration_test_data,

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -145,7 +145,7 @@ ON_DISK2_ID = DatasetLite(uuid.UUID('10c4a9fe-2890-11e6-8ec8-a0000100fe80'))
 ON_DISK2_OFFSET = ('LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924', 'ga-metadata.yaml')
 
 
-class TestDataset(NamedTuple):
+class DatasetOnDisk(NamedTuple):
     """
     Information on a test dataset. The properties are recorded here separately so tests can verify them.
     """
@@ -190,7 +190,7 @@ class SimpleEnv(NamedTuple):
 
 
 @pytest.fixture
-def test_dataset(integration_test_data, dea_index) -> TestDataset:
+def test_dataset(integration_test_data, dea_index) -> DatasetOnDisk:
     """A dataset on disk, indexed in a collection"""
     test_data = integration_test_data
 
@@ -222,7 +222,7 @@ def test_dataset(integration_test_data, dea_index) -> TestDataset:
     cache_path = test_data.joinpath('cache')
     cache_path.mkdir()
 
-    return TestDataset(
+    return DatasetOnDisk(
         collection=ls8_collection,
         id_=uuid.UUID('86150afc-b7d5-4938-a75e-3445007256d3'),
         base_path=test_data,
@@ -232,7 +232,7 @@ def test_dataset(integration_test_data, dea_index) -> TestDataset:
 
 
 @pytest.fixture
-def other_dataset(integration_test_data: Path) -> TestDataset:
+def other_dataset(integration_test_data: Path) -> DatasetOnDisk:
     """
     A dataset matching the same collection as test_dataset, but not indexed.
     """
@@ -262,7 +262,7 @@ lineage:
         containing_dir=integration_test_data
     )
 
-    return TestDataset(
+    return DatasetOnDisk(
         collection=None,
         id_=ds_id,
         base_path=integration_test_data,

--- a/integration_tests/data/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924/additional/20150924_20140804_B6_gverify.log
+++ b/integration_tests/data/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924/additional/20150924_20140804_B6_gverify.log
@@ -1,0 +1,190 @@
+2016-12-20T10:19:30 main.cpp 34: INFO: Arguments
+gridSize = '26'
+resampleType  = 'BI'
+nullValue = '0.000000000000000'
+chipGenType = 'FIXED_LOCATION'
+fixedChipLocationFile = '/g/data/v10/eoancillarydata/GCP/Fix_QA_points/114/080/points.txt
+correlationThreshold = '0.750000000000000'
+referenceImage = 
+'	pathToImage = '/g/data/v10/eoancillarydata/GCP/GQA_v3/wrs2/114/080/LC81140802014216LGN00_B6.TIF'
+	proj4Str = '''
+inputImage = 
+'	pathToImage = '/g/data/v10/reprocess/ls8/level1/2015/09/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924/product/LC81140802015267LGN00_B6.TIF'
+	proj4Str = '''
+logPath = '/g/data/v10/reprocess/gqa/ls8/2015/09/output/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924.gqa-work'
+outputPath = '/g/data/v10/reprocess/gqa/ls8/2015/09/output/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924.gqa-work'
+threadCount = '4'
+usePhaseCorrelation = 'FALSE'
+workingDirectory = '/g/data/v10/reprocess/gqa/ls8/2015/09/output/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924.gqa-work'
+chipSize = '31'
+amountOfPyramids = '5'
+
+
+2016-12-20T10:19:35 ul_Reproject.cpp 133: INFO: Projecting 100%   
+2016-12-20T10:19:38 ul_Reproject.cpp 173: INFO: Generate translation map 100%   
+2016-12-20T10:19:38 ul_Resampler.h 476: INFO: Resample map is of type 'double'
+2016-12-20T10:19:39 ul_Resampler.h 97: INFO: Resampler is bilinear
+2016-12-20T10:19:43 ul_Resampler.h 326: INFO: Resampling 100%     
+2016-12-20T10:19:49 ul_ImageOverlap.cpp 356: INFO: Save new overlapped image to '/g/data/v10/reprocess/gqa/ls8/2015/09/output/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924.gqa-work/MinMaxBox/Input/warpedInput_LC81140802015267LGN00_B6.TIF'
+2016-12-20T10:19:55 ul_ImageOverlap.cpp 356: INFO: Save new overlapped image to '/g/data/v10/reprocess/gqa/ls8/2015/09/output/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924.gqa-work/MinMaxBox/Reference/LC81140802014216LGN00_B6.TIF'
+2016-12-20T10:20:01 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T10:20:09 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T10:20:18 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T10:20:22 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T10:20:28 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T10:20:33 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T10:20:35 ul_TiledGaussianPyramidTiePointGenerator.cpp 534: INFO: <<----------------------------------------------------------->>
+2016-12-20T10:20:35 ul_TiledGaussianPyramidTiePointGenerator.cpp 535: INFO:  <----TILE LOOP (1/2)----------------->
+2016-12-20T10:20:35 ul_TiledGaussianPyramidTiePointGenerator.cpp 536: INFO: <<----------------------------------------------------------->>
+2016-12-20T10:20:35 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '2' of '5' for image 'Input_1_1'
+2016-12-20T10:20:37 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '3' of '5' for image 'Input_1_1'
+2016-12-20T10:20:37 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '4' of '5' for image 'Input_1_1'
+2016-12-20T10:20:37 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '5' of '5' for image 'Input_1_1'
+2016-12-20T10:20:38 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '2' of '5' for image 'Reference_1_1'
+2016-12-20T10:20:39 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '3' of '5' for image 'Reference_1_1'
+2016-12-20T10:20:40 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '4' of '5' for image 'Reference_1_1'
+2016-12-20T10:20:40 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '5' of '5' for image 'Reference_1_1'
+2016-12-20T10:20:40 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (1/5)----------------->>
+2016-12-20T10:20:40 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T10:20:40 ul_FixedLocationChips.cpp 171: INFO: Generated '216' chips
+2016-12-20T10:20:40 ul_TiePointGenerator.cpp 166: INFO: Correlating '216' chips of size '31x31' on a search window of size '52x52' using a 'CCOEFF_NORM' correlator
+2016-12-20T10:20:40 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T10:20:41 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T10:20:41 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T10:20:41 ul_TiePointGenerator.cpp 285: INFO: Obtained '216' chips
+2016-12-20T10:20:41 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T10:20:41 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '1/5' is 'x = 0.011282519514810 y = -0.003943295980524' pixels
+2016-12-20T10:20:41 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (2/5)----------------->>
+2016-12-20T10:20:41 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T10:20:41 ul_FixedLocationChips.cpp 171: INFO: Generated '291' chips
+2016-12-20T10:20:41 ul_TiePointGenerator.cpp 166: INFO: Correlating '291' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T10:20:41 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T10:20:42 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T10:20:42 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T10:20:42 ul_TiePointGenerator.cpp 285: INFO: Obtained '291' chips
+2016-12-20T10:20:42 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T10:20:42 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '2/5' is 'x = 0.001563976812921 y = -0.010439160552921' pixels
+2016-12-20T10:20:42 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (3/5)----------------->>
+2016-12-20T10:20:43 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T10:20:43 ul_FixedLocationChips.cpp 171: INFO: Generated '308' chips
+2016-12-20T10:20:43 ul_TiePointGenerator.cpp 166: INFO: Correlating '308' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T10:20:43 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T10:20:43 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T10:20:43 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T10:20:43 ul_TiePointGenerator.cpp 285: INFO: Obtained '308' chips
+2016-12-20T10:20:43 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T10:20:44 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '3/5' is 'x = 0.010714463061429 y = -0.007776243891401' pixels
+2016-12-20T10:20:44 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (4/5)----------------->>
+2016-12-20T10:20:44 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T10:20:44 ul_FixedLocationChips.cpp 171: INFO: Generated '320' chips
+2016-12-20T10:20:44 ul_TiePointGenerator.cpp 166: INFO: Correlating '320' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T10:20:44 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T10:20:45 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T10:20:45 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T10:20:45 ul_TiePointGenerator.cpp 285: INFO: Obtained '320' chips
+2016-12-20T10:20:45 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T10:20:45 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '4/5' is 'x = 0.019369012925536 y = 0.004951726112796' pixels
+2016-12-20T10:20:45 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (5/5)----------------->>
+2016-12-20T10:20:45 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T10:20:45 ul_FixedLocationChips.cpp 171: INFO: Generated '328' chips
+2016-12-20T10:20:45 ul_TiePointGenerator.cpp 166: INFO: Correlating '328' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T10:20:46 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T10:20:47 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T10:20:47 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T10:20:47 ul_TiePointGenerator.cpp 285: INFO: Obtained '328' chips
+2016-12-20T10:20:48 ul_GcpHullRejection.cpp 264: INFO: Hull trim size is '31'
+2016-12-20T10:20:51 ul_ConvKernelToImage.h 178: INFO: 100%   
+2016-12-20T10:20:51 ul_ConvKernelToImage.h 178: INFO: 100%   
+2016-12-20T10:20:51 ul_ConvexHull.cpp 142: INFO: Sorting '474189' data points
+2016-12-20T10:20:52 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T10:20:52 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T10:20:52 ul_ConvexHull.cpp 142: INFO: Sorting '828172' data points
+2016-12-20T10:20:52 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T10:20:52 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T10:20:57 ul_GcpOutlierTestingHullGenThread.cpp 235: INFO: TrimHullArea 100%     
+2016-12-20T10:20:58 ul_GcpOutlierTestingHullGenThread.cpp 235: INFO: TrimHullArea 100%     
+2016-12-20T10:20:58 ul_GcpHullRejection.cpp 155: INFO: RejectGcps 100%     
+2016-12-20T10:20:58 ul_GcpHullRejection.cpp 275: INFO: Rejected a total of '1' GCP on the outer hull edges
+2016-12-20T10:20:58 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 205: INFO: Average shift in pixels are 'x = 0.005968880843412 y = 0.005709017122569'
+2016-12-20T10:20:58 ul_TiledGaussianPyramidTiePointGenerator.cpp 534: INFO: <<----------------------------------------------------------->>
+2016-12-20T10:20:58 ul_TiledGaussianPyramidTiePointGenerator.cpp 535: INFO:  <----TILE LOOP (2/2)----------------->
+2016-12-20T10:20:58 ul_TiledGaussianPyramidTiePointGenerator.cpp 536: INFO: <<----------------------------------------------------------->>
+2016-12-20T10:20:58 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '2' of '5' for image 'Input_2_1'
+2016-12-20T10:21:00 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '3' of '5' for image 'Input_2_1'
+2016-12-20T10:21:00 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '4' of '5' for image 'Input_2_1'
+2016-12-20T10:21:01 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '5' of '5' for image 'Input_2_1'
+2016-12-20T10:21:01 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '2' of '5' for image 'Reference_2_1'
+2016-12-20T10:21:03 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '3' of '5' for image 'Reference_2_1'
+2016-12-20T10:21:03 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '4' of '5' for image 'Reference_2_1'
+2016-12-20T10:21:03 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '5' of '5' for image 'Reference_2_1'
+2016-12-20T10:21:03 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (1/5)----------------->>
+2016-12-20T10:21:03 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T10:21:03 ul_FixedLocationChips.cpp 171: INFO: Generated '42' chips
+2016-12-20T10:21:03 ul_TiePointGenerator.cpp 166: INFO: Correlating '42' chips of size '31x31' on a search window of size '52x52' using a 'CCOEFF_NORM' correlator
+2016-12-20T10:21:03 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T10:21:04 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T10:21:04 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T10:21:04 ul_TiePointGenerator.cpp 285: INFO: Obtained '42' chips
+2016-12-20T10:21:04 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T10:21:04 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '1/5' is 'x = 0.014691141027320 y = -0.033336012674554' pixels
+2016-12-20T10:21:04 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (2/5)----------------->>
+2016-12-20T10:21:04 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T10:21:04 ul_FixedLocationChips.cpp 171: INFO: Generated '63' chips
+2016-12-20T10:21:04 ul_TiePointGenerator.cpp 166: INFO: Correlating '63' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T10:21:04 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T10:21:04 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T10:21:04 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T10:21:04 ul_TiePointGenerator.cpp 285: INFO: Obtained '63' chips
+2016-12-20T10:21:04 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T10:21:04 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '2/5' is 'x = 0.041529518770903 y = -0.003110852063957' pixels
+2016-12-20T10:21:04 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (3/5)----------------->>
+2016-12-20T10:21:04 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T10:21:04 ul_FixedLocationChips.cpp 171: INFO: Generated '76' chips
+2016-12-20T10:21:04 ul_TiePointGenerator.cpp 166: INFO: Correlating '76' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T10:21:04 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T10:21:04 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T10:21:04 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T10:21:04 ul_TiePointGenerator.cpp 285: INFO: Obtained '76' chips
+2016-12-20T10:21:04 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T10:21:04 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '3/5' is 'x = 0.001010195332119 y = 0.013237053628080' pixels
+2016-12-20T10:21:04 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (4/5)----------------->>
+2016-12-20T10:21:05 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T10:21:05 ul_FixedLocationChips.cpp 171: INFO: Generated '88' chips
+2016-12-20T10:21:05 ul_TiePointGenerator.cpp 166: INFO: Correlating '88' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T10:21:05 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T10:21:05 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T10:21:05 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T10:21:05 ul_TiePointGenerator.cpp 285: INFO: Obtained '88' chips
+2016-12-20T10:21:05 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T10:21:05 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '4/5' is 'x = 0.028458433705919 y = 0.002585211800268' pixels
+2016-12-20T10:21:05 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (5/5)----------------->>
+2016-12-20T10:21:05 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T10:21:05 ul_FixedLocationChips.cpp 171: INFO: Generated '95' chips
+2016-12-20T10:21:05 ul_TiePointGenerator.cpp 166: INFO: Correlating '95' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T10:21:07 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T10:21:07 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T10:21:07 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T10:21:07 ul_TiePointGenerator.cpp 285: INFO: Obtained '95' chips
+2016-12-20T10:21:08 ul_GcpHullRejection.cpp 264: INFO: Hull trim size is '31'
+2016-12-20T10:21:11 ul_ConvKernelToImage.h 178: INFO: 100%   
+2016-12-20T10:21:11 ul_ConvKernelToImage.h 178: INFO: 100%   
+2016-12-20T10:21:11 ul_ConvexHull.cpp 142: INFO: Sorting '441722' data points
+2016-12-20T10:21:11 ul_ConvexHull.cpp 142: INFO: Sorting '1083160' data points
+2016-12-20T10:21:11 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T10:21:11 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T10:21:12 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T10:21:12 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T10:21:16 ul_GcpOutlierTestingHullGenThread.cpp 235: INFO: TrimHullArea 100%     
+2016-12-20T10:21:18 ul_GcpOutlierTestingHullGenThread.cpp 235: INFO: TrimHullArea 100%     
+2016-12-20T10:21:18 ul_GcpHullRejection.cpp 155: INFO: RejectGcps 100%     
+2016-12-20T10:21:18 ul_GcpHullRejection.cpp 275: INFO: Rejected a total of '0' GCP on the outer hull edges
+2016-12-20T10:21:18 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 205: INFO: Average shift in pixels are 'x = 0.032365943609122 y = 0.011038294084636'
+2016-12-20T10:21:18 ul_TiledGaussianPyramidTiePointGenerator.cpp 457: INFO: Removing duplicate GCPs
+2016-12-20T10:21:18 ul_TiledGaussianPyramidTiePointGenerator.cpp 481: INFO: Removed '7' duplicate GCPs
+2016-12-20T10:21:30 GenerateResults.cpp 57: INFO: Residual X = 0.116857964454341 Y = 0.117312935325642
+2016-12-20T10:21:30 GenerateResults.cpp 81: INFO: Residual histogram
+	Green 167
+	Teal 3
+	Blue 2
+	Yellow 0
+	Red 0

--- a/integration_tests/data/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924/additional/LPGS.log
+++ b/integration_tests/data/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924/additional/LPGS.log
@@ -1,0 +1,932 @@
+Thu Jun 2 16:30:42 AEST 2016
+ 
+DMS Setup Work Order (DSW)
+ 
+2016-06-02 16:30:42  setup_work_order    18143 setup_work_order.c        91  INFO Initiated
+2016-06-02 16:30:42  setup_work_order    18143 read_l0r_metadata.c       91  INFO Reading L0R metadata from l0r_symlink/LC81140802015267LGN00
+2016-06-02 16:30:42  setup_work_order    18143 setup_work_order.c       554  INFO Successful completion
+ 
+setup_work_order execution completed with status of 0
+ 
+Thu Jun 2 16:30:42 AEST 2016
+Thu Jun 2 16:30:45 AEST 2016
+ 
+DMS Retrieve Elevation (DRE)
+ 
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      41  INFO Gls tile name v2: s28_e112_3arc_v2
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      74  INFO Gls tile name v1: s28_e112_3arc_v1
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c     107  INFO Gls tile name v0: s28e112
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      41  INFO Gls tile name v2: s28_e113_3arc_v2
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      74  INFO Gls tile name v1: s28_e113_3arc_v1
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c     107  INFO Gls tile name v0: s28e113
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      41  INFO Gls tile name v2: s28_e114_3arc_v2
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      74  INFO Gls tile name v1: s28_e114_3arc_v1
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c     107  INFO Gls tile name v0: s28e114
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      41  INFO Gls tile name v2: s28_e115_3arc_v2
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      74  INFO Gls tile name v1: s28_e115_3arc_v1
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c     107  INFO Gls tile name v0: s28e115
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      41  INFO Gls tile name v2: s29_e112_3arc_v2
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      74  INFO Gls tile name v1: s29_e112_3arc_v1
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c     107  INFO Gls tile name v0: s29e112
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      41  INFO Gls tile name v2: s29_e113_3arc_v2
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      74  INFO Gls tile name v1: s29_e113_3arc_v1
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c     107  INFO Gls tile name v0: s29e113
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      41  INFO Gls tile name v2: s29_e114_3arc_v2
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      74  INFO Gls tile name v1: s29_e114_3arc_v1
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c     107  INFO Gls tile name v0: s29e114
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      41  INFO Gls tile name v2: s29_e115_3arc_v2
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      74  INFO Gls tile name v1: s29_e115_3arc_v1
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c     107  INFO Gls tile name v0: s29e115
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      41  INFO Gls tile name v2: s30_e112_3arc_v2
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      74  INFO Gls tile name v1: s30_e112_3arc_v1
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c     107  INFO Gls tile name v0: s30e112
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      41  INFO Gls tile name v2: s30_e113_3arc_v2
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      74  INFO Gls tile name v1: s30_e113_3arc_v1
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c     107  INFO Gls tile name v0: s30e113
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      41  INFO Gls tile name v2: s30_e114_3arc_v2
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      74  INFO Gls tile name v1: s30_e114_3arc_v1
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c     107  INFO Gls tile name v0: s30e114
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      41  INFO Gls tile name v2: s30_e115_3arc_v2
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      74  INFO Gls tile name v1: s30_e115_3arc_v1
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c     107  INFO Gls tile name v0: s30e115
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      41  INFO Gls tile name v2: s31_e112_3arc_v2
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      74  INFO Gls tile name v1: s31_e112_3arc_v1
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c     107  INFO Gls tile name v0: s31e112
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      41  INFO Gls tile name v2: s31_e113_3arc_v2
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      74  INFO Gls tile name v1: s31_e113_3arc_v1
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c     107  INFO Gls tile name v0: s31e113
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      41  INFO Gls tile name v2: s31_e114_3arc_v2
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      74  INFO Gls tile name v1: s31_e114_3arc_v1
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c     107  INFO Gls tile name v0: s31e114
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      41  INFO Gls tile name v2: s31_e115_3arc_v2
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c      74  INFO Gls tile name v1: s31_e115_3arc_v1
+2016-06-02 16:30:45  retrieve_elevation    18197 make_gls_tile_name.c     107  INFO Gls tile name v0: s31e115
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           180  INFO Mosaicing GLS DEM tiles...
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-06-02 16:30:45  retrieve_elevation    18197 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-06-02 16:30:54  retrieve_elevation    18197 retrieve_elevation.c     416  INFO DEM data retrieval successfully completed.
+ 
+retrieve_elevation execution completed with status of 0
+ 
+Thu Jun 2 16:30:54 AEST 2016
+Thu Jun 2 16:30:56 AEST 2016
+ 
+DMS Ground Control (DGC)
+ 
+2016-06-02T06:30:58 LoadChips.cpp 766: INFO: Found chips at '/g/data/v10/eoancillarydata/GCP/Phase2_GCP/114/080/GCPLib'
+2016-06-02T06:30:59 SaveChips.cpp 385: INFO: Saving tile as version '2'
+ 
+lpgs-chip-loader execution completed with status of 0
+ 
+Thu Jun 2 16:30:59 AEST 2016
+Thu Jun 2 16:31:02 AEST 2016
+ 
+Ancillary Data Preprocessor (ADP)
+ 
+2016-06-02 16:31:02  ancillary_data_preprocessor    18392 ancillary_data_preprocessor.c     100  INFO Initiated
+2016-06-02 16:31:02  ancillary_data_preprocessor    18392 ias_ancillary_smooth_ephemeris.c     172  INFO L0R ephemeris record count = 225
+2016-06-02 16:31:02  ancillary_data_preprocessor    18392 ias_ancillary_identify_quaternion_outliers.c     268  INFO Number of attitude quaternion points 11250
+2016-06-02 16:31:02  ancillary_data_preprocessor    18392 ias_ancillary_convert_imu_to_acs.c     350  INFO Bounds on IMU time 496332915.898602, 496333140.878015
+2016-06-02 16:31:02  ancillary_data_preprocessor    18392 ias_ancillary_extract_valid_imu_data_window.c      60  INFO Ephemeris times --- start 496332916.900065, end 496333139.900065 -> center 496333028.400065
+2016-06-02 16:31:02  ancillary_data_preprocessor    18392 ancillary_data_preprocessor.c     232  INFO Successful completion
+ 
+ancillary_data_preprocessor execution completed with status of 0
+ 
+Thu Jun 2 16:31:02 AEST 2016
+Thu Jun 2 16:31:04 AEST 2016
+ 
+Create Line of Sight Model Initialization (L8INIT)
+ 
+2016-06-02 16:31:04  create_los_model    18444 read_parameters.c        302  INFO Overriding the estimated TIRS SSM position file with '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20160601.l8_tirs_estimated_ssm_position.txt'
+2016-06-02 16:31:04  create_los_model    18444 create_los_model.c        76  INFO Create LOS Model started
+2016-06-02 16:31:04  create_los_model    18444 create_los_model.c       271  INFO Create LOS Model finished
+ 
+create_los_model execution completed with status of 0
+ 
+Thu Jun 2 16:31:05 AEST 2016
+Thu Jun 2 16:31:06 AEST 2016
+ 
+Create Level 1R (L8RPS)
+ 
+2016-06-02 16:31:06  create_l1r    18492 rps_main.c                71  INFO Initiated create_l1r
+2016-06-02 16:31:09  create_l1r    18492 process_scas.c            46  INFO Processing band 1
+2016-06-02 16:31:27  create_l1r    18492 process_scas.c            46  INFO Processing band 2
+2016-06-02 16:31:36  create_l1r    18492 process_scas.c            46  INFO Processing band 3
+2016-06-02 16:31:44  create_l1r    18492 process_scas.c            46  INFO Processing band 4
+2016-06-02 16:31:53  create_l1r    18492 process_scas.c            46  INFO Processing band 5
+2016-06-02 16:32:01  create_l1r    18492 process_scas.c            46  INFO Processing band 6
+2016-06-02 16:32:08  create_l1r    18492 process_scas.c            46  INFO Processing band 7
+2016-06-02 16:32:15  create_l1r    18492 process_scas.c            46  INFO Processing band 8
+2016-06-02 16:32:53  create_l1r    18492 process_scas.c            46  INFO Processing band 9
+2016-06-02 16:33:14  create_l1r    18492 process_scas.c            46  INFO Processing band 10
+2016-06-02 16:33:15  create_l1r    18492 process_scas.c            46  INFO Processing band 11
+2016-06-02 16:33:15  create_l1r    18492 api/api_striping_characterization.c     329  INFO Overall striping metric not calculated due to report and database storage flags being false
+2016-06-02 16:33:16  create_l1r    18492 rps_main.c               261  INFO Successful completion
+ 
+create_l1r execution completed with status of 0
+ 
+Thu Jun 2 16:33:17 AEST 2016
+Thu Jun 2 16:33:18 AEST 2016
+ 
+Create Systematic Grid (L8GRID_SYS)
+ 
+2016-06-02 16:33:18  create_grid    18713 get_parms_and_initialize_grid.c    1228  INFO Pixel origin will be 'UL'
+2016-06-02 16:33:18  create_grid    18713 create_grid.c            173  INFO Initiate Create Grid...
+2016-06-02 16:33:18  create_grid    18713 create_grid.c            284  INFO Elevation range   -40.00   419.00
+2016-06-02 16:33:18  create_grid    18713 pad_corners.c             58  INFO Scene padding size is 30.000000
+2016-06-02 16:33:18  create_grid    18713 build_grid.c             259  INFO Processing band number 6
+2016-06-02 16:33:19  create_grid    18713 build_grid.c              93  INFO Writing grid band number 6
+2016-06-02 16:33:20  create_grid    18713 create_grid.c            869  INFO Writing output grid file headers
+2016-06-02 16:33:20  create_grid    18713 create_grid.c            929  INFO Successful completion
+ 
+create_grid execution completed with status of 0
+ 
+Thu Jun 2 16:33:20 AEST 2016
+Thu Jun 2 16:33:22 AEST 2016
+ 
+Make the Geometric Terrain Grid (GRID_TERRAIN)
+ 
+2016-06-02 16:33:22  Makegeomgrid    18727 make_geom_grid.c         100  INFO Initiated
+2016-06-02 16:33:22  Makegeomgrid    18727 make_geom_grid.c         189  INFO Using band number 6 from the TARGET_FRAME_FILE
+2016-06-02 16:33:23  Makegeomgrid    18727 make_geom_grid.c         607  INFO Successful Completion
+ 
+makegeomgrid execution completed with status of 0
+ 
+Thu Jun 2 16:33:23 AEST 2016
+Thu Jun 2 16:33:25 AEST 2016
+ 
+Geometric Terrain Resample (RESAMPLE_TERRAIN)
+ 
+2016-06-02 16:33:25  Geomresample    18733 geomresample.c            93  INFO Geometric Resample Initiated
+2016-06-02 16:33:25  Geomresample    18733 geomresample.c           112  INFO Reading Grid
+2016-06-02 16:33:25  Geomresample    18733 geomresample.c           219  INFO Resampling band 1
+2016-06-02 16:33:25  Geomresample    18733 scanman.c                250  INFO resampling lines 0 through 800
+2016-06-02 16:33:25  Geomresample    18733 scanman.c                250  INFO resampling lines 650 through 1450
+2016-06-02 16:33:25  Geomresample    18733 scanman.c                250  INFO resampling lines 1300 through 2100
+2016-06-02 16:33:25  Geomresample    18733 scanman.c                250  INFO resampling lines 1950 through 2750
+2016-06-02 16:33:26  Geomresample    18733 scanman.c                250  INFO resampling lines 2600 through 3400
+2016-06-02 16:33:26  Geomresample    18733 scanman.c                250  INFO resampling lines 3250 through 4050
+2016-06-02 16:33:26  Geomresample    18733 scanman.c                250  INFO resampling lines 3900 through 4700
+2016-06-02 16:33:27  Geomresample    18733 scanman.c                250  INFO resampling lines 4550 through 5350
+2016-06-02 16:33:27  Geomresample    18733 scanman.c                250  INFO resampling lines 5200 through 6000
+2016-06-02 16:33:27  Geomresample    18733 scanman.c                250  INFO resampling lines 5850 through 6650
+2016-06-02 16:33:28  Geomresample    18733 scanman.c                250  INFO resampling lines 6500 through 7300
+2016-06-02 16:33:28  Geomresample    18733 scanman.c                250  INFO resampling lines 7150 through 7950
+2016-06-02 16:33:28  Geomresample    18733 scanman.c                250  INFO resampling lines 7800 through 8600
+2016-06-02 16:33:29  Geomresample    18733 scanman.c                250  INFO resampling lines 8450 through 9250
+2016-06-02 16:33:29  Geomresample    18733 scanman.c                250  INFO resampling lines 9100 through 9900
+2016-06-02 16:33:29  Geomresample    18733 scanman.c                250  INFO resampling lines 9750 through 10550
+2016-06-02 16:33:30  Geomresample    18733 scanman.c                250  INFO resampling lines 10400 through 11200
+2016-06-02 16:33:30  Geomresample    18733 scanman.c                250  INFO resampling lines 11050 through 11850
+2016-06-02 16:33:30  Geomresample    18733 scanman.c                250  INFO resampling lines 11700 through 12500
+2016-06-02 16:33:30  Geomresample    18733 scanman.c                250  INFO resampling lines 12350 through 13094
+2016-06-02 16:33:31  Geomresample    18733 geomresample.c           330  INFO Geometric Resample Successful Completion
+ 
+geomresample execution completed with status of 0
+ 
+Thu Jun 2 16:33:31 AEST 2016
+Thu Jun 2 16:33:32 AEST 2016
+ 
+Systematic L8 Resample (L8RESAMPLE_SYS)
+ 
+2016-06-02 16:33:32  Resample    18761 resample.c               115  INFO Initiated
+2016-06-02 16:33:33  Resample    18761 process_band.c            80  INFO Resampling band number 6
+2016-06-02 16:33:51  Resample    18761 resample.c               789  INFO Successful Completion
+ 
+resample execution completed with status of 0
+ 
+Thu Jun 2 16:33:51 AEST 2016
+Thu Jun 2 16:33:53 AEST 2016
+ 
+L8 GCP Correlation for Precision (L8PRECISION_GCP)
+ 
+2016-06-02 16:33:53  gcpcorrelate    18877 GCPcorrelate.c            84  INFO Initiated
+2016-06-02 16:33:53  gcpcorrelate    18877 GCPcorrelate.c            87  INFO Reading gcp_lib/GCPLib
+2016-06-02 16:33:53  gcpcorrelate    18877 ias_gcp_read_gcplib.c     292  INFO Reading gcp_lib/GCPLib
+2016-06-02 16:33:53  gcpcorrelate    18877 ias_gcp_read_gcplib.c     313  INFO Read 408 GCPs
+2016-06-02 16:33:53  gcpcorrelate    18877 ias_gcp_read_gcplib.c     135  INFO Pixel alignment will be 'UL', hemisphere is 'S', datum = 'GDA_94'
+2016-06-02 16:33:53  gcpcorrelate    18877 GCPcorrelate.c           116  INFO Read 408 GCPs
+2016-06-02 16:33:53  gcpcorrelate    18877 process_gcp.c            236  INFO Processing 1 SCA(s) in image sys_l1g.h5
+2016-06-02 16:33:53  gcpcorrelate    18877 process_gcp.c            375  INFO Using image chips from gcp_lib
+2016-06-02 16:33:53  gcpcorrelate    18877 process_gcp.c            430  INFO Correlating GCP # 0 to SCA 0
+2016-06-02 16:33:53  gcpcorrelate    18877 process_gcp.c            430  INFO Correlating GCP # 40 to SCA 0
+2016-06-02 16:33:53  gcpcorrelate    18877 process_gcp.c            430  INFO Correlating GCP # 80 to SCA 0
+2016-06-02 16:33:54  gcpcorrelate    18877 process_gcp.c            430  INFO Correlating GCP # 120 to SCA 0
+2016-06-02 16:33:54  gcpcorrelate    18877 process_gcp.c            430  INFO Correlating GCP # 160 to SCA 0
+2016-06-02 16:33:54  gcpcorrelate    18877 process_gcp.c            430  INFO Correlating GCP # 200 to SCA 0
+2016-06-02 16:33:54  gcpcorrelate    18877 process_gcp.c            430  INFO Correlating GCP # 240 to SCA 0
+2016-06-02 16:33:54  gcpcorrelate    18877 process_gcp.c            430  INFO Correlating GCP # 280 to SCA 0
+2016-06-02 16:33:54  gcpcorrelate    18877 process_gcp.c            430  INFO Correlating GCP # 320 to SCA 0
+2016-06-02 16:33:54  gcpcorrelate    18877 process_gcp.c            430  INFO Correlating GCP # 360 to SCA 0
+2016-06-02 16:33:54  gcpcorrelate    18877 process_gcp.c            430  INFO Correlating GCP # 400 to SCA 0
+2016-06-02 16:33:54  gcpcorrelate    18877 process_gcp.c            694  INFO Points inside image 408, Number used 408, Last used 0
+2016-06-02 16:33:54  gcpcorrelate    18877 process_gcp.c            759  INFO 319 of 408 points correlated
+2016-06-02 16:33:54  gcpcorrelate    18877 GCPcorrelate.c           151  INFO Successful completion
+ 
+gcpcorrelate execution completed with status of 0
+ 
+Thu Jun 2 16:33:54 AEST 2016
+Thu Jun 2 16:33:56 AEST 2016
+ 
+L8 Precision Correction (L8PRECISION_SOLVE)
+ 
+2016-06-02 16:33:56  correct_los_model    18896 correct_los_model.c      116  INFO Initiated correct_los_model
+2016-06-02 16:33:56  correct_los_model    18896 correct_los_model.c      298  INFO Finished getting satellite time and position
+2016-06-02 16:34:27  correct_los_model    18896 correct_los_model.c      369  INFO Finished calculating the precision corrections
+2016-06-02 16:34:27  correct_los_model    18896 correct_los_model.c      402  INFO Pre-fit RMS residuals:   X =  12.160 meters  Y =   5.109 meters
+2016-06-02 16:34:27  correct_los_model    18896 correct_los_model.c      405  INFO Post-fit RMS residuals:  X =   4.355 meters  Y =   5.023 meters
+2016-06-02 16:34:27  correct_los_model    18896 correct_los_model.c      409  INFO GCP Outlier Percentage:  13.79 percent
+2016-06-02 16:34:27  correct_los_model    18896 correct_los_model.c      544  INFO Successful completion
+ 
+correct_los_model exection completed with status of 0
+ 
+Thu Jun 2 16:34:27 AEST 2016
+Thu Jun 2 16:34:29 AEST 2016
+ 
+Geodetic Accuracy Characterization (GEODETIC)
+ 
+2016-06-02 16:34:29  geodetic    19032 geodetic_char.c           89  INFO Geodetic Accuracy Assessment initiated
+2016-06-02 16:34:29  geodetic    19032 geodetic_char.c          235  INFO Successful Completion
+ 
+geodetic execution completed with status of 0
+ 
+Thu Jun 2 16:34:29 AEST 2016
+Thu Jun 2 16:34:33 AEST 2016
+ 
+Create Grid for Precision (L8GRID_PREC)
+ 
+2016-06-02 16:34:33  create_grid    19064 get_parms_and_initialize_grid.c    1228  INFO Pixel origin will be 'UL'
+2016-06-02 16:34:33  create_grid    19064 create_grid.c            173  INFO Initiate Create Grid...
+2016-06-02 16:34:33  create_grid    19064 create_grid.c            284  INFO Elevation range   -40.00   419.00
+2016-06-02 16:34:33  create_grid    19064 pad_corners.c             58  INFO Scene padding size is 25.000000
+2016-06-02 16:34:33  create_grid    19064 get_frame_minbox.c       189  INFO 121975.000000 349925.000000 6687875.000000 6918550.000000
+
+2016-06-02 16:34:33  create_grid    19064 build_grid.c             259  INFO Processing band number 1
+2016-06-02 16:34:34  create_grid    19064 build_grid.c             259  INFO Processing band number 2
+2016-06-02 16:34:34  create_grid    19064 build_grid.c              93  INFO Writing grid band number 1
+2016-06-02 16:34:35  create_grid    19064 build_grid.c             259  INFO Processing band number 3
+2016-06-02 16:34:36  create_grid    19064 build_grid.c             259  INFO Processing band number 4
+2016-06-02 16:34:37  create_grid    19064 build_grid.c              93  INFO Writing grid band number 2
+2016-06-02 16:34:37  create_grid    19064 build_grid.c             259  INFO Processing band number 5
+2016-06-02 16:34:38  create_grid    19064 build_grid.c             259  INFO Processing band number 6
+2016-06-02 16:34:39  create_grid    19064 build_grid.c             259  INFO Processing band number 7
+2016-06-02 16:34:40  create_grid    19064 build_grid.c              93  INFO Writing grid band number 3
+2016-06-02 16:34:41  create_grid    19064 build_grid.c             259  INFO Processing band number 8
+2016-06-02 16:34:42  create_grid    19064 build_grid.c             259  INFO Processing band number 9
+2016-06-02 16:34:43  create_grid    19064 build_grid.c             259  INFO Processing band number 10
+2016-06-02 16:34:43  create_grid    19064 build_grid.c             259  INFO Processing band number 11
+2016-06-02 16:34:45  create_grid    19064 build_grid.c              93  INFO Writing grid band number 4
+2016-06-02 16:34:45  create_grid    19064 build_grid.c              93  INFO Writing grid band number 5
+2016-06-02 16:34:47  create_grid    19064 build_grid.c              93  INFO Writing grid band number 6
+2016-06-02 16:34:48  create_grid    19064 build_grid.c              93  INFO Writing grid band number 7
+2016-06-02 16:34:48  create_grid    19064 build_grid.c              93  INFO Writing grid band number 8
+2016-06-02 16:34:49  create_grid    19064 build_grid.c              93  INFO Writing grid band number 9
+2016-06-02 16:34:52  create_grid    19064 build_grid.c              93  INFO Writing grid band number 10
+2016-06-02 16:34:53  create_grid    19064 build_grid.c              93  INFO Writing grid band number 11
+2016-06-02 16:34:55  create_grid    19064 create_grid.c            869  INFO Writing output grid file headers
+2016-06-02 16:34:55  create_grid    19064 create_grid.c            929  INFO Successful completion
+ 
+create_grid execution completed with status of 0
+ 
+Thu Jun 2 16:34:55 AEST 2016
+Thu Jun 2 16:34:57 AEST 2016
+ 
+Grid Terrain Second Pass (GRID_TERRAIN_PASS2)
+ 
+2016-06-02 16:34:57  Makegeomgrid    19214 make_geom_grid.c         100  INFO Initiated
+2016-06-02 16:34:57  Makegeomgrid    19214 make_geom_grid.c         189  INFO Using band number 6 from the TARGET_FRAME_FILE
+2016-06-02 16:34:58  Makegeomgrid    19214 make_geom_grid.c         607  INFO Successful Completion
+ 
+makegeomgrid execution completed with status of 0
+ 
+Thu Jun 2 16:34:58 AEST 2016
+Thu Jun 2 16:34:59 AEST 2016
+ 
+Resample Terrain Second Pass (RESAMPLE_TERRAIN_PASS2)
+ 
+2016-06-02 16:34:59  Geomresample    19220 geomresample.c            93  INFO Geometric Resample Initiated
+2016-06-02 16:34:59  Geomresample    19220 geomresample.c           112  INFO Reading Grid
+2016-06-02 16:34:59  Geomresample    19220 geomresample.c           219  INFO Resampling band 1
+2016-06-02 16:34:59  Geomresample    19220 scanman.c                250  INFO resampling lines 0 through 800
+2016-06-02 16:34:59  Geomresample    19220 scanman.c                250  INFO resampling lines 650 through 1450
+2016-06-02 16:34:59  Geomresample    19220 scanman.c                250  INFO resampling lines 1300 through 2100
+2016-06-02 16:34:59  Geomresample    19220 scanman.c                250  INFO resampling lines 1950 through 2750
+2016-06-02 16:34:59  Geomresample    19220 scanman.c                250  INFO resampling lines 2600 through 3400
+2016-06-02 16:34:59  Geomresample    19220 scanman.c                250  INFO resampling lines 3250 through 4050
+2016-06-02 16:35:00  Geomresample    19220 scanman.c                250  INFO resampling lines 3900 through 4700
+2016-06-02 16:35:00  Geomresample    19220 scanman.c                250  INFO resampling lines 4550 through 5350
+2016-06-02 16:35:00  Geomresample    19220 scanman.c                250  INFO resampling lines 5200 through 6000
+2016-06-02 16:35:01  Geomresample    19220 scanman.c                250  INFO resampling lines 5850 through 6650
+2016-06-02 16:35:01  Geomresample    19220 scanman.c                250  INFO resampling lines 6500 through 7300
+2016-06-02 16:35:01  Geomresample    19220 scanman.c                250  INFO resampling lines 7150 through 7950
+2016-06-02 16:35:02  Geomresample    19220 scanman.c                250  INFO resampling lines 7800 through 8600
+2016-06-02 16:35:02  Geomresample    19220 scanman.c                250  INFO resampling lines 8450 through 9250
+2016-06-02 16:35:03  Geomresample    19220 scanman.c                250  INFO resampling lines 9100 through 9900
+2016-06-02 16:35:03  Geomresample    19220 scanman.c                250  INFO resampling lines 9750 through 10550
+2016-06-02 16:35:03  Geomresample    19220 scanman.c                250  INFO resampling lines 10400 through 11200
+2016-06-02 16:35:03  Geomresample    19220 scanman.c                250  INFO resampling lines 11050 through 11850
+2016-06-02 16:35:03  Geomresample    19220 scanman.c                250  INFO resampling lines 11700 through 12500
+2016-06-02 16:35:03  Geomresample    19220 scanman.c                250  INFO resampling lines 12350 through 13094
+2016-06-02 16:35:04  Geomresample    19220 geomresample.c           330  INFO Geometric Resample Successful Completion
+ 
+geomresample execution completed with status of 0
+ 
+Thu Jun 2 16:35:04 AEST 2016
+Thu Jun 2 16:35:06 AEST 2016
+ 
+L8 Resample Precision (L8RESAMPLE_PREC)
+ 
+2016-06-02 16:35:06  Resample    19273 resample.c               115  INFO Initiated
+2016-06-02 16:35:07  Resample    19273 process_band.c            80  INFO Resampling band number 1
+2016-06-02 16:35:24  Resample    19273 process_band.c            80  INFO Resampling band number 2
+2016-06-02 16:35:47  Resample    19273 process_band.c            80  INFO Resampling band number 3
+2016-06-02 16:36:15  Resample    19273 process_band.c            80  INFO Resampling band number 4
+2016-06-02 16:36:36  Resample    19273 process_band.c            80  INFO Resampling band number 5
+2016-06-02 16:36:51  Resample    19273 process_band.c            80  INFO Resampling band number 6
+2016-06-02 16:37:30  Resample    19273 process_band.c            80  INFO Resampling band number 7
+2016-06-02 16:38:01  Resample    19273 process_band.c            80  INFO Resampling band number 8
+2016-06-02 16:40:14  Resample    19273 process_band.c            80  INFO Resampling band number 9
+2016-06-02 16:40:39  Resample    19273 process_band.c            80  INFO Resampling band number 10
+2016-06-02 16:41:04  Resample    19273 process_band.c            80  INFO Resampling band number 11
+2016-06-02 16:41:43  Resample    19273 resample.c               789  INFO Successful Completion
+ 
+resample execution completed with status of 0
+ 
+Thu Jun 2 16:41:43 AEST 2016
+Thu Jun 2 16:41:45 AEST 2016
+ 
+L8 GCP Correlation for Precision Second Pass (L8PRECISION_GCP_PASS2)
+ 
+2016-06-02 16:41:45  gcpcorrelate    19657 GCPcorrelate.c            84  INFO Initiated
+2016-06-02 16:41:45  gcpcorrelate    19657 GCPcorrelate.c            87  INFO Reading gcp_lib/GCPLib
+2016-06-02 16:41:45  gcpcorrelate    19657 ias_gcp_read_gcplib.c     292  INFO Reading gcp_lib/GCPLib
+2016-06-02 16:41:45  gcpcorrelate    19657 ias_gcp_read_gcplib.c     313  INFO Read 408 GCPs
+2016-06-02 16:41:45  gcpcorrelate    19657 ias_gcp_read_gcplib.c     135  INFO Pixel alignment will be 'UL', hemisphere is 'S', datum = 'GDA_94'
+2016-06-02 16:41:45  gcpcorrelate    19657 GCPcorrelate.c           116  INFO Read 408 GCPs
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            236  INFO Processing 1 SCA(s) in image l1t.h5
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            375  INFO Using image chips from gcp_lib
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            430  INFO Correlating GCP # 0 to SCA 0
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800156 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800374 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800184 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800061 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800142 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800367 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800305 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800194 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800116 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800379 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800252 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800370 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800361 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800113 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800090 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800060 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800327 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800259 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800198 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800378 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800042 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800393 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800025 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800328 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800261 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800039 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800139 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800188 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800024 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800056 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800206 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800064 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800217 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800164 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800015 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800363 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800218 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800291 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800301 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800020 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            430  INFO Correlating GCP # 40 to SCA 0
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800284 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800197 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800294 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800234 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800272 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800009 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800154 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800346 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800058 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800038 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800109 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800005 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800223 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800114 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800099 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800022 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800317 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800120 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800176 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800250 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800322 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800130 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800246 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800028 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800092 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800210 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800170 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800135 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800107 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800225 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800310 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800131 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800079 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800260 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800040 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800181 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800100 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800345 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800076 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800125 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            430  INFO Correlating GCP # 80 to SCA 0
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800012 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800175 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800354 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800282 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800018 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800240 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800088 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800280 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800073 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800117 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800318 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800375 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800033 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800239 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800035 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800150 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800059 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800147 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800074 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800362 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800377 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800172 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800032 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800249 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800288 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800395 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800245 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800192 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800258 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800050 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800075 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800340 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800004 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800148 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800081 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800247 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800315 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800337 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800266 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800052 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            430  INFO Correlating GCP # 120 to SCA 0
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800201 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800065 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800224 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800145 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800338 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800086 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800205 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800163 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800271 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800091 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800066 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800041 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800263 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800143 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800069 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800037 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800297 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800119 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800264 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800230 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800231 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800151 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800110 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800391 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800278 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800190 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800355 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800002 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800057 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800146 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800168 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800098 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800084 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800102 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800221 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800166 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800289 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800352 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800237 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800296 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            430  INFO Correlating GCP # 160 to SCA 0
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800128 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800277 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800106 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800394 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800101 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800017 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800406 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800158 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800254 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800108 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800169 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800211 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800085 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800356 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800177 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800202 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800093 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800126 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800123 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800178 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800314 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800072 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800173 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800381 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800220 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800403 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800311 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800319 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800010 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800019 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800400 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800236 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800044 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800062 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800384 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800267 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800304 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800273 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800321 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800227 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            430  INFO Correlating GCP # 200 to SCA 0
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800121 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800144 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800115 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800386 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800342 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800171 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800083 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800161 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800251 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800281 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800071 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800390 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800193 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800335 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800348 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800136 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800360 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800174 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800298 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800213 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800129 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800183 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800134 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800215 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800388 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800330 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800292 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800248 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800182 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800396 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800089 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800299 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800212 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800034 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800257 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800207 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800047 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800255 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800339 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800419 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            430  INFO Correlating GCP # 240 to SCA 0
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800068 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800343 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800222 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800167 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800372 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800195 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800233 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800313 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800031 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800235 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800006 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800373 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800189 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800295 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800208 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800138 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800080 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800347 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800104 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800358 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800268 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800132 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800013 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800199 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800269 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800275 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800325 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800127 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800229 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800357 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800320 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800293 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800232 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800054 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800111 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800279 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800265 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800341 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800287 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800118 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            430  INFO Correlating GCP # 280 to SCA 0
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800124 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800141 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800187 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800368 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800228 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800001 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800140 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800155 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800014 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800308 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800196 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800369 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800326 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800112 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800048 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800276 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800316 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800046 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800380 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800094 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800003 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800398 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800149 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800331 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800152 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800336 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800133 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800055 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800097 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800021 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800185 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800385 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800165 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800027 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800290 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800137 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800366 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800179 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800191 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800051 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            430  INFO Correlating GCP # 320 to SCA 0
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800382 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800200 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800333 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800204 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800365 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800371 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800043 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800383 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800323 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800226 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800306 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800351 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800392 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800359 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800334 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800399 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800159 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800045 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800096 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800303 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800387 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800067 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800008 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800016 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800186 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800030 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800162 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800241 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800350 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800302 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800283 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800397 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800103 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800153 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800312 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800349 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800082 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800011 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800216 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800332 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            430  INFO Correlating GCP # 360 to SCA 0
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800244 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800242 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800344 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800087 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800353 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800389 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800270 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800324 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800238 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800243 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800023 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800364 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800274 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800105 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800077 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800253 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800286 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800285 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800122 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800029 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800307 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800063 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800219 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800095 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800007 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800157 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800300 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800070 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800214 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800078 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800180 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800053 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800036 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800376 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800407 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800026 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800049 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800405 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800309 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800160 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            430  INFO Correlating GCP # 400 to SCA 0
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800404 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800203 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800262 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800402 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800209 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800418 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800416 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            476  WARN Skipping GCP 1140800329 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            694  INFO Points inside image 0, Number used 0, Last used 0
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            755  WARN No points correlated successfully
+2016-06-02 16:41:45  gcpcorrelate    19657 process_gcp.c            759  INFO 0 of 408 points correlated
+2016-06-02 16:41:45  gcpcorrelate    19657 GCPcorrelate.c           151  INFO Successful completion
+ 
+gcpcorrelate execution completed with status of 0
+ 
+Thu Jun 2 16:41:45 AEST 2016
+Thu Jun 2 16:41:47 AEST 2016
+ 
+Geometric Accuracy Characterization (GEOMETRIC)
+ 
+2016-06-02 16:41:47  geometric    19669 geometric_char.c         104  INFO Geometric Accuracy Assessment Characterization initiated
+2016-06-02 16:41:47  geometric    19669 geometric_char.c         143  WARN Number of correlated validation GCPs read 0 is below the minimum threshold 20, so geometric results should not be used
+ 
+geometric execution completed with status of 0
+ 
+Thu Jun 2 16:41:47 AEST 2016
+Thu Jun 2 16:41:49 AEST 2016
+ 
+Terrain Occlusion (TERRAIN_OCCLUSION)
+ 
+2016-06-02 16:41:49  terrain_occlusion    19676 terrain_occlusion.c       86  INFO Initiate ...
+2016-06-02 16:41:55  terrain_occlusion    19676 terrain_occlusion.c      269  INFO Elevation range on unresampled DEM: -40 to 419
+
+2016-06-02 16:41:56  terrain_occlusion    19676 occlusion_threading.c     348  INFO Starting terrain occlusion with 4 threads
+2016-06-02 16:41:56  terrain_occlusion    19676 occlusion_threading.c     144  INFO Starting SCA 0
+2016-06-02 16:41:57  terrain_occlusion    19676 occlusion_threading.c     144  INFO Starting SCA 1
+2016-06-02 16:41:58  terrain_occlusion    19676 occlusion_threading.c     144  INFO Starting SCA 2
+2016-06-02 16:41:59  terrain_occlusion    19676 occlusion_threading.c     144  INFO Starting SCA 3
+2016-06-02 16:42:00  terrain_occlusion    19676 occlusion_threading.c     144  INFO Starting SCA 4
+2016-06-02 16:42:01  terrain_occlusion    19676 occlusion_threading.c     144  INFO Starting SCA 5
+2016-06-02 16:42:02  terrain_occlusion    19676 occlusion_threading.c     144  INFO Starting SCA 6
+2016-06-02 16:42:02  terrain_occlusion    19676 occlusion_threading.c     144  INFO Starting SCA 7
+2016-06-02 16:42:03  terrain_occlusion    19676 occlusion_threading.c     144  INFO Starting SCA 8
+2016-06-02 16:42:04  terrain_occlusion    19676 occlusion_threading.c     144  INFO Starting SCA 9
+2016-06-02 16:42:05  terrain_occlusion    19676 occlusion_threading.c     144  INFO Starting SCA 10
+2016-06-02 16:42:06  terrain_occlusion    19676 occlusion_threading.c     144  INFO Starting SCA 11
+2016-06-02 16:42:07  terrain_occlusion    19676 occlusion_threading.c     144  INFO Starting SCA 12
+2016-06-02 16:42:08  terrain_occlusion    19676 occlusion_threading.c     144  INFO Starting SCA 13
+2016-06-02 16:42:09  terrain_occlusion    19676 occlusion_threading.c     377  INFO Occluded pixels in SCA 0: 0
+2016-06-02 16:42:09  terrain_occlusion    19676 occlusion_threading.c     377  INFO Occluded pixels in SCA 1: 0
+2016-06-02 16:42:09  terrain_occlusion    19676 occlusion_threading.c     377  INFO Occluded pixels in SCA 2: 0
+2016-06-02 16:42:09  terrain_occlusion    19676 occlusion_threading.c     377  INFO Occluded pixels in SCA 3: 0
+2016-06-02 16:42:09  terrain_occlusion    19676 occlusion_threading.c     377  INFO Occluded pixels in SCA 4: 0
+2016-06-02 16:42:09  terrain_occlusion    19676 occlusion_threading.c     377  INFO Occluded pixels in SCA 5: 0
+2016-06-02 16:42:09  terrain_occlusion    19676 occlusion_threading.c     377  INFO Occluded pixels in SCA 6: 0
+2016-06-02 16:42:09  terrain_occlusion    19676 occlusion_threading.c     377  INFO Occluded pixels in SCA 7: 0
+2016-06-02 16:42:09  terrain_occlusion    19676 occlusion_threading.c     377  INFO Occluded pixels in SCA 8: 0
+2016-06-02 16:42:09  terrain_occlusion    19676 occlusion_threading.c     377  INFO Occluded pixels in SCA 9: 0
+2016-06-02 16:42:09  terrain_occlusion    19676 occlusion_threading.c     377  INFO Occluded pixels in SCA 10: 0
+2016-06-02 16:42:09  terrain_occlusion    19676 occlusion_threading.c     377  INFO Occluded pixels in SCA 11: 0
+2016-06-02 16:42:09  terrain_occlusion    19676 occlusion_threading.c     377  INFO Occluded pixels in SCA 12: 0
+2016-06-02 16:42:09  terrain_occlusion    19676 occlusion_threading.c     377  INFO Occluded pixels in SCA 13: 0
+2016-06-02 16:42:09  terrain_occlusion    19676 occlusion_threading.c     381  INFO Total occluded pixels: 0
+2016-06-02 16:42:09  terrain_occlusion    19676 write_l1g.c               61  INFO Writing occlusion file occlusion_mask.h5
+2016-06-02 16:42:09  terrain_occlusion    19676 terrain_occlusion.c      330  INFO Successful completion.
+ 
+terrain_occlusion execution completed with a status of 0
+ 
+Thu Jun 2 16:42:09 AEST 2016
+Thu Jun 2 16:42:12 AEST 2016
+ 
+Assess Cloud Cover (ASSESS_CLOUD_COVER)
+ 
+2016-06-02 16:42:12  assess_cloud_cover    19686 assess_cloud_cover.c    2061  INFO assess_cloud_cover l1t.h5
+2016-06-02 16:42:12  assess_cloud_cover    19686 ias_cpf_parse_cloud_cover_assessment.c     122  WARN Only 1 parameter read in from the CPF for Cirrus Threshold
+2016-06-02 16:42:12  assess_cloud_cover    19686 algorithm.c              359  INFO Using ACCA algorithm
+2016-06-02 16:42:12  assess_cloud_cover    19686 algorithm.c              359  INFO Using Cirrus algorithm
+2016-06-02 16:42:12  assess_cloud_cover    19686 algorithm.c              359  INFO Using See5 algorithm
+2016-06-02 16:42:14  assess_cloud_cover    19686 assess_cloud_cover.c    1374  INFO Processing line    0/9228 (0%)
+2016-06-02 16:42:20  assess_cloud_cover    19686 assess_cloud_cover.c    1374  INFO Processing line  922/9228 (10%)
+2016-06-02 16:42:24  assess_cloud_cover    19686 assess_cloud_cover.c    1374  INFO Processing line 1844/9228 (20%)
+2016-06-02 16:42:28  assess_cloud_cover    19686 assess_cloud_cover.c    1374  INFO Processing line 2766/9228 (30%)
+2016-06-02 16:42:32  assess_cloud_cover    19686 assess_cloud_cover.c    1374  INFO Processing line 3688/9228 (40%)
+2016-06-02 16:42:35  assess_cloud_cover    19686 assess_cloud_cover.c    1374  INFO Processing line 4610/9228 (50%)
+2016-06-02 16:42:40  assess_cloud_cover    19686 assess_cloud_cover.c    1374  INFO Processing line 5532/9228 (60%)
+2016-06-02 16:42:44  assess_cloud_cover    19686 assess_cloud_cover.c    1374  INFO Processing line 6454/9228 (70%)
+2016-06-02 16:42:49  assess_cloud_cover    19686 assess_cloud_cover.c    1374  INFO Processing line 7376/9228 (80%)
+2016-06-02 16:42:52  assess_cloud_cover    19686 assess_cloud_cover.c    1374  INFO Processing line 8298/9228 (90%)
+2016-06-02 16:42:54  assess_cloud_cover    19686 assess_cloud_cover.c    1374  INFO Processing line 9220/9228 (100%)
+2016-06-02 16:42:54  assess_cloud_cover    19686 assess_cloud_cover.c    1633  INFO Processing line 9228/9228 (100%)
+2016-06-02 16:42:55  assess_cloud_cover    19686 assess_cloud_cover.c    1971  INFO Cloud Score l1t.h5: 0.83%
+2016-06-02 16:42:55  assess_cloud_cover    19686 assess_cloud_cover.c    1972  INFO Snow/Ice Score l1t.h5: 0.16%
+2016-06-02 16:42:55  assess_cloud_cover    19686 assess_cloud_cover.c    1974  INFO Land Cloud Cover Score l1t.h5: 2.42%
+2016-06-02 16:42:55  assess_cloud_cover    19686 assess_cloud_cover.c    1975  INFO Created quality band image: quality_band.h5
+2016-06-02 16:42:55  assess_cloud_cover    19686 assess_cloud_cover.c    1976  INFO assess_cloud_cover took 43 seconds
+ 
+assess_cloud_cover execution completed with a status of 0
+ 
+Thu Jun 2 16:42:55 AEST 2016
+Thu Jun 2 16:42:57 AEST 2016
+ 
+DMS Format and Package (DFP)
+ 
+2016-06-02 16:42:57  format_and_package    19748 format_and_package.c     244  INFO DMS Format & Package started
+2016-06-02 16:42:57  format_and_package    19748 format_and_package.c     245  INFO Pixel origin is UL
+2016-06-02 16:42:57  format_and_package    19748 convert_band.c            92  INFO Converting band 1
+2016-06-02 16:43:00  format_and_package    19748 convert_band.c            92  INFO Converting band 2
+2016-06-02 16:43:00  format_and_package    19748 convert_band.c            92  INFO Converting band 3
+2016-06-02 16:43:19  format_and_package    19748 convert_band.c            92  INFO Converting band 4
+2016-06-02 16:44:05  format_and_package    19748 convert_band.c            92  INFO Converting band 5
+2016-06-02 16:44:25  format_and_package    19748 convert_band.c            92  INFO Converting band 6
+2016-06-02 16:45:50  format_and_package    19748 convert_band.c            92  INFO Converting band 7
+2016-06-02 16:46:09  format_and_package    19748 convert_band.c            92  INFO Converting band 8
+2016-06-02 16:47:30  format_and_package    19748 convert_band.c            92  INFO Converting band 9
+2016-06-02 16:47:49  format_and_package    19748 convert_band.c            92  INFO Converting band 10
+2016-06-02 16:48:10  format_and_package    19748 convert_band.c            92  INFO Converting band 11
+2016-06-02 16:48:37  format_and_package    19748 convert_band.c            95  INFO Converting quality band
+2016-06-02 16:48:56  format_and_package    19748 format_and_package.c     532  INFO Creating the angle coefficients file
+2016-06-02 16:48:56  format_and_package    19748 write_metadata.c        1557  INFO Creating the L1G metadata file
+2016-06-02 16:48:56  format_and_package    19748 format_and_package.c     616  INFO Successful completion of DMS Format & Package
+ 
+format_and_package execution completed with status of 0
+ 
+Thu Jun 2 16:48:56 AEST 2016

--- a/integration_tests/data/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924/additional/OLI_TIRS_subsetter.log
+++ b/integration_tests/data/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924/additional/OLI_TIRS_subsetter.log
@@ -1,0 +1,5 @@
+CMD = '"/projects/v10/PinkMatter/LPGS4.1.4110/build/LAM/ot_subsetter" LC81140740812015267LGN00 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_080_080" --scene LC81140802015267LGN00'
+-------------------------------------------------------
+2016-06-02 16:29:49  Subsetter    17931 src/OTS/ot_subsetter.c     231  INFO scene_id LC81140802015267LGN00
+2016-06-02 16:29:49  Subsetter    17931 src/OTS/ot_subroutines.c    1730  INFO oli start: 34280
+2016-06-02 16:29:49  Subsetter    17931 src/OTS/ot_subroutines.c    1731  INFO oli stop: 41780

--- a/integration_tests/data/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924/additional/landsat-processor.log
+++ b/integration_tests/data/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924/additional/landsat-processor.log
@@ -1,0 +1,7574 @@
+2016-06-02T16:20:03 ComServer.cpp 90: INFO: Trying to host communication server on port '15000'
+2016-06-02T16:20:04 SystemSpecLogThread.cpp 73: WARN: Failed to obtain all system logs
+--------------------------------------------------
+----------------SYSTEM SPECS BEGIN----------------
+--------------------------------------------------
+---------------
+/proc/cpuinfo
+---------------
+processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 0
+cpu cores	: 8
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.46
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 1
+cpu cores	: 8
+apicid		: 2
+initial apicid	: 2
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.46
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 2
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 2
+cpu cores	: 8
+apicid		: 4
+initial apicid	: 4
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.46
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 3
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 3
+cpu cores	: 8
+apicid		: 6
+initial apicid	: 6
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.46
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 4
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 4
+cpu cores	: 8
+apicid		: 8
+initial apicid	: 8
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.46
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 5
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 5
+cpu cores	: 8
+apicid		: 10
+initial apicid	: 10
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.46
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 6
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 6
+cpu cores	: 8
+apicid		: 12
+initial apicid	: 12
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.46
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 7
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 7
+cpu cores	: 8
+apicid		: 14
+initial apicid	: 14
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.46
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 8
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 0
+cpu cores	: 8
+apicid		: 32
+initial apicid	: 32
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 9
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 1
+cpu cores	: 8
+apicid		: 34
+initial apicid	: 34
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 10
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 2
+cpu cores	: 8
+apicid		: 36
+initial apicid	: 36
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 11
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 3
+cpu cores	: 8
+apicid		: 38
+initial apicid	: 38
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 12
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 4
+cpu cores	: 8
+apicid		: 40
+initial apicid	: 40
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 13
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 5
+cpu cores	: 8
+apicid		: 42
+initial apicid	: 42
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 14
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 6
+cpu cores	: 8
+apicid		: 44
+initial apicid	: 44
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 15
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 7
+cpu cores	: 8
+apicid		: 46
+initial apicid	: 46
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 16
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 0
+cpu cores	: 8
+apicid		: 1
+initial apicid	: 1
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.46
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 17
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 1
+cpu cores	: 8
+apicid		: 3
+initial apicid	: 3
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.46
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 18
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 2
+cpu cores	: 8
+apicid		: 5
+initial apicid	: 5
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.46
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 19
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 3
+cpu cores	: 8
+apicid		: 7
+initial apicid	: 7
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.46
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 20
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 4
+cpu cores	: 8
+apicid		: 9
+initial apicid	: 9
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.46
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 21
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 5
+cpu cores	: 8
+apicid		: 11
+initial apicid	: 11
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.46
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 22
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 6
+cpu cores	: 8
+apicid		: 13
+initial apicid	: 13
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.46
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 23
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 7
+cpu cores	: 8
+apicid		: 15
+initial apicid	: 15
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.46
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 24
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 0
+cpu cores	: 8
+apicid		: 33
+initial apicid	: 33
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 25
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 1
+cpu cores	: 8
+apicid		: 35
+initial apicid	: 35
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 26
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 2
+cpu cores	: 8
+apicid		: 37
+initial apicid	: 37
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 27
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 3
+cpu cores	: 8
+apicid		: 39
+initial apicid	: 39
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 28
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 4
+cpu cores	: 8
+apicid		: 41
+initial apicid	: 41
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 29
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 5
+cpu cores	: 8
+apicid		: 43
+initial apicid	: 43
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 30
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 6
+cpu cores	: 8
+apicid		: 45
+initial apicid	: 45
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 31
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 7
+cpu cores	: 8
+apicid		: 47
+initial apicid	: 47
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dts tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+
+---------------
+/proc/meminfo
+---------------
+MemTotal:       32987364 kB
+MemFree:         3966884 kB
+Buffers:          156076 kB
+Cached:         23964152 kB
+SwapCached:        28576 kB
+Active:          5895332 kB
+Inactive:       18311396 kB
+Active(anon):     101064 kB
+Inactive(anon):    35804 kB
+Active(file):    5794268 kB
+Inactive(file): 18275592 kB
+Unevictable:       49380 kB
+Mlocked:               0 kB
+SwapTotal:      12000252 kB
+SwapFree:       11961160 kB
+Dirty:           1788420 kB
+Writeback:         69296 kB
+AnonPages:        122352 kB
+Mapped:            36896 kB
+Shmem:               700 kB
+Slab:            3128352 kB
+SReclaimable:     494124 kB
+SUnreclaim:      2634228 kB
+KernelStack:       17120 kB
+PageTables:         7252 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:    28493932 kB
+Committed_AS:    1162476 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:     1408696 kB
+VmallocChunk:   34339676832 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:         0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+DirectMap4k:        4096 kB
+DirectMap2M:     2084864 kB
+DirectMap1G:    31457280 kB
+
+---------------
+/proc/swaps
+---------------
+Filename				Type		Size	Used	Priority
+/dev/sda2                               partition	12000252	39092	-1
+
+---------------
+/proc/version
+---------------
+Linux version 2.6.32-573.22.1.el6.x86_64 (mockbuild@c6b8.bsys.dev.centos.org) (gcc version 4.4.7 20120313 (Red Hat 4.4.7-16) (GCC) ) #1 SMP Wed Mar 23 03:35:39 UTC 2016
+
+---------------
+export
+---------------
+export BASH_ENV="/home/554/lww554/.bashrc"
+export BLAS="/projects/u46/opt/modules/core/lib64/libblas.so"
+export CC="gcc"
+export CPATH="/projects/u46/opt/modules/core/include"
+export CXX="g++"
+export ENV="/home/554/lww554/.bashrc"
+export ENVIRONMENT="BATCH"
+export FPATH="/opt/Modules/krutsh/commands"
+export GCC_BASE="/apps/gcc/5.2.0"
+export GCC_ROOT="/apps/gcc/5.2.0"
+export GCC_VERSION="5.2.0"
+export GDAL_DATA="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/gdal/share/gdal"
+export GDAL_DRIVER_PATH="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/gdal/gdalplugins"
+export GEOTIFF_CSV="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/libgeotiff/share/epsg_csv"
+export HISTSIZE="1000"
+export HOME="/home/554/lww554"
+export HOST="r928"
+export HOSTNAME="r928"
+export HPCLPGS_HOME="/projects/v10/NEMO/hpc-lpgs"
+export IASBIN="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/bin"
+export IASDEM="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/GEOID"
+export IASSYS="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/share/sys"
+export IASYS="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/share/sys"
+export IAS_BIN="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/bin"
+export IAS_BIN2="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS2/bin"
+export IAS_DATA_DIR2="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS2/share"
+export IAS_SERVICES="DUMMY"
+export IAS_SYS_DIR2="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS2"
+export INFOPATH="/projects/u46/opt/modules/core/share/info"
+export INPUTRC="/etc/inputrc"
+export JPLDE421="/projects/v10/PinkMatter/LPGS4.1.4110/build/COTS64/novas3.1/data/lnxp1900p2053.421"
+export LANDSAT_INSTALL_DIR="/projects/v10/PinkMatter/LPGS4.1.4110"
+export LANG="C"
+export LAPACK="/projects/u46/opt/modules/core/lib64/liblapack.so"
+export LD_LIBRARY_PATH="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/COTS64/unixodbc/lib64:/projects/v10/PinkMatter/LPGS4.1.4110/build/LACS/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/LAM/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/DPAS/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/tiff/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/libgeotiff/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/openjpeg/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/OpenThreads/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/allegro/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/proj4/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/geos/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/gdal/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/fann/lib"
+export LD_RUN_PATH="/apps/gcc/5.2.0/lib64"
+export LEAP_SECONDS_FILE="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/LeapSeconds/leap_seconds.odl"
+export LEVEL1_MODE="LPGS"
+export LIBRARY_PATH="/projects/u46/opt/modules/core/lib64:/projects/u46/opt/modules/core/lib:/apps/gcc/5.2.0/lib64"
+export LOADEDMODULES="pbs:gcc/5.2.0:core/1.0:gaip/test-core:galpgs-py2-env/1.2"
+export LOGNAME="lww554"
+export LPGS_SYS_DIR2="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS2"
+export LPS_TABLE_PATH="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPS/tables"
+export LP_MAX_PORT="15025"
+export LP_MIN_PORT="15000"
+export MACHTYPE="x86_64"
+export MAIL="/var/spool/mail/lww554"
+export MANPATH="/projects/u46/opt/modules/core/share/man:/apps/gcc/5.2.0/share/man:/opt/pbs/default/man:/usr/share/man:/opt/man:/opt/Modules/default/man"
+export MODULEPATH="/projects/u46/opt/modules/modulefiles:/apps/.mf:/opt/Modules/modulefiles:/apps/Modules/modulefiles:"
+export MODULESHOME="/opt/Modules/3.2.6"
+export MODULE_VERSION="3.2.6"
+export MODULE_VERSION_STACK="3.2.6"
+export NCPUS="16"
+export NF_MODULES_LOADED="YES"
+export OLDPWD
+export OMP_NUM_THREADS="1"
+export OPSBIN="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/bin"
+export OSSIM_BIN="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/bin"
+export OSSIM_INC="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/include"
+export OSSIM_LIB="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/lib"
+export OSSIM_PREFS_FILE="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/ossim_preferences"
+export PATH="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/libgeotiff/bin:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/tiff/bin:/projects/v10/PinkMatter/LPGS4.1.4110/build/landsat_Pinkmatter:/g/data/v10/projects/S2_test/anaconda/bin:/projects/u46/opt/modules/galpgs-py2-env/1.2/bin:/projects/u46/opt/modules/gaip/test-core/ga-neo-landsat-processor/workflow:/projects/u46/opt/modules/core/bin:/apps/gcc/5.2.0/wrapper:/apps/gcc/5.2.0/bin:/projects/v10/NEMO/hpc-lpgs/bin:/home/554/lww554/bin:/g/data/v10/projects/S2_test/anaconda/bin:/opt/bin:/bin:/usr/bin:/opt/pbs/default/bin:/projects/v10/PinkMatter/LPGS4.1.4110/build/LAM/perl5lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/bin:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/gdal/bin"
+export PBS_ENVIRONMENT="PBS_BATCH"
+export PBS_JOBCOOKIE="00000000135E58330000000008645B8E"
+export PBS_JOBDIR="/home/554/lww554"
+export PBS_JOBFS="/jobfs/local/6654022.r-man2"
+export PBS_JOBID="6654022.r-man2"
+export PBS_JOBNAME="l8-2015-lvl1-2"
+export PBS_MOMPORT="15003"
+export PBS_NCI_FS_GDATA1="1"
+export PBS_NCI_FS_GDATA2="1"
+export PBS_NCI_FS_GDATA3="1"
+export PBS_NCI_HT="0"
+export PBS_NCI_JOBFS_LOCAL="12884901888000b"
+export PBS_NCI_WD="1"
+export PBS_NCPUS="768"
+export PBS_NGPUS="0"
+export PBS_NODENUM="16"
+export PBS_O_HOME="/home/554/lww554"
+export PBS_O_HOST="raijin2"
+export PBS_O_LANG="C"
+export PBS_O_LOGNAME="lww554"
+export PBS_O_MAIL="/var/spool/mail/lww554"
+export PBS_O_PATH="/projects/u46/opt/modules/galpgs-py2-env/1.2/bin:/projects/u46/opt/modules/gaip/test-core/ga-neo-landsat-processor/workflow:/projects/u46/opt/modules/core/bin:/apps/gcc/5.2.0/wrapper:/apps/gcc/5.2.0/bin:/projects/v10/NEMO/hpc-lpgs/bin:/home/554/lww554/bin:/g/data/v10/projects/S2_test/anaconda/bin:/g/data/v10/projects/S2_test/anaconda/bin:/opt/bin:/bin:/usr/bin:/opt/pbs/default/bin"
+export PBS_O_QUEUE="normal"
+export PBS_O_SHELL="/bin/bash"
+export PBS_O_SYSTEM="Linux"
+export PBS_O_WORKDIR="/home/554/lww554"
+export PBS_QUEUE="normal-def"
+export PBS_TASKNUM="04000001"
+export PBS_VMEM="1649267441664"
+export PERL5LIB="/projects/v10/PinkMatter/LPGS4.1.4110/build/landsat_Pinkmatter/perl5lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/perl/lib/5.10.0/x86_64-linux-thread-multi:/projects/v10/PinkMatter/LPGS4.1.4110/build/COTS/lib/perl:/projects/v10/PinkMatter/LPGS4.1.4110/build/perl/lib"
+export PINKMATTER_LPGS_HOME="/projects/v10/PinkMatter/LPGS4.1.4110"
+export PKG_CONFIG_PATH="/projects/u46/opt/modules/core/lib64/pkgconfig:/projects/u46/opt/modules/core/lib/pkgconfig"
+export PROCESSING_CENTER="GA"
+export PROCESSING_SYSTEM="LPGS_LDCM"
+export PROJECT="v10"
+export PWD="/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work"
+export PYTHONPATH="/projects/u46/opt/modules/galpgs-py2-env/1.2/lib/python2.7/site-packages:/projects/u46/opt/modules/gaip/test-core/ga-neo-landsat-processor:/projects/u46/opt/modules/core/lib/python2.7/site-packages:/projects/v10/NEMO/hpc-lpgs/python:"
+export SHLVL="3"
+export TCLLIBPATH="/apps/modext/default/lib/tcl"
+export TMPDIR="/jobfs/local/6654022.r-man2"
+export TMSS_HOME="/projects/v10/PinkMatter/LPGS4.1.4110/build/LAM/TMSS"
+export ULTRA_INSTALL_DIR="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA"
+export USER="lww554"
+export _="/projects/v10/PinkMatter/LPGS4.1.4110/build/landsat_Pinkmatter/landsat_processor"
+export _LMFILES_="/opt/Modules/modulefiles/pbs:/apps/Modules/modulefiles/gcc/5.2.0:/projects/u46/opt/modules/modulefiles/core/1.0:/projects/u46/opt/modules/modulefiles/gaip/test-core:/projects/u46/opt/modules/modulefiles/galpgs-py2-env/1.2"
+
+---------------
+/sbin/ldconfig -p
+---------------
+1224 libs found in cache `/etc/ld.so.cache'
+	libz.so.1 (libc6,x86-64) => /lib64/libz.so.1
+	libz.so.1 (libc6) => /lib/libz.so.1
+	libz.so (libc6,x86-64) => /usr/lib64/libz.so
+	libxtables.so.4 (libc6,x86-64) => /lib64/libxtables.so.4
+	libxslt.so.1 (libc6,x86-64) => /usr/lib64/libxslt.so.1
+	libxslt.so (libc6,x86-64) => /usr/lib64/libxslt.so
+	libxml2.so.2 (libc6,x86-64) => /usr/lib64/libxml2.so.2
+	libxml2.so (libc6,x86-64) => /usr/lib64/libxml2.so
+	libxmlsec1.so.1 (libc6,x86-64) => /usr/lib64/libxmlsec1.so.1
+	libxmlsec1.so (libc6,x86-64) => /usr/lib64/libxmlsec1.so
+	libxmlsec1-openssl.so.1 (libc6,x86-64) => /usr/lib64/libxmlsec1-openssl.so.1
+	libxmlsec1-openssl.so (libc6,x86-64) => /usr/lib64/libxmlsec1-openssl.so
+	libxmlrpc_util.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_util.so.3
+	libxmlrpc_server_cgi.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_server_cgi.so.3
+	libxmlrpc_server_abyss.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_server_abyss.so.3
+	libxmlrpc_server.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_server.so.3
+	libxmlrpc_client.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_client.so.3
+	libxmlrpc_abyss.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_abyss.so.3
+	libxmlrpc.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc.so.3
+	libxkbfile.so.1 (libc6,x86-64) => /usr/lib64/libxkbfile.so.1
+	libxerces-c-3.0.so (libc6,x86-64) => /usr/lib64/libxerces-c-3.0.so
+	libxdot.so.4 (libc6,x86-64) => /usr/lib64/libxdot.so.4
+	libxcb.so.1 (libc6,x86-64) => /usr/lib64/libxcb.so.1
+	libxcb.so.1 (libc6) => /usr/lib/libxcb.so.1
+	libxcb.so (libc6,x86-64) => /usr/lib64/libxcb.so
+	libxcb-xvmc.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xvmc.so.0
+	libxcb-xvmc.so.0 (libc6) => /usr/lib/libxcb-xvmc.so.0
+	libxcb-xvmc.so (libc6,x86-64) => /usr/lib64/libxcb-xvmc.so
+	libxcb-xv.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xv.so.0
+	libxcb-xv.so.0 (libc6) => /usr/lib/libxcb-xv.so.0
+	libxcb-xv.so (libc6,x86-64) => /usr/lib64/libxcb-xv.so
+	libxcb-xtest.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xtest.so.0
+	libxcb-xtest.so.0 (libc6) => /usr/lib/libxcb-xtest.so.0
+	libxcb-xtest.so (libc6,x86-64) => /usr/lib64/libxcb-xtest.so
+	libxcb-xselinux.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xselinux.so.0
+	libxcb-xselinux.so.0 (libc6) => /usr/lib/libxcb-xselinux.so.0
+	libxcb-xselinux.so (libc6,x86-64) => /usr/lib64/libxcb-xselinux.so
+	libxcb-xinerama.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xinerama.so.0
+	libxcb-xinerama.so.0 (libc6) => /usr/lib/libxcb-xinerama.so.0
+	libxcb-xinerama.so (libc6,x86-64) => /usr/lib64/libxcb-xinerama.so
+	libxcb-xf86dri.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xf86dri.so.0
+	libxcb-xf86dri.so.0 (libc6) => /usr/lib/libxcb-xf86dri.so.0
+	libxcb-xf86dri.so (libc6,x86-64) => /usr/lib64/libxcb-xf86dri.so
+	libxcb-xfixes.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xfixes.so.0
+	libxcb-xfixes.so.0 (libc6) => /usr/lib/libxcb-xfixes.so.0
+	libxcb-xfixes.so (libc6,x86-64) => /usr/lib64/libxcb-xfixes.so
+	libxcb-xevie.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xevie.so.0
+	libxcb-xevie.so.0 (libc6) => /usr/lib/libxcb-xevie.so.0
+	libxcb-xevie.so (libc6,x86-64) => /usr/lib64/libxcb-xevie.so
+	libxcb-sync.so.0 (libc6,x86-64) => /usr/lib64/libxcb-sync.so.0
+	libxcb-sync.so.0 (libc6) => /usr/lib/libxcb-sync.so.0
+	libxcb-sync.so (libc6,x86-64) => /usr/lib64/libxcb-sync.so
+	libxcb-shm.so.0 (libc6,x86-64) => /usr/lib64/libxcb-shm.so.0
+	libxcb-shm.so.0 (libc6) => /usr/lib/libxcb-shm.so.0
+	libxcb-shm.so (libc6,x86-64) => /usr/lib64/libxcb-shm.so
+	libxcb-shape.so.0 (libc6,x86-64) => /usr/lib64/libxcb-shape.so.0
+	libxcb-shape.so.0 (libc6) => /usr/lib/libxcb-shape.so.0
+	libxcb-shape.so (libc6,x86-64) => /usr/lib64/libxcb-shape.so
+	libxcb-screensaver.so.0 (libc6,x86-64) => /usr/lib64/libxcb-screensaver.so.0
+	libxcb-screensaver.so.0 (libc6) => /usr/lib/libxcb-screensaver.so.0
+	libxcb-screensaver.so (libc6,x86-64) => /usr/lib64/libxcb-screensaver.so
+	libxcb-res.so.0 (libc6,x86-64) => /usr/lib64/libxcb-res.so.0
+	libxcb-res.so.0 (libc6) => /usr/lib/libxcb-res.so.0
+	libxcb-res.so (libc6,x86-64) => /usr/lib64/libxcb-res.so
+	libxcb-reply.so.1 (libc6,x86-64) => /usr/lib64/libxcb-reply.so.1
+	libxcb-render.so.0 (libc6,x86-64) => /usr/lib64/libxcb-render.so.0
+	libxcb-render.so.0 (libc6) => /usr/lib/libxcb-render.so.0
+	libxcb-render.so (libc6,x86-64) => /usr/lib64/libxcb-render.so
+	libxcb-render-util.so.0 (libc6,x86-64) => /usr/lib64/libxcb-render-util.so.0
+	libxcb-record.so.0 (libc6,x86-64) => /usr/lib64/libxcb-record.so.0
+	libxcb-record.so.0 (libc6) => /usr/lib/libxcb-record.so.0
+	libxcb-record.so (libc6,x86-64) => /usr/lib64/libxcb-record.so
+	libxcb-randr.so.0 (libc6,x86-64) => /usr/lib64/libxcb-randr.so.0
+	libxcb-randr.so.0 (libc6) => /usr/lib/libxcb-randr.so.0
+	libxcb-randr.so (libc6,x86-64) => /usr/lib64/libxcb-randr.so
+	libxcb-property.so.1 (libc6,x86-64) => /usr/lib64/libxcb-property.so.1
+	libxcb-keysyms.so.1 (libc6,x86-64) => /usr/lib64/libxcb-keysyms.so.1
+	libxcb-glx.so.0 (libc6,x86-64) => /usr/lib64/libxcb-glx.so.0
+	libxcb-glx.so.0 (libc6) => /usr/lib/libxcb-glx.so.0
+	libxcb-glx.so (libc6,x86-64) => /usr/lib64/libxcb-glx.so
+	libxcb-event.so.1 (libc6,x86-64) => /usr/lib64/libxcb-event.so.1
+	libxcb-dri2.so.0 (libc6,x86-64) => /usr/lib64/libxcb-dri2.so.0
+	libxcb-dri2.so.0 (libc6) => /usr/lib/libxcb-dri2.so.0
+	libxcb-dri2.so (libc6,x86-64) => /usr/lib64/libxcb-dri2.so
+	libxcb-dpms.so.0 (libc6,x86-64) => /usr/lib64/libxcb-dpms.so.0
+	libxcb-dpms.so.0 (libc6) => /usr/lib/libxcb-dpms.so.0
+	libxcb-dpms.so (libc6,x86-64) => /usr/lib64/libxcb-dpms.so
+	libxcb-damage.so.0 (libc6,x86-64) => /usr/lib64/libxcb-damage.so.0
+	libxcb-damage.so.0 (libc6) => /usr/lib/libxcb-damage.so.0
+	libxcb-damage.so (libc6,x86-64) => /usr/lib64/libxcb-damage.so
+	libxcb-composite.so.0 (libc6,x86-64) => /usr/lib64/libxcb-composite.so.0
+	libxcb-composite.so.0 (libc6) => /usr/lib/libxcb-composite.so.0
+	libxcb-composite.so (libc6,x86-64) => /usr/lib64/libxcb-composite.so
+	libxcb-aux.so.0 (libc6,x86-64) => /usr/lib64/libxcb-aux.so.0
+	libxcb-atom.so.1 (libc6,x86-64) => /usr/lib64/libxcb-atom.so.1
+	libwx_gtk2u_xrc-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_xrc-2.8.so.0
+	libwx_gtk2u_xrc-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_xrc-2.8.so
+	libwx_gtk2u_svg-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_svg-2.8.so.0
+	libwx_gtk2u_svg-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_svg-2.8.so
+	libwx_gtk2u_stc-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_stc-2.8.so.0
+	libwx_gtk2u_stc-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_stc-2.8.so
+	libwx_gtk2u_richtext-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_richtext-2.8.so.0
+	libwx_gtk2u_richtext-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_richtext-2.8.so
+	libwx_gtk2u_qa-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_qa-2.8.so.0
+	libwx_gtk2u_qa-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_qa-2.8.so
+	libwx_gtk2u_ogl-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_ogl-2.8.so.0
+	libwx_gtk2u_ogl-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_ogl-2.8.so
+	libwx_gtk2u_media-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_media-2.8.so.0
+	libwx_gtk2u_media-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_media-2.8.so
+	libwx_gtk2u_html-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_html-2.8.so.0
+	libwx_gtk2u_html-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_html-2.8.so
+	libwx_gtk2u_gl-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gl-2.8.so.0
+	libwx_gtk2u_gl-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gl-2.8.so
+	libwx_gtk2u_gizmos_xrc-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gizmos_xrc-2.8.so.0
+	libwx_gtk2u_gizmos_xrc-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gizmos_xrc-2.8.so
+	libwx_gtk2u_gizmos-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gizmos-2.8.so.0
+	libwx_gtk2u_gizmos-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gizmos-2.8.so
+	libwx_gtk2u_core-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_core-2.8.so.0
+	libwx_gtk2u_core-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_core-2.8.so
+	libwx_gtk2u_aui-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_aui-2.8.so.0
+	libwx_gtk2u_aui-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_aui-2.8.so
+	libwx_gtk2u_adv-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_adv-2.8.so.0
+	libwx_gtk2u_adv-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_adv-2.8.so
+	libwx_baseu_xml-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_baseu_xml-2.8.so.0
+	libwx_baseu_xml-2.8.so (libc6,x86-64) => /usr/lib64/libwx_baseu_xml-2.8.so
+	libwx_baseu_net-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_baseu_net-2.8.so.0
+	libwx_baseu_net-2.8.so (libc6,x86-64) => /usr/lib64/libwx_baseu_net-2.8.so
+	libwx_baseu-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_baseu-2.8.so.0
+	libwx_baseu-2.8.so (libc6,x86-64) => /usr/lib64/libwx_baseu-2.8.so
+	libwrap.so.0 (libc6,x86-64) => /lib64/libwrap.so.0
+	libwmflite-0.2.so.7 (libc6,x86-64) => /usr/lib64/libwmflite-0.2.so.7
+	libwmf-0.2.so.7 (libc6,x86-64) => /usr/lib64/libwmf-0.2.so.7
+	libvsl.so (libc6,x86-64) => /usr/lib/fio/libvsl.so
+	libvorbisfile.so.3 (libc6,x86-64) => /usr/lib64/libvorbisfile.so.3
+	libvorbisenc.so.2 (libc6,x86-64) => /usr/lib64/libvorbisenc.so.2
+	libvorbis.so.0 (libc6,x86-64) => /usr/lib64/libvorbis.so.0
+	libvma.so.6 (libc6,x86-64) => /usr/lib64/libvma.so.6
+	libvma.so (libc6,x86-64) => /usr/lib64/libvma.so
+	libvisual-0.4.so.0 (libc6,x86-64) => /usr/lib64/libvisual-0.4.so.0
+	libverto.so.0 (libc6,x86-64) => /usr/lib64/libverto.so.0
+	libverto.so (libc6,x86-64) => /usr/lib64/libverto.so
+	libverto-k5ev.so.0 (libc6,x86-64) => /usr/lib64/libverto-k5ev.so.0
+	libverto-k5ev.so (libc6,x86-64) => /usr/lib64/libverto-k5ev.so
+	libvdpau_trace.so (libc6,x86-64) => /usr/lib64/libvdpau_trace.so
+	libvdpau_nvidia.so (libc6,x86-64, OS ABI: Linux 2.3.99) => /usr/lib64/libvdpau_nvidia.so
+	libvdpau.so.1 (libc6,x86-64) => /usr/lib64/libvdpau.so.1
+	libvdpau.so (libc6,x86-64) => /usr/lib64/libvdpau.so
+	libuuid.so.1 (libc6,x86-64) => /lib64/libuuid.so.1
+	libuuid.so.1 (libc6) => /lib/libuuid.so.1
+	libuuid.so (libc6,x86-64) => /usr/lib64/libuuid.so
+	libutil.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libutil.so.1
+	libutil.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libutil.so.1
+	libutil.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libutil.so
+	libutil.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libutil.so
+	libutempter.so.0 (libc6,x86-64) => /usr/lib64/libutempter.so.0
+	libustr-1.0.so.1 (libc6,x86-64) => /usr/lib64/libustr-1.0.so.1
+	libuser.so.1 (libc6,x86-64) => /usr/lib64/libuser.so.1
+	libusbpp-0.1.so.4 (libc6,x86-64) => /usr/lib64/libusbpp-0.1.so.4
+	libusb-1.0.so.0 (libc6,x86-64) => /usr/lib64/libusb-1.0.so.0
+	libusb-0.1.so.4 (libc6,x86-64) => /usr/lib64/libusb-0.1.so.4
+	libunistring.so.0 (libc6,x86-64) => /usr/lib64/libunistring.so.0
+	libunique-1.0.so.0 (libc6,x86-64) => /usr/lib64/libunique-1.0.so.0
+	libungif.so.4 (libc6,x86-64) => /usr/lib64/libungif.so.4
+	libungif.so (libc6,x86-64) => /usr/lib64/libungif.so
+	libudf.so.0 (libc6,x86-64) => /usr/lib64/libudf.so.0
+	libudev.so.0 (libc6,x86-64) => /lib64/libudev.so.0
+	libt1x.so.5 (libc6,x86-64) => /usr/lib64/libt1x.so.5
+	libt1.so.5 (libc6,x86-64) => /usr/lib64/libt1.so.5
+	libturbojpeg.so (libc6,x86-64) => /usr/lib64/libturbojpeg.so
+	libtt-1.0.0.so (libc6,x86-64) => /usr/lib64/libtt-1.0.0.so
+	libtk8.5.so (libc6,x86-64) => /usr/lib64/libtk8.5.so
+	libtirpc.so.1 (libc6,x86-64) => /lib64/libtirpc.so.1
+	libtinfo.so.5 (libc6,x86-64) => /lib64/libtinfo.so.5
+	libtinfo.so.5 (libc6) => /lib/libtinfo.so.5
+	libtinfo.so (libc6,x86-64) => /usr/lib64/libtinfo.so
+	libtinfo.so (libc6) => /usr/lib/libtinfo.so
+	libtiffxx.so.3 (libc6,x86-64) => /usr/lib64/libtiffxx.so.3
+	libtiffxx.so.3 (libc6) => /usr/lib/libtiffxx.so.3
+	libtiffxx.so (libc6,x86-64) => /usr/lib64/libtiffxx.so
+	libtiff.so.3 (libc6,x86-64) => /usr/lib64/libtiff.so.3
+	libtiff.so.3 (libc6) => /usr/lib/libtiff.so.3
+	libtiff.so (libc6,x86-64) => /usr/lib64/libtiff.so
+	libtic.so.5 (libc6,x86-64) => /usr/lib64/libtic.so.5
+	libtic.so.5 (libc6) => /usr/lib/libtic.so.5
+	libtic.so (libc6,x86-64) => /usr/lib64/libtic.so
+	libtic.so (libc6) => /usr/lib/libtic.so
+	libthread_db.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libthread_db.so.1
+	libthread_db.so.1 (libc6, hwcap: 0x0028000000000000, OS ABI: Linux 2.6.18) => /lib/i686/nosegneg/libthread_db.so.1
+	libthread_db.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libthread_db.so.1
+	libthread_db.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libthread_db.so
+	libthread_db.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libthread_db.so
+	libtheoraenc.so.1 (libc6,x86-64) => /usr/lib64/libtheoraenc.so.1
+	libtheoradec.so.1 (libc6,x86-64) => /usr/lib64/libtheoradec.so.1
+	libtheora.so.0 (libc6,x86-64) => /usr/lib64/libtheora.so.0
+	libthai.so.0 (libc6,x86-64) => /usr/lib64/libthai.so.0
+	libtevent.so.0 (libc6,x86-64) => /usr/lib64/libtevent.so.0
+	libtevent-util.so.0 (libc6,x86-64) => /usr/lib64/libtevent-util.so.0
+	libtdb.so.1 (libc6,x86-64) => /usr/lib64/libtdb.so.1
+	libtcl8.5.so (libc6,x86-64) => /usr/lib64/libtcl8.5.so
+	libtclx8.4.so (libc6,x86-64) => /usr/lib64/tcl8.5/tclx8.4/libtclx8.4.so
+	libtasn1.so.3 (libc6,x86-64) => /usr/lib64/libtasn1.so.3
+	libtar.so.1 (libc6,x86-64) => /usr/lib64/libtar.so.1
+	libtalloc.so.2 (libc6,x86-64) => /usr/lib64/libtalloc.so.2
+	libsysfs.so.2 (libc6,x86-64) => /usr/lib64/libsysfs.so.2
+	libsvn_wc-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_wc-1.so.0
+	libsvn_swig_py-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_swig_py-1.so.0
+	libsvn_swig_perl-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_swig_perl-1.so.0
+	libsvn_subr-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_subr-1.so.0
+	libsvn_repos-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_repos-1.so.0
+	libsvn_ra_svn-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_ra_svn-1.so.0
+	libsvn_ra_neon-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_ra_neon-1.so.0
+	libsvn_ra_local-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_ra_local-1.so.0
+	libsvn_ra-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_ra-1.so.0
+	libsvn_fs_util-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_fs_util-1.so.0
+	libsvn_fs_fs-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_fs_fs-1.so.0
+	libsvn_fs_base-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_fs_base-1.so.0
+	libsvn_fs-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_fs-1.so.0
+	libsvn_diff-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_diff-1.so.0
+	libsvn_delta-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_delta-1.so.0
+	libsvn_client-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_client-1.so.0
+	libstdc++.so.6 (libc6,x86-64) => /usr/lib64/libstdc++.so.6
+	libstdc++.so.6 (libc6) => /usr/lib/libstdc++.so.6
+	libstdc++.so.5 (libc6,x86-64) => /usr/lib64/libstdc++.so.5
+	libstdc++.so.5 (libc6) => /usr/lib/libstdc++.so.5
+	libstartup-notification-1.so.0 (libc6,x86-64) => /usr/lib64/libstartup-notification-1.so.0
+	libsss_sudo.so (libc6,x86-64) => /usr/lib64/libsss_sudo.so
+	libsss_idmap.so.0 (libc6,x86-64) => /usr/lib64/libsss_idmap.so.0
+	libssl3.so (libc6,x86-64) => /usr/lib64/libssl3.so
+	libssl.so.10 (libc6,x86-64) => /usr/lib64/libssl.so.10
+	libssl.so (libc6,x86-64) => /usr/lib64/libssl.so
+	libssh2.so.1 (libc6,x86-64) => /usr/lib64/libssh2.so.1
+	libss.so.2 (libc6,x86-64) => /lib64/libss.so.2
+	libsqlite3.so.0 (libc6,x86-64) => /usr/lib64/libsqlite3.so.0
+	libsqlite3.so (libc6,x86-64) => /usr/lib64/libsqlite3.so
+	libspectre.so.1 (libc6,x86-64) => /usr/lib64/libspectre.so.1
+	libsoup-2.4.so.1 (libc6,x86-64) => /usr/lib64/libsoup-2.4.so.1
+	libsoup-gnome-2.4.so.1 (libc6,x86-64) => /usr/lib64/libsoup-gnome-2.4.so.1
+	libsoftokn3.so (libc6,x86-64) => /usr/lib64/libsoftokn3.so
+	libsnmp.so.20 (libc6,x86-64) => /usr/lib64/libsnmp.so.20
+	libsnappy.so.1 (libc6,x86-64) => /usr/lib64/libsnappy.so.1
+	libsmime3.so (libc6,x86-64) => /usr/lib64/libsmime3.so
+	libsmbldap.so.0 (libc6,x86-64) => /usr/lib64/libsmbldap.so.0
+	libsmbconf.so.0 (libc6,x86-64) => /usr/lib64/libsmbconf.so.0
+	libsmbclient-raw.so.0 (libc6,x86-64) => /usr/lib64/libsmbclient-raw.so.0
+	libslang.so.2 (libc6,x86-64) => /usr/lib64/libslang.so.2
+	libsgutils2.so.2 (libc6,x86-64) => /usr/lib64/libsgutils2.so.2
+	libsepol.so.1 (libc6,x86-64) => /lib64/libsepol.so.1
+	libsepol.so (libc6,x86-64) => /usr/lib64/libsepol.so
+	libsensors.so.4 (libc6,x86-64) => /usr/lib64/libsensors.so.4
+	libsemanage.so.1 (libc6,x86-64) => /lib64/libsemanage.so.1
+	libselinux.so.1 (libc6,x86-64) => /lib64/libselinux.so.1
+	libselinux.so.1 (libc6) => /lib/libselinux.so.1
+	libselinux.so (libc6,x86-64) => /usr/lib64/libselinux.so
+	libsasl2.so.2 (libc6,x86-64) => /usr/lib64/libsasl2.so.2
+	libsasl2.so (libc6,x86-64) => /usr/lib64/libsasl2.so
+	libsamdb.so.0 (libc6,x86-64) => /usr/lib64/libsamdb.so.0
+	libsamba-util.so.0 (libc6,x86-64) => /usr/lib64/libsamba-util.so.0
+	libsamba-policy.so.0 (libc6,x86-64) => /usr/lib64/libsamba-policy.so.0
+	libsamba-hostconfig.so.0 (libc6,x86-64) => /usr/lib64/libsamba-hostconfig.so.0
+	libsamba-credentials.so.0 (libc6,x86-64) => /usr/lib64/libsamba-credentials.so.0
+	libruby.so.1.8 (libc6,x86-64) => /usr/lib64/libruby.so.1.8
+	libruby.so (libc6,x86-64) => /usr/lib64/libruby.so
+	librt.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/librt.so.1
+	librt.so.1 (libc6, hwcap: 0x0028000000000000, OS ABI: Linux 2.6.18) => /lib/i686/nosegneg/librt.so.1
+	librt.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/librt.so.1
+	librt.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/librt.so
+	librt.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/librt.so
+	librsvg-2.so.2 (libc6,x86-64) => /usr/lib64/librsvg-2.so.2
+	librrd_th.so.4 (libc6,x86-64) => /usr/lib64/librrd_th.so.4
+	librrd_th.so (libc6,x86-64) => /usr/lib64/librrd_th.so
+	librrd.so.4 (libc6,x86-64) => /usr/lib64/librrd.so.4
+	librrd.so (libc6,x86-64) => /usr/lib64/librrd.so
+	librpmio.so.1 (libc6,x86-64) => /usr/lib64/librpmio.so.1
+	librpmbuild.so.1 (libc6,x86-64) => /usr/lib64/librpmbuild.so.1
+	librpm.so.1 (libc6,x86-64) => /usr/lib64/librpm.so.1
+	librpcsecgss.so.3 (libc6,x86-64) => /usr/lib64/librpcsecgss.so.3
+	libresolv.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libresolv.so.2
+	libresolv.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libresolv.so.2
+	libresolv.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libresolv.so
+	libresolv.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libresolv.so
+	libregistry.so.0 (libc6,x86-64) => /usr/lib64/libregistry.so.0
+	libref_array.so.1 (libc6,x86-64) => /usr/lib64/libref_array.so.1
+	libreadline.so.6 (libc6,x86-64) => /lib64/libreadline.so.6
+	libreadline.so.5 (libc6,x86-64) => /lib64/libreadline.so.5
+	libreadline.so (libc6,x86-64) => /usr/lib64/libreadline.so
+	librdmacm.so.1 (libc6,x86-64) => /usr/lib64/librdmacm.so.1
+	librdmacm.so (libc6,x86-64) => /usr/lib64/librdmacm.so
+	librarian.so.0 (libc6,x86-64) => /usr/lib64/librarian.so.0
+	libqui.so.1 (libc6,x86-64) => /usr/lib64/qt-3.3/lib/libqui.so.1
+	libqt-mt.so.3 (libc6,x86-64) => /usr/lib64/qt-3.3/lib/libqt-mt.so.3
+	libp11-kit.so.0 (libc6,x86-64) => /usr/lib64/libp11-kit.so.0
+	libpython2.6.so.1.0 (libc6,x86-64) => /usr/lib64/libpython2.6.so.1.0
+	libpython2.6.so (libc6,x86-64) => /usr/lib64/libpython2.6.so
+	libpytalloc-util.so.2 (libc6,x86-64) => /usr/lib64/libpytalloc-util.so.2
+	libpyglib-2.0-python.so.0 (libc6,x86-64) => /usr/lib64/libpyglib-2.0-python.so.0
+	libpyglib-2.0-python.so (libc6,x86-64) => /usr/lib64/libpyglib-2.0-python.so
+	libpthread.so.0 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libpthread.so.0
+	libpthread.so.0 (libc6, hwcap: 0x0028000000000000, OS ABI: Linux 2.6.18) => /lib/i686/nosegneg/libpthread.so.0
+	libpthread.so.0 (libc6, OS ABI: Linux 2.6.18) => /lib/libpthread.so.0
+	libpth.so.20 (libc6,x86-64) => /usr/lib64/libpth.so.20
+	libpsm_infinipath.so.1 (libc6,x86-64) => /usr/lib64/libpsm_infinipath.so.1
+	libpsm_infinipath.so (libc6,x86-64) => /usr/lib64/libpsm_infinipath.so
+	libproxy.so.0 (libc6,x86-64) => /usr/lib64/libproxy.so.0
+	libproj.so.0 (libc6,x86-64) => /usr/lib64/libproj.so.0
+	libproc-3.2.8.so (libc6,x86-64) => /lib64/libproc-3.2.8.so
+	libpq.so.5 (libc6,x86-64) => /usr/lib64/libpq.so.5
+	libpq.so (libc6,x86-64) => /usr/lib64/libpq.so
+	libppl_c.so.2 (libc6,x86-64) => /usr/lib64/libppl_c.so.2
+	libppl.so.7 (libc6,x86-64) => /usr/lib64/libppl.so.7
+	libpopt.so.0 (libc6,x86-64) => /lib64/libpopt.so.0
+	libpopt.so (libc6,x86-64) => /usr/lib64/libpopt.so
+	libpoppler.so.5 (libc6,x86-64) => /usr/lib64/libpoppler.so.5
+	libpoppler-glib.so.4 (libc6,x86-64) => /usr/lib64/libpoppler-glib.so.4
+	libpolkit-gobject-1.so.0 (libc6,x86-64) => /usr/lib64/libpolkit-gobject-1.so.0
+	libpolkit-backend-1.so.0 (libc6,x86-64) => /usr/lib64/libpolkit-backend-1.so.0
+	libpolkit-agent-1.so.0 (libc6,x86-64) => /usr/lib64/libpolkit-agent-1.so.0
+	libpng12.so.0 (libc6,x86-64) => /usr/lib64/libpng12.so.0
+	libpng12.so.0 (libc6) => /usr/lib/libpng12.so.0
+	libpng12.so (libc6,x86-64) => /usr/lib64/libpng12.so
+	libpng.so.3 (libc6,x86-64) => /usr/lib64/libpng.so.3
+	libpng.so.3 (libc6) => /usr/lib/libpng.so.3
+	libply.so.2 (libc6,x86-64) => /lib64/libply.so.2
+	libply-splash-core.so.2 (libc6,x86-64) => /lib64/libply-splash-core.so.2
+	libply-boot-client.so.2 (libc6,x86-64) => /usr/lib64/libply-boot-client.so.2
+	libplds4.so (libc6,x86-64) => /lib64/libplds4.so
+	libplds4.so (libc6,x86-64) => /usr/lib64/libplds4.so
+	libplc4.so (libc6,x86-64) => /lib64/libplc4.so
+	libplc4.so (libc6,x86-64) => /usr/lib64/libplc4.so
+	libpixman-1.so.0 (libc6,x86-64) => /usr/lib64/libpixman-1.so.0
+	libpixman-1.so (libc6,x86-64) => /usr/lib64/libpixman-1.so
+	libphonon.so.4 (libc6,x86-64) => /usr/lib64/libphonon.so.4
+	libphonon.so (libc6,x86-64) => /usr/lib64/libphonon.so
+	libpgtypes.so.3 (libc6,x86-64) => /usr/lib64/libpgtypes.so.3
+	libpgtypes.so (libc6,x86-64) => /usr/lib64/libpgtypes.so
+	libpdb.so.0 (libc6,x86-64) => /usr/lib64/libpdb.so.0
+	libpcreposix.so.0 (libc6,x86-64) => /usr/lib64/libpcreposix.so.0
+	libpcreposix.so (libc6,x86-64) => /usr/lib64/libpcreposix.so
+	libpcrecpp.so.0 (libc6,x86-64) => /usr/lib64/libpcrecpp.so.0
+	libpcrecpp.so (libc6,x86-64) => /usr/lib64/libpcrecpp.so
+	libpcre.so.0 (libc6,x86-64) => /lib64/libpcre.so.0
+	libpcre.so (libc6,x86-64) => /usr/lib64/libpcre.so
+	libpcprofile.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libpcprofile.so
+	libpcprofile.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libpcprofile.so
+	libpciaccess.so.0 (libc6,x86-64) => /usr/lib64/libpciaccess.so.0
+	libpciaccess.so.0 (libc6) => /usr/lib/libpciaccess.so.0
+	libpci.so.3 (libc6,x86-64) => /lib64/libpci.so.3
+	libpci.so (libc6,x86-64) => /usr/lib64/libpci.so
+	libpcap.so.1 (libc6,x86-64) => /usr/lib64/libpcap.so.1
+	libpathplan.so.4 (libc6,x86-64) => /usr/lib64/libpathplan.so.4
+	libpath_utils.so.1 (libc6,x86-64) => /usr/lib64/libpath_utils.so.1
+	libparted-2.1.so.0 (libc6,x86-64) => /lib64/libparted-2.1.so.0
+	libpaper.so.1 (libc6,x86-64) => /usr/lib64/libpaper.so.1
+	libpangoxft-1.0.so.0 (libc6,x86-64) => /usr/lib64/libpangoxft-1.0.so.0
+	libpangoxft-1.0.so (libc6,x86-64) => /usr/lib64/libpangoxft-1.0.so
+	libpangox-1.0.so.0 (libc6,x86-64) => /usr/lib64/libpangox-1.0.so.0
+	libpangox-1.0.so (libc6,x86-64) => /usr/lib64/libpangox-1.0.so
+	libpangoft2-1.0.so.0 (libc6,x86-64) => /usr/lib64/libpangoft2-1.0.so.0
+	libpangoft2-1.0.so (libc6,x86-64) => /usr/lib64/libpangoft2-1.0.so
+	libpangocairo-1.0.so.0 (libc6,x86-64) => /usr/lib64/libpangocairo-1.0.so.0
+	libpangocairo-1.0.so (libc6,x86-64) => /usr/lib64/libpangocairo-1.0.so
+	libpango-1.0.so.0 (libc6,x86-64) => /usr/lib64/libpango-1.0.so.0
+	libpango-1.0.so (libc6,x86-64) => /usr/lib64/libpango-1.0.so
+	libpanelw.so.5 (libc6,x86-64) => /usr/lib64/libpanelw.so.5
+	libpanelw.so.5 (libc6) => /usr/lib/libpanelw.so.5
+	libpanelw.so (libc6,x86-64) => /usr/lib64/libpanelw.so
+	libpanelw.so (libc6) => /usr/lib/libpanelw.so
+	libpanel.so.5 (libc6,x86-64) => /usr/lib64/libpanel.so.5
+	libpanel.so.5 (libc6) => /usr/lib/libpanel.so.5
+	libpanel.so (libc6,x86-64) => /usr/lib64/libpanel.so
+	libpanel.so (libc6) => /usr/lib/libpanel.so
+	libpamc.so.0 (libc6,x86-64) => /lib64/libpamc.so.0
+	libpam_misc.so.0 (libc6,x86-64) => /lib64/libpam_misc.so.0
+	libpam.so.0 (libc6,x86-64) => /lib64/libpam.so.0
+	libpakchois.so.0 (libc6,x86-64) => /usr/lib64/libpakchois.so.0
+	libotf.so.0 (libc6,x86-64) => /usr/lib64/libotf.so.0
+	libostyle.so.0 (libc6,x86-64) => /usr/lib64/libostyle.so.0
+	libospgrove.so.0 (libc6,x86-64) => /usr/lib64/libospgrove.so.0
+	libosp.so.5 (libc6,x86-64) => /usr/lib64/libosp.so.5
+	libosmvendor.so.3 (libc6,x86-64) => /usr/lib64/libosmvendor.so.3
+	libosmvendor.so (libc6,x86-64) => /usr/lib64/libosmvendor.so
+	libosmcomp.so.3 (libc6,x86-64) => /usr/lib64/libosmcomp.so.3
+	libosmcomp.so (libc6,x86-64) => /usr/lib64/libosmcomp.so
+	libopensm.so.5 (libc6,x86-64) => /usr/lib64/libopensm.so.5
+	libopensm.so (libc6,x86-64) => /usr/lib64/libopensm.so
+	libopenjpeg.so.2 (libc6,x86-64) => /usr/lib64/libopenjpeg.so.2
+	libopenjpeg.so (libc6,x86-64) => /usr/lib64/libopenjpeg.so
+	libopcodes-2.20.51.0.2-5.43.el6.so (libc6,x86-64) => /usr/lib64/libopcodes-2.20.51.0.2-5.43.el6.so
+	liboil-0.3.so.0 (libc6,x86-64) => /usr/lib64/liboil-0.3.so.0
+	libogrove.so.0 (libc6,x86-64) => /usr/lib64/libogrove.so.0
+	libogg.so.0 (libc6,x86-64) => /usr/lib64/libogg.so.0
+	libnvidia-tls.so.352.79 (libc6,x86-64, hwcap: 0x8000000000000000, OS ABI: Linux 2.3.99) => /usr/lib64/tls/libnvidia-tls.so.352.79
+	libnvidia-tls.so.352.79 (libc6,x86-64, OS ABI: Linux 2.2.5) => /usr/lib64/libnvidia-tls.so.352.79
+	libnvidia-opencl.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-opencl.so.1
+	libnvidia-ml.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-ml.so.1
+	libnvidia-ml.so (libc6,x86-64) => /usr/lib64/libnvidia-ml.so
+	libnvidia-ifr.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-ifr.so.1
+	libnvidia-ifr.so (libc6,x86-64) => /usr/lib64/libnvidia-ifr.so
+	libnvidia-gtk3.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-gtk3.so.352.79
+	libnvidia-gtk2.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-gtk2.so.352.79
+	libnvidia-glsi.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-glsi.so.352.79
+	libnvidia-glcore.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-glcore.so.352.79
+	libnvidia-fbc.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-fbc.so.1
+	libnvidia-fbc.so (libc6,x86-64) => /usr/lib64/libnvidia-fbc.so
+	libnvidia-encode.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-encode.so.1
+	libnvidia-encode.so (libc6,x86-64) => /usr/lib64/libnvidia-encode.so
+	libnvidia-eglcore.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-eglcore.so.352.79
+	libnvidia-compiler.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-compiler.so.352.79
+	libnvidia-cfg.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-cfg.so.1
+	libnvidia-cfg.so (libc6,x86-64) => /usr/lib64/libnvidia-cfg.so
+	libnvcuvid.so.1 (libc6,x86-64) => /usr/lib64/libnvcuvid.so.1
+	libnvcuvid.so (libc6,x86-64) => /usr/lib64/libnvcuvid.so
+	libnuma.so.1 (libc6,x86-64) => /usr/lib64/libnuma.so.1
+	libnuma.so (libc6,x86-64) => /usr/lib64/libnuma.so
+	libnss3.so (libc6,x86-64) => /usr/lib64/libnss3.so
+	libnssutil3.so (libc6,x86-64) => /usr/lib64/libnssutil3.so
+	libnsssysinit.so (libc6,x86-64) => /usr/lib64/libnsssysinit.so
+	libnsspem.so (libc6,x86-64) => /usr/lib64/libnsspem.so
+	libnssdbm3.so (libc6,x86-64) => /usr/lib64/libnssdbm3.so
+	libnssckbi.so (libc6,x86-64) => /usr/lib64/libnssckbi.so
+	libnss_sss.so.2 (libc6,x86-64) => /lib64/libnss_sss.so.2
+	libnss_nisplus.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_nisplus.so.2
+	libnss_nisplus.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_nisplus.so.2
+	libnss_nisplus.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_nisplus.so
+	libnss_nisplus.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_nisplus.so
+	libnss_nis.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_nis.so.2
+	libnss_nis.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_nis.so.2
+	libnss_nis.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_nis.so
+	libnss_nis.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_nis.so
+	libnss_ldap.so.2 (libc6,x86-64) => /lib64/libnss_ldap.so.2
+	libnss_ldap.so (libc6,x86-64) => /usr/lib64/libnss_ldap.so
+	libnss_hesiod.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_hesiod.so.2
+	libnss_hesiod.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_hesiod.so.2
+	libnss_hesiod.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_hesiod.so
+	libnss_hesiod.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_hesiod.so
+	libnss_files.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_files.so.2
+	libnss_files.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_files.so.2
+	libnss_files.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_files.so
+	libnss_files.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_files.so
+	libnss_dns.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_dns.so.2
+	libnss_dns.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_dns.so.2
+	libnss_dns.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_dns.so
+	libnss_dns.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_dns.so
+	libnss_compat.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_compat.so.2
+	libnss_compat.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_compat.so.2
+	libnss_compat.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_compat.so
+	libnss_compat.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_compat.so
+	libnspr4.so (libc6,x86-64) => /lib64/libnspr4.so
+	libnspr4.so (libc6,x86-64) => /usr/lib64/libnspr4.so
+	libnsl.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnsl.so.1
+	libnsl.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libnsl.so.1
+	libnsl.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnsl.so
+	libnsl.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnsl.so
+	libnl.so.1 (libc6,x86-64) => /lib64/libnl.so.1
+	libnl.so (libc6,x86-64) => /usr/lib64/libnl.so
+	libnih.so.1 (libc6,x86-64) => /lib64/libnih.so.1
+	libnih-dbus.so.1 (libc6,x86-64) => /lib64/libnih-dbus.so.1
+	libnfsidmap.so.0 (libc6,x86-64) => /usr/lib64/libnfsidmap.so.0
+	libnewt.so.0.52 (libc6,x86-64) => /usr/lib64/libnewt.so.0.52
+	libnetsnmptrapd.so.20 (libc6,x86-64) => /usr/lib64/libnetsnmptrapd.so.20
+	libnetsnmpmibs.so.20 (libc6,x86-64) => /usr/lib64/libnetsnmpmibs.so.20
+	libnetsnmphelpers.so.20 (libc6,x86-64) => /usr/lib64/libnetsnmphelpers.so.20
+	libnetsnmpagent.so.20 (libc6,x86-64) => /usr/lib64/libnetsnmpagent.so.20
+	libnetsnmp.so.20 (libc6,x86-64) => /usr/lib64/libnetsnmp.so.20
+	libnetpbm.so.10 (libc6,x86-64) => /usr/lib64/libnetpbm.so.10
+	libnetpbm.so (libc6,x86-64) => /usr/lib64/libnetpbm.so
+	libnes-rdmav2.so (libc6,x86-64) => /usr/lib64/libnes-rdmav2.so
+	libneon.so.27 (libc6,x86-64) => /usr/lib64/libneon.so.27
+	libndr.so.0 (libc6,x86-64) => /usr/lib64/libndr.so.0
+	libndr-standard.so.0 (libc6,x86-64) => /usr/lib64/libndr-standard.so.0
+	libndr-nbt.so.0 (libc6,x86-64) => /usr/lib64/libndr-nbt.so.0
+	libndr-krb5pac.so.0 (libc6,x86-64) => /usr/lib64/libndr-krb5pac.so.0
+	libncursesw.so.5 (libc6,x86-64) => /lib64/libncursesw.so.5
+	libncursesw.so.5 (libc6) => /lib/libncursesw.so.5
+	libncursesw.so (libc6,x86-64) => /usr/lib64/libncursesw.so
+	libncursesw.so (libc6) => /usr/lib/libncursesw.so
+	libncurses.so.5 (libc6,x86-64) => /lib64/libncurses.so.5
+	libncurses.so.5 (libc6) => /lib/libncurses.so.5
+	libncurses.so (libc6,x86-64) => /usr/lib64/libncurses.so
+	libncurses.so (libc6) => /usr/lib/libncurses.so
+	libnautilus-extension.so.1 (libc6,x86-64) => /usr/lib64/libnautilus-extension.so.1
+	libm17n.so.0 (libc6,x86-64) => /usr/lib64/libm17n.so.0
+	libm17n-flt.so.0 (libc6,x86-64) => /usr/lib64/libm17n-flt.so.0
+	libm17n-core.so.0 (libc6,x86-64) => /usr/lib64/libm17n-core.so.0
+	libmysqlclient_r.so.16 (libc6,x86-64) => /usr/lib64/mysql/libmysqlclient_r.so.16
+	libmysqlclient_r.so (libc6,x86-64) => /usr/lib64/mysql/libmysqlclient_r.so
+	libmysqlclient.so.16 (libc6,x86-64) => /usr/lib64/mysql/libmysqlclient.so.16
+	libmysqlclient.so (libc6,x86-64) => /usr/lib64/mysql/libmysqlclient.so
+	libmxm.so.2 (libc6,x86-64) => /opt/mellanox/mxm/lib/libmxm.so.2
+	libmxm.so (libc6,x86-64) => /opt/mellanox/mxm/lib/libmxm.so
+	libmunge.so.2 (libc6,x86-64) => /usr/lib64/libmunge.so.2
+	libmunge.so (libc6,x86-64) => /usr/lib64/libmunge.so
+	libmultipath.so (libc6,x86-64) => /lib64/libmultipath.so
+	libmtdev.so.1 (libc6,x86-64) => /usr/lib64/libmtdev.so.1
+	libmpfr.so.1 (libc6,x86-64) => /usr/lib64/libmpfr.so.1
+	libmpfr.so (libc6,x86-64) => /usr/lib64/libmpfr.so
+	libmpc.so.2 (libc6,x86-64) => /usr/lib64/libmpc.so.2
+	libmpc.so (libc6,x86-64) => /usr/lib64/libmpc.so
+	libmpathpersist.so.0 (libc6,x86-64) => /lib64/libmpathpersist.so.0
+	libmpathpersist.so (libc6,x86-64) => /lib64/libmpathpersist.so
+	libmp.so.3 (libc6,x86-64) => /usr/lib64/libmp.so.3
+	libmp.so (libc6,x86-64) => /usr/lib64/libmp.so
+	libmount.so.1 (libc6,x86-64) => /lib64/libmount.so.1
+	libmng.so.1 (libc6,x86-64) => /usr/lib64/libmng.so.1
+	libmng.so (libc6,x86-64) => /usr/lib64/libmng.so
+	libmlx5-rdmav2.so (libc6,x86-64) => /usr/lib64/libmlx5-rdmav2.so
+	libmlx4-rdmav2.so (libc6,x86-64) => /usr/lib64/libmlx4-rdmav2.so
+	libmenuw.so.5 (libc6,x86-64) => /usr/lib64/libmenuw.so.5
+	libmenuw.so.5 (libc6) => /usr/lib/libmenuw.so.5
+	libmenuw.so (libc6,x86-64) => /usr/lib64/libmenuw.so
+	libmenuw.so (libc6) => /usr/lib/libmenuw.so
+	libmenu.so.5 (libc6,x86-64) => /usr/lib64/libmenu.so.5
+	libmenu.so.5 (libc6) => /usr/lib/libmenu.so.5
+	libmenu.so (libc6,x86-64) => /usr/lib64/libmenu.so
+	libmenu.so (libc6) => /usr/lib/libmenu.so
+	libmemusage.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libmemusage.so
+	libmemusage.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libmemusage.so
+	libmcpp.so.0 (libc6,x86-64) => /usr/lib64/libmcpp.so.0
+	libmagic.so.1 (libc6,x86-64) => /usr/lib64/libmagic.so.1
+	libm.so.6 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libm.so.6
+	libm.so.6 (libc6, hwcap: 0x0028000000000000, OS ABI: Linux 2.6.18) => /lib/i686/nosegneg/libm.so.6
+	libm.so.6 (libc6, OS ABI: Linux 2.6.18) => /lib/libm.so.6
+	libm.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libm.so
+	libm.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libm.so
+	liblzo2.so.2 (libc6,x86-64) => /usr/lib64/liblzo2.so.2
+	liblzma.so.0 (libc6,x86-64) => /usr/lib64/liblzma.so.0
+	liblzma.so (libc6,x86-64) => /usr/lib64/liblzma.so
+	liblwres.so.80 (libc6,x86-64) => /usr/lib64/liblwres.so.80
+	liblvm2cmd.so.2.02 (libc6,x86-64) => /lib64/liblvm2cmd.so.2.02
+	liblvm2app.so.2.2 (libc6,x86-64) => /lib64/liblvm2app.so.2.2
+	liblustreapi.so (libc6,x86-64) => /usr/lib64/liblustreapi.so
+	liblustre.so (libc6,x86-64) => /usr/lib64/liblustre.so
+	liblua-5.1.so (libc6,x86-64) => /usr/lib64/liblua-5.1.so
+	libltdl.so.7 (libc6,x86-64) => /usr/lib64/libltdl.so.7
+	libldif-2.4.so.2 (libc6,x86-64) => /lib64/libldif-2.4.so.2
+	libldif-2.4.so.2 (libc6,x86-64) => /usr/lib64/libldif-2.4.so.2
+	libldb.so.1 (libc6,x86-64) => /usr/lib64/libldb.so.1
+	libldap_r-2.4.so.2 (libc6,x86-64) => /lib64/libldap_r-2.4.so.2
+	libldap_r-2.4.so.2 (libc6,x86-64) => /usr/lib64/libldap_r-2.4.so.2
+	libldap-2.4.so.2 (libc6,x86-64) => /lib64/libldap-2.4.so.2
+	libldap-2.4.so.2 (libc6,x86-64) => /usr/lib64/libldap-2.4.so.2
+	liblcms.so.1 (libc6,x86-64) => /usr/lib64/liblcms.so.1
+	liblcms.so (libc6,x86-64) => /usr/lib64/liblcms.so
+	liblber-2.4.so.2 (libc6,x86-64) => /lib64/liblber-2.4.so.2
+	liblber-2.4.so.2 (libc6,x86-64) => /usr/lib64/liblber-2.4.so.2
+	libk5crypto.so.3 (libc6,x86-64) => /lib64/libk5crypto.so.3
+	libk5crypto.so (libc6,x86-64) => /usr/lib64/libk5crypto.so
+	libkrb5support.so.0 (libc6,x86-64) => /lib64/libkrb5support.so.0
+	libkrb5support.so (libc6,x86-64) => /usr/lib64/libkrb5support.so
+	libkrb5.so.3 (libc6,x86-64) => /lib64/libkrb5.so.3
+	libkrb5.so (libc6,x86-64) => /usr/lib64/libkrb5.so
+	libkpathsea.so.4 (libc6,x86-64) => /usr/lib64/libkpathsea.so.4
+	libkeyutils.so.1 (libc6,x86-64) => /lib64/libkeyutils.so.1
+	libkeyutils.so (libc6,x86-64) => /usr/lib64/libkeyutils.so
+	libkdb5.so.6 (libc6,x86-64) => /usr/lib64/libkdb5.so.6
+	libkdb5.so (libc6,x86-64) => /usr/lib64/libkdb5.so
+	libkadm5srv_mit.so.8 (libc6,x86-64) => /usr/lib64/libkadm5srv_mit.so.8
+	libkadm5srv_mit.so (libc6,x86-64) => /usr/lib64/libkadm5srv_mit.so
+	libkadm5clnt_mit.so.8 (libc6,x86-64) => /usr/lib64/libkadm5clnt_mit.so.8
+	libkadm5clnt_mit.so (libc6,x86-64) => /usr/lib64/libkadm5clnt_mit.so
+	libjpeg.so.62 (libc6,x86-64) => /usr/lib64/libjpeg.so.62
+	libjpeg.so.62 (libc6) => /usr/lib/libjpeg.so.62
+	libjpeg.so (libc6,x86-64) => /usr/lib64/libjpeg.so
+	libjasper.so.1 (libc6,x86-64) => /usr/lib64/libjasper.so.1
+	libjasper.so (libc6,x86-64) => /usr/lib64/libjasper.so
+	libiw.so.29 (libc6,x86-64) => /lib64/libiw.so.29
+	libiso9660.so.7 (libc6,x86-64) => /usr/lib64/libiso9660.so.7
+	libiso9660++.so.0 (libc6,x86-64) => /usr/lib64/libiso9660++.so.0
+	libisccfg.so.82 (libc6,x86-64) => /usr/lib64/libisccfg.so.82
+	libisccc.so.80 (libc6,x86-64) => /usr/lib64/libisccc.so.80
+	libisc.so.83 (libc6,x86-64) => /usr/lib64/libisc.so.83
+	libip6tc.so.0 (libc6,x86-64) => /lib64/libip6tc.so.0
+	libip4tc.so.0 (libc6,x86-64) => /lib64/libip4tc.so.0
+	libiptc.so.0 (libc6,x86-64) => /lib64/libiptc.so.0
+	libipq.so.0 (libc6,x86-64) => /lib64/libipq.so.0
+	libipmimonitoring.so.5 (libc6,x86-64) => /usr/lib64/libipmimonitoring.so.5
+	libipmidetect.so.0 (libc6,x86-64) => /usr/lib64/libipmidetect.so.0
+	libipmiconsole.so.2 (libc6,x86-64) => /usr/lib64/libipmiconsole.so.2
+	libipathverbs-rdmav2.so (libc6,x86-64) => /usr/lib64/libipathverbs-rdmav2.so
+	libipa_hbac.so.0 (libc6,x86-64) => /usr/lib64/libipa_hbac.so.0
+	libini_config.so.5 (libc6,x86-64) => /usr/lib64/libini_config.so.5
+	libinfinipath.so.4 (libc6,x86-64) => /usr/lib64/libinfinipath.so.4
+	libinfinipath.so (libc6,x86-64) => /usr/lib64/libinfinipath.so
+	libijs-0.35.so (libc6,x86-64) => /usr/lib64/libijs-0.35.so
+	libidn.so.11 (libc6,x86-64) => /lib64/libidn.so.11
+	libidn.so (libc6,x86-64) => /usr/lib64/libidn.so
+	libicuuc.so.42 (libc6,x86-64) => /usr/lib64/libicuuc.so.42
+	libicutu.so.42 (libc6,x86-64) => /usr/lib64/libicutu.so.42
+	libiculx.so.42 (libc6,x86-64) => /usr/lib64/libiculx.so.42
+	libicule.so.42 (libc6,x86-64) => /usr/lib64/libicule.so.42
+	libicui18n.so.42 (libc6,x86-64) => /usr/lib64/libicui18n.so.42
+	libicuio.so.42 (libc6,x86-64) => /usr/lib64/libicuio.so.42
+	libicudata.so.42 (libc6,x86-64) => /usr/lib64/libicudata.so.42
+	libibverbs.so.1 (libc6,x86-64) => /usr/lib64/libibverbs.so.1
+	libibverbs.so (libc6,x86-64) => /usr/lib64/libibverbs.so
+	libibumad.so.3 (libc6,x86-64) => /usr/lib64/libibumad.so.3
+	libibumad.so (libc6,x86-64) => /usr/lib64/libibumad.so
+	libibsysapi.so.1 (libc6,x86-64) => /opt/ibutils/lib64/libibsysapi.so.1
+	libibsysapi.so (libc6,x86-64) => /opt/ibutils/lib64/libibsysapi.so
+	libibsysapi-2.1.1.so (libc6,x86-64) => /usr/lib64/libibsysapi-2.1.1.so
+	libibprof.so.0 (libc6,x86-64) => /opt/mellanox/libibperf/lib/libibprof.so.0
+	libibprof.so (libc6,x86-64) => /opt/mellanox/libibperf/lib/libibprof.so
+	libibnetdisc.so.5 (libc6,x86-64) => /usr/lib64/libibnetdisc.so.5
+	libibnetdisc.so (libc6,x86-64) => /usr/lib64/libibnetdisc.so
+	libibmscli.so.1 (libc6,x86-64) => /opt/ibutils/lib64/libibmscli.so.1
+	libibmscli.so (libc6,x86-64) => /opt/ibutils/lib64/libibmscli.so
+	libibmad.so.5 (libc6,x86-64) => /usr/lib64/libibmad.so.5
+	libibmad.so (libc6,x86-64) => /usr/lib64/libibmad.so
+	libibis-2.1.1.so (libc6,x86-64) => /usr/lib64/libibis-2.1.1.so
+	libibdmcom.so.1 (libc6,x86-64) => /opt/ibutils/lib64/libibdmcom.so.1
+	libibdmcom.so (libc6,x86-64) => /opt/ibutils/lib64/libibdmcom.so
+	libibdmcom-2.1.1.so (libc6,x86-64) => /usr/lib64/libibdmcom-2.1.1.so
+	libibdm.so.1 (libc6,x86-64) => /opt/ibutils/lib64/libibdm.so.1
+	libibdm.so (libc6,x86-64) => /opt/ibutils/lib64/libibdm.so
+	libibdiagnet_plugins_ifc-2.1.1.so (libc6,x86-64) => /usr/lib64/libibdiagnet_plugins_ifc-2.1.1.so
+	libibdiag-2.1.1.so (libc6,x86-64) => /usr/lib64/libibdiag-2.1.1.so
+	libibcm.so.1 (libc6,x86-64) => /usr/lib64/libibcm.so.1
+	libibcm.so (libc6,x86-64) => /usr/lib64/libibcm.so
+	libhwloc.so.5 (libc6,x86-64) => /usr/lib64/libhwloc.so.5
+	libhwloc.so.1 (libc6,x86-64) => /usr/lib64/libhwloc.so.1
+	libhwloc.so (libc6,x86-64) => /usr/lib64/libhwloc.so
+	libhunspell-1.2.so.0 (libc6,x86-64) => /usr/lib64/libhunspell-1.2.so.0
+	libhistory.so.6 (libc6,x86-64) => /usr/lib64/libhistory.so.6
+	libhistory.so.5 (libc6,x86-64) => /usr/lib64/libhistory.so.5
+	libhistory.so (libc6,x86-64) => /usr/lib64/libhistory.so
+	libhesiod.so.0 (libc6,x86-64) => /usr/lib64/libhesiod.so.0
+	libhandle.so.1 (libc6,x86-64) => /lib64/libhandle.so.1
+	libhandle.so (libc6,x86-64) => /usr/lib64/libhandle.so
+	libhal.so.1 (libc6,x86-64) => /usr/lib64/libhal.so.1
+	libhal-storage.so.1 (libc6,x86-64) => /usr/lib64/libhal-storage.so.1
+	libg2c.so.0 (libc6,x86-64) => /usr/lib64/libg2c.so.0
+	libgvpr.so.1 (libc6,x86-64) => /usr/lib64/libgvpr.so.1
+	libgvfscommon.so.0 (libc6,x86-64) => /usr/lib64/libgvfscommon.so.0
+	libgvfscommon-dnssd.so.0 (libc6,x86-64) => /usr/lib64/libgvfscommon-dnssd.so.0
+	libgvc.so.5 (libc6,x86-64) => /usr/lib64/libgvc.so.5
+	libguilereadline-v-17.so.17 (libc6,x86-64) => /usr/lib64/libguilereadline-v-17.so.17
+	libguilereadline-v-17.so (libc6,x86-64) => /usr/lib64/libguilereadline-v-17.so
+	libguile.so.17 (libc6,x86-64) => /usr/lib64/libguile.so.17
+	libguile.so (libc6,x86-64) => /usr/lib64/libguile.so
+	libguile-srfi-srfi-60-v-2.so.2 (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-60-v-2.so.2
+	libguile-srfi-srfi-60-v-2.so (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-60-v-2.so
+	libguile-srfi-srfi-13-14-v-3.so.3 (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-13-14-v-3.so.3
+	libguile-srfi-srfi-13-14-v-3.so (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-13-14-v-3.so
+	libguile-srfi-srfi-4-v-3.so.3 (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-4-v-3.so.3
+	libguile-srfi-srfi-4-v-3.so (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-4-v-3.so
+	libguile-srfi-srfi-1-v-3.so.3 (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-1-v-3.so.3
+	libguile-srfi-srfi-1-v-3.so (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-1-v-3.so
+	libgudev-1.0.so.0 (libc6,x86-64) => /usr/lib64/libgudev-1.0.so.0
+	libgtk-1.2.so.0 (libc6,x86-64) => /usr/lib64/libgtk-1.2.so.0
+	libgtk-x11-2.0.so.0 (libc6,x86-64) => /usr/lib64/libgtk-x11-2.0.so.0
+	libgtk-x11-2.0.so (libc6,x86-64) => /usr/lib64/libgtk-x11-2.0.so
+	libgthread-2.0.so.0 (libc6,x86-64) => /lib64/libgthread-2.0.so.0
+	libgthread-2.0.so (libc6,x86-64) => /usr/lib64/libgthread-2.0.so
+	libgthread-1.2.so.0 (libc6,x86-64) => /usr/lib64/libgthread-1.2.so.0
+	libgstvideo-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstvideo-0.10.so.0
+	libgsttag-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgsttag-0.10.so.0
+	libgstsdp-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstsdp-0.10.so.0
+	libgstrtsp-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstrtsp-0.10.so.0
+	libgstrtp-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstrtp-0.10.so.0
+	libgstriff-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstriff-0.10.so.0
+	libgstreamer-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstreamer-0.10.so.0
+	libgstpbutils-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstpbutils-0.10.so.0
+	libgstnetbuffer-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstnetbuffer-0.10.so.0
+	libgstnet-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstnet-0.10.so.0
+	libgstinterfaces-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstinterfaces-0.10.so.0
+	libgstfft-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstfft-0.10.so.0
+	libgstdataprotocol-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstdataprotocol-0.10.so.0
+	libgstcontroller-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstcontroller-0.10.so.0
+	libgstcdda-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstcdda-0.10.so.0
+	libgstbase-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstbase-0.10.so.0
+	libgstaudio-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstaudio-0.10.so.0
+	libgstapp-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstapp-0.10.so.0
+	libgssrpc.so.4 (libc6,x86-64) => /lib64/libgssrpc.so.4
+	libgssrpc.so (libc6,x86-64) => /usr/lib64/libgssrpc.so
+	libgssglue.so.1 (libc6,x86-64) => /lib64/libgssglue.so.1
+	libgssapi_krb5.so.2 (libc6,x86-64) => /lib64/libgssapi_krb5.so.2
+	libgssapi_krb5.so (libc6,x86-64) => /usr/lib64/libgssapi_krb5.so
+	libgsf-1.so.114 (libc6,x86-64) => /usr/lib64/libgsf-1.so.114
+	libgs.so.8 (libc6,x86-64) => /usr/lib64/libgs.so.8
+	libgs.so (libc6,x86-64) => /usr/lib64/libgs.so
+	libgraph.so.4 (libc6,x86-64) => /usr/lib64/libgraph.so.4
+	libgp11.so.0 (libc6,x86-64) => /usr/lib64/libgp11.so.0
+	libgpm.so.2 (libc6,x86-64) => /usr/lib64/libgpm.so.2
+	libgpgme.so.11 (libc6,x86-64) => /usr/lib64/libgpgme.so.11
+	libgpgme-pthread.so.11 (libc6,x86-64) => /usr/lib64/libgpgme-pthread.so.11
+	libgpgme-pth.so.11 (libc6,x86-64) => /usr/lib64/libgpgme-pth.so.11
+	libgpg-error.so.0 (libc6,x86-64) => /lib64/libgpg-error.so.0
+	libgpg-error.so (libc6,x86-64) => /usr/lib64/libgpg-error.so
+	libgomp.so.1 (libc6,x86-64) => /usr/lib64/libgomp.so.1
+	libgobject-2.0.so.0 (libc6,x86-64) => /lib64/libgobject-2.0.so.0
+	libgobject-2.0.so (libc6,x86-64) => /usr/lib64/libgobject-2.0.so
+	libgnutlsxx.so.26 (libc6,x86-64) => /usr/lib64/libgnutlsxx.so.26
+	libgnutls.so.26 (libc6,x86-64) => /usr/lib64/libgnutls.so.26
+	libgnutls-extra.so.26 (libc6,x86-64) => /usr/lib64/libgnutls-extra.so.26
+	libgnomevfs-2.so.0 (libc6,x86-64) => /usr/lib64/libgnomevfs-2.so.0
+	libgnomeui-2.so.0 (libc6,x86-64) => /usr/lib64/libgnomeui-2.so.0
+	libgnomecanvas-2.so.0 (libc6,x86-64) => /usr/lib64/libgnomecanvas-2.so.0
+	libgnome-2.so.0 (libc6,x86-64) => /usr/lib64/libgnome-2.so.0
+	libgnome-keyring.so.0 (libc6,x86-64) => /usr/lib64/libgnome-keyring.so.0
+	libgnome-desktop-2.so.11 (libc6,x86-64) => /usr/lib64/libgnome-desktop-2.so.11
+	libgmpxx.so.4 (libc6,x86-64) => /usr/lib64/libgmpxx.so.4
+	libgmpxx.so (libc6,x86-64) => /usr/lib64/libgmpxx.so
+	libgmp.so.3 (libc6,x86-64) => /usr/lib64/libgmp.so.3
+	libgmp.so (libc6,x86-64) => /usr/lib64/libgmp.so
+	libgmodule-2.0.so.0 (libc6,x86-64) => /lib64/libgmodule-2.0.so.0
+	libgmodule-2.0.so (libc6,x86-64) => /usr/lib64/libgmodule-2.0.so
+	libgmodule-1.2.so.0 (libc6,x86-64) => /usr/lib64/libgmodule-1.2.so.0
+	libglut.so.3 (libc6,x86-64) => /usr/lib64/libglut.so.3
+	libglut.so (libc6,x86-64) => /usr/lib64/libglut.so
+	libglib-2.0.so.0 (libc6,x86-64) => /lib64/libglib-2.0.so.0
+	libglib-2.0.so (libc6,x86-64) => /usr/lib64/libglib-2.0.so
+	libglib-1.2.so.0 (libc6,x86-64) => /usr/lib64/libglib-1.2.so.0
+	libglapi.so.0 (libc6,x86-64) => /usr/lib64/libglapi.so.0
+	libglapi.so.0 (libc6) => /usr/lib/libglapi.so.0
+	libglapi.so (libc6,x86-64) => /usr/lib64/libglapi.so
+	libglapi.so (libc6) => /usr/lib/libglapi.so
+	libglade-2.0.so.0 (libc6,x86-64) => /usr/lib64/libglade-2.0.so.0
+	libgio-2.0.so.0 (libc6,x86-64) => /lib64/libgio-2.0.so.0
+	libgio-2.0.so (libc6,x86-64) => /usr/lib64/libgio-2.0.so
+	libgif.so.4 (libc6,x86-64) => /usr/lib64/libgif.so.4
+	libgif.so (libc6,x86-64) => /usr/lib64/libgif.so
+	libgfortran.so.3 (libc6,x86-64) => /usr/lib64/libgfortran.so.3
+	libgfortran.so.1 (libc6,x86-64) => /usr/lib64/libgfortran.so.1
+	libgettextsrc-0.17.so (libc6,x86-64) => /usr/lib64/libgettextsrc-0.17.so
+	libgettextlib-0.17.so (libc6,x86-64) => /usr/lib64/libgettextlib-0.17.so
+	libgeotiff.so.1.2 (libc6,x86-64) => /usr/lib64/libgeotiff.so.1.2
+	libgensec.so.0 (libc6,x86-64) => /usr/lib64/libgensec.so.0
+	libgdu.so.0 (libc6,x86-64) => /usr/lib64/libgdu.so.0
+	libgdk_pixbuf_xlib-2.0.so.0 (libc6,x86-64) => /usr/lib64/libgdk_pixbuf_xlib-2.0.so.0
+	libgdk_pixbuf_xlib-2.0.so (libc6,x86-64) => /usr/lib64/libgdk_pixbuf_xlib-2.0.so
+	libgdk_pixbuf-2.0.so.0 (libc6,x86-64) => /usr/lib64/libgdk_pixbuf-2.0.so.0
+	libgdk_pixbuf-2.0.so (libc6,x86-64) => /usr/lib64/libgdk_pixbuf-2.0.so
+	libgdk-1.2.so.0 (libc6,x86-64) => /usr/lib64/libgdk-1.2.so.0
+	libgdk-x11-2.0.so.0 (libc6,x86-64) => /usr/lib64/libgdk-x11-2.0.so.0
+	libgdk-x11-2.0.so (libc6,x86-64) => /usr/lib64/libgdk-x11-2.0.so
+	libgdbm.so.2 (libc6,x86-64) => /usr/lib64/libgdbm.so.2
+	libgdbm.so (libc6,x86-64) => /usr/lib64/libgdbm.so
+	libgd.so.2 (libc6,x86-64) => /usr/lib64/libgd.so.2
+	libgd.so (libc6,x86-64) => /usr/lib64/libgd.so
+	libgcrypt.so.11 (libc6,x86-64) => /lib64/libgcrypt.so.11
+	libgcrypt.so (libc6,x86-64) => /usr/lib64/libgcrypt.so
+	libgcr.so.0 (libc6,x86-64) => /usr/lib64/libgcr.so.0
+	libgconf-2.so.4 (libc6,x86-64) => /usr/lib64/libgconf-2.so.4
+	libgcc_s.so.1 (libc6,x86-64) => /lib64/libgcc_s.so.1
+	libgcc_s.so.1 (libc6) => /lib/libgcc_s.so.1
+	libganglia.so.0 (libc6,x86-64) => /usr/lib64/libganglia.so.0
+	libganglia-3.6.0.so.0 (libc6,x86-64) => /usr/lib64/libganglia-3.6.0.so.0
+	libgamin-1.so.0 (libc6,x86-64) => /usr/lib64/libgamin-1.so.0
+	libgailutil.so.18 (libc6,x86-64) => /usr/lib64/libgailutil.so.18
+	libgailutil.so (libc6,x86-64) => /usr/lib64/libgailutil.so
+	libfreetype.so.6 (libc6,x86-64) => /usr/lib64/libfreetype.so.6
+	libfreetype.so.6 (libc6) => /usr/lib/libfreetype.so.6
+	libfreetype.so (libc6,x86-64) => /usr/lib64/libfreetype.so
+	libfreeipmi.so.13 (libc6,x86-64) => /usr/lib64/libfreeipmi.so.13
+	libfreebl3.so (libc6,x86-64) => /lib64/libfreebl3.so
+	libfreebl3.so (libc6,x86-64) => /usr/lib64/libfreebl3.so
+	libfreebl3.so (libc6) => /lib/libfreebl3.so
+	libfreebl3.so (libc6) => /usr/lib/libfreebl3.so
+	libfreeblpriv3.so (libc6,x86-64) => /lib64/libfreeblpriv3.so
+	libfreeblpriv3.so (libc6,x86-64) => /usr/lib64/libfreeblpriv3.so
+	libfreeblpriv3.so (libc6) => /lib/libfreeblpriv3.so
+	libfreeblpriv3.so (libc6) => /usr/lib/libfreeblpriv3.so
+	libformw.so.5 (libc6,x86-64) => /usr/lib64/libformw.so.5
+	libformw.so.5 (libc6) => /usr/lib/libformw.so.5
+	libformw.so (libc6,x86-64) => /usr/lib64/libformw.so
+	libformw.so (libc6) => /usr/lib/libformw.so
+	libform.so.5 (libc6,x86-64) => /usr/lib64/libform.so.5
+	libform.so.5 (libc6) => /usr/lib/libform.so.5
+	libform.so (libc6,x86-64) => /usr/lib64/libform.so
+	libform.so (libc6) => /usr/lib/libform.so
+	libfontenc.so.1 (libc6,x86-64) => /usr/lib64/libfontenc.so.1
+	libfontconfig.so.1 (libc6,x86-64) => /usr/lib64/libfontconfig.so.1
+	libfontconfig.so.1 (libc6) => /usr/lib/libfontconfig.so.1
+	libfontconfig.so (libc6,x86-64) => /usr/lib64/libfontconfig.so
+	libfltk_images.so.1.1 (libc6,x86-64) => /usr/lib64/libfltk_images.so.1.1
+	libfltk_gl.so.1.1 (libc6,x86-64) => /usr/lib64/libfltk_gl.so.1.1
+	libfltk_forms.so.1.1 (libc6,x86-64) => /usr/lib64/libfltk_forms.so.1.1
+	libfltk.so.1.1 (libc6,x86-64) => /usr/lib64/libfltk.so.1.1
+	libfipscheck.so.1 (libc6,x86-64) => /lib64/libfipscheck.so.1
+	libffi.so.5 (libc6,x86-64) => /usr/lib64/libffi.so.5
+	libffi.so (libc6,x86-64) => /usr/lib64/libffi.so
+	libfca.so.0 (libc6,x86-64) => /opt/mellanox/fca/lib/libfca.so.0
+	libfca.so (libc6,x86-64) => /opt/mellanox/fca/lib/libfca.so
+	libfam.so.0 (libc6,x86-64) => /usr/lib64/libfam.so.0
+	libe2p.so.2 (libc6,x86-64) => /lib64/libe2p.so.2
+	libe2p.so (libc6,x86-64) => /usr/lib64/libe2p.so
+	libext2fs.so.2 (libc6,x86-64) => /lib64/libext2fs.so.2
+	libext2fs.so (libc6,x86-64) => /usr/lib64/libext2fs.so
+	libexslt.so.0 (libc6,x86-64) => /usr/lib64/libexslt.so.0
+	libexslt.so (libc6,x86-64) => /usr/lib64/libexslt.so
+	libexpect5.44.1.15.so (libc6,x86-64) => /usr/lib64/libexpect5.44.1.15.so
+	libexpect.so (libc6,x86-64) => /usr/lib64/libexpect.so
+	libexpat.so.1 (libc6,x86-64) => /lib64/libexpat.so.1
+	libexpat.so.1 (libc6) => /lib/libexpat.so.1
+	libexpat.so (libc6,x86-64) => /usr/lib64/libexpat.so
+	libexif.so.12 (libc6,x86-64) => /usr/lib64/libexif.so.12
+	libexempi.so.3 (libc6,x86-64) => /usr/lib64/libexempi.so.3
+	libevview.so.1 (libc6,x86-64) => /usr/lib64/libevview.so.1
+	libevent_extra-1.4.so.2 (libc6,x86-64) => /usr/lib64/libevent_extra-1.4.so.2
+	libevent_core-1.4.so.2 (libc6,x86-64) => /usr/lib64/libevent_core-1.4.so.2
+	libevent-1.4.so.2 (libc6,x86-64) => /usr/lib64/libevent-1.4.so.2
+	libevdocument.so.1 (libc6,x86-64) => /usr/lib64/libevdocument.so.1
+	libelf.so.1 (libc6,x86-64) => /usr/lib64/libelf.so.1
+	libelf.so.1 (libc6) => /usr/lib/libelf.so.1
+	libeggdbus-1.so.0 (libc6,x86-64) => /usr/lib64/libeggdbus-1.so.0
+	libedit.so.0 (libc6,x86-64) => /usr/lib64/libedit.so.0
+	libecpg_compat.so.3 (libc6,x86-64) => /usr/lib64/libecpg_compat.so.3
+	libecpg_compat.so (libc6,x86-64) => /usr/lib64/libecpg_compat.so
+	libecpg.so.6 (libc6,x86-64) => /usr/lib64/libecpg.so.6
+	libecpg.so (libc6,x86-64) => /usr/lib64/libecpg.so
+	libdw.so.1 (libc6,x86-64) => /usr/lib64/libdw.so.1
+	libdump_pr.so.1 (libc6,x86-64) => /usr/lib64/libdump_pr.so.1
+	libdump_pr.so (libc6,x86-64) => /usr/lib64/libdump_pr.so
+	libdrm_radeon.so.1 (libc6,x86-64) => /usr/lib64/libdrm_radeon.so.1
+	libdrm_radeon.so.1 (libc6) => /usr/lib/libdrm_radeon.so.1
+	libdrm_radeon.so (libc6,x86-64) => /usr/lib64/libdrm_radeon.so
+	libdrm_nouveau2.so.2 (libc6,x86-64) => /usr/lib64/libdrm_nouveau2.so.2
+	libdrm_nouveau2.so.2 (libc6) => /usr/lib/libdrm_nouveau2.so.2
+	libdrm_nouveau2.so (libc6,x86-64) => /usr/lib64/libdrm_nouveau2.so
+	libdrm_nouveau.so.1 (libc6,x86-64) => /usr/lib64/libdrm_nouveau.so.1
+	libdrm_nouveau.so.1 (libc6) => /usr/lib/libdrm_nouveau.so.1
+	libdrm_nouveau.so (libc6,x86-64) => /usr/lib64/libdrm_nouveau.so
+	libdrm_intel.so.1 (libc6,x86-64) => /usr/lib64/libdrm_intel.so.1
+	libdrm_intel.so.1 (libc6) => /usr/lib/libdrm_intel.so.1
+	libdrm_intel.so (libc6,x86-64) => /usr/lib64/libdrm_intel.so
+	libdrm.so.2 (libc6,x86-64) => /usr/lib64/libdrm.so.2
+	libdrm.so.2 (libc6) => /usr/lib/libdrm.so.2
+	libdrm.so (libc6,x86-64) => /usr/lib64/libdrm.so
+	libdns.so.81 (libc6,x86-64) => /usr/lib64/libdns.so.81
+	libdmx.so.1 (libc6,x86-64) => /usr/lib64/libdmx.so.1
+	libdl.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libdl.so.2
+	libdl.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libdl.so.2
+	libdl.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libdl.so
+	libdl.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libdl.so
+	libdhash.so.1 (libc6,x86-64) => /usr/lib64/libdhash.so.1
+	libdevmapper.so.1.02 (libc6,x86-64) => /lib64/libdevmapper.so.1.02
+	libdevmapper-event.so.1.02 (libc6,x86-64) => /lib64/libdevmapper-event.so.1.02
+	libdevmapper-event-lvm2thin.so (libc6,x86-64) => /lib64/libdevmapper-event-lvm2thin.so
+	libdevmapper-event-lvm2snapshot.so (libc6,x86-64) => /lib64/libdevmapper-event-lvm2snapshot.so
+	libdevmapper-event-lvm2raid.so (libc6,x86-64) => /lib64/libdevmapper-event-lvm2raid.so
+	libdevmapper-event-lvm2mirror.so (libc6,x86-64) => /lib64/libdevmapper-event-lvm2mirror.so
+	libdevmapper-event-lvm2.so.2.02 (libc6,x86-64) => /lib64/libdevmapper-event-lvm2.so.2.02
+	libdcerpc.so.0 (libc6,x86-64) => /usr/lib64/libdcerpc.so.0
+	libdcerpc-samr.so.0 (libc6,x86-64) => /usr/lib64/libdcerpc-samr.so.0
+	libdcerpc-binding.so.0 (libc6,x86-64) => /usr/lib64/libdcerpc-binding.so.0
+	libdcerpc-atsvc.so.0 (libc6,x86-64) => /usr/lib64/libdcerpc-atsvc.so.0
+	libdbus-1.so.3 (libc6,x86-64) => /lib64/libdbus-1.so.3
+	libdbus-glib-1.so.2 (libc6,x86-64) => /usr/lib64/libdbus-glib-1.so.2
+	libdb_cxx-4.7.so (libc6,x86-64) => /usr/lib64/libdb_cxx-4.7.so
+	libdb-4.7.so (libc6,x86-64) => /lib64/libdb-4.7.so
+	libdb-4.7.so (libc6,x86-64) => /usr/lib64/libdb-4.7.so
+	libdat2.so.2 (libc6,x86-64) => /usr/lib64/libdat2.so.2
+	libdat2.so (libc6,x86-64) => /usr/lib64/libdat2.so
+	libdaploucm.so.2 (libc6,x86-64) => /usr/lib64/libdaploucm.so.2
+	libdaploucm.so (libc6,x86-64) => /usr/lib64/libdaploucm.so
+	libdaploscm.so.2 (libc6,x86-64) => /usr/lib64/libdaploscm.so.2
+	libdaploscm.so (libc6,x86-64) => /usr/lib64/libdaploscm.so
+	libdaplofa.so.2 (libc6,x86-64) => /usr/lib64/libdaplofa.so.2
+	libdaplofa.so (libc6,x86-64) => /usr/lib64/libdaplofa.so
+	libdaemon.so.0 (libc6,x86-64) => /usr/lib64/libdaemon.so.0
+	libcxgb4-rdmav2.so (libc6,x86-64) => /usr/lib64/libcxgb4-rdmav2.so
+	libcxgb3-rdmav2.so (libc6,x86-64) => /usr/lib64/libcxgb3-rdmav2.so
+	libcurl.so.4 (libc6,x86-64) => /usr/lib64/libcurl.so.4
+	libcurl.so (libc6,x86-64) => /usr/lib64/libcurl.so
+	libcupsppdc.so.1 (libc6,x86-64) => /usr/lib64/libcupsppdc.so.1
+	libcupsmime.so.1 (libc6,x86-64) => /usr/lib64/libcupsmime.so.1
+	libcupsimage.so.2 (libc6,x86-64) => /usr/lib64/libcupsimage.so.2
+	libcupsdriver.so.1 (libc6,x86-64) => /usr/lib64/libcupsdriver.so.1
+	libcupscgi.so.1 (libc6,x86-64) => /usr/lib64/libcupscgi.so.1
+	libcups.so.2 (libc6,x86-64) => /usr/lib64/libcups.so.2
+	libcuda.so.1 (libc6,x86-64) => /usr/lib64/libcuda.so.1
+	libcuda.so (libc6,x86-64) => /usr/lib64/libcuda.so
+	libcryptsetup.so.1 (libc6,x86-64) => /lib64/libcryptsetup.so.1
+	libcrypto.so.10 (libc6,x86-64) => /usr/lib64/libcrypto.so.10
+	libcrypto.so (libc6,x86-64) => /usr/lib64/libcrypto.so
+	libcrypt.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libcrypt.so.1
+	libcrypt.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libcrypt.so.1
+	libcrypt.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libcrypt.so
+	libcrypt.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libcrypt.so
+	libcroco-0.6.so.3 (libc6,x86-64) => /usr/lib64/libcroco-0.6.so.3
+	libcrack.so.2 (libc6,x86-64) => /usr/lib64/libcrack.so.2
+	libcpupower.so.0 (libc6,x86-64) => /usr/lib64/libcpupower.so.0
+	libcppunit-1.12.so.1 (libc6,x86-64) => /usr/lib64/libcppunit-1.12.so.1
+	libconfuse.so.0 (libc6,x86-64) => /usr/lib64/libconfuse.so.0
+	libconfuse.so (libc6,x86-64) => /usr/lib64/libconfuse.so
+	libcom_err.so.2 (libc6,x86-64) => /lib64/libcom_err.so.2
+	libcom_err.so (libc6,x86-64) => /usr/lib64/libcom_err.so
+	libcollection.so.4 (libc6,x86-64) => /usr/lib64/libcollection.so.4
+	libcmdparser-1.0.0.so (libc6,x86-64) => /usr/lib64/libcmdparser-1.0.0.so
+	libcloog.so.0 (libc6,x86-64) => /usr/lib64/libcloog.so.0
+	libck-connector.so.0 (libc6,x86-64) => /usr/lib64/libck-connector.so.0
+	libcidn.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libcidn.so.1
+	libcidn.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libcidn.so.1
+	libcidn.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libcidn.so
+	libcidn.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libcidn.so
+	libcgroup.so.1 (libc6,x86-64) => /lib64/libcgroup.so.1
+	libcgroup.so (libc6,x86-64) => /usr/lib64/libcgroup.so
+	libcgraph.so.4 (libc6,x86-64) => /usr/lib64/libcgraph.so.4
+	libcdt.so.4 (libc6,x86-64) => /usr/lib64/libcdt.so.4
+	libcdio_paranoia.so.0 (libc6,x86-64) => /usr/lib64/libcdio_paranoia.so.0
+	libcdio_cdda.so.0 (libc6,x86-64) => /usr/lib64/libcdio_cdda.so.0
+	libcdio.so.10 (libc6,x86-64) => /usr/lib64/libcdio.so.10
+	libcdio++.so.0 (libc6,x86-64) => /usr/lib64/libcdio++.so.0
+	libcdda_paranoia.so.0 (libc6,x86-64) => /usr/lib64/libcdda_paranoia.so.0
+	libcdda_paranoia.so (libc6,x86-64) => /usr/lib64/libcdda_paranoia.so
+	libcdda_interface.so.0 (libc6,x86-64) => /usr/lib64/libcdda_interface.so.0
+	libcdda_interface.so (libc6,x86-64) => /usr/lib64/libcdda_interface.so
+	libccmgr.so.1 (libc6,x86-64) => /usr/lib64/libccmgr.so.1
+	libccmgr.so (libc6,x86-64) => /usr/lib64/libccmgr.so
+	libcares.so.2 (libc6,x86-64) => /usr/lib64/libcares.so.2
+	libcap.so.2 (libc6,x86-64) => /lib64/libcap.so.2
+	libcap-ng.so.0 (libc6,x86-64) => /lib64/libcap-ng.so.0
+	libcairo.so.2 (libc6,x86-64) => /usr/lib64/libcairo.so.2
+	libcairo.so (libc6,x86-64) => /usr/lib64/libcairo.so
+	libc.so.6 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libc.so.6
+	libc.so.6 (libc6, hwcap: 0x0028000000000000, OS ABI: Linux 2.6.18) => /lib/i686/nosegneg/libc.so.6
+	libc.so.6 (libc6, OS ABI: Linux 2.6.18) => /lib/libc.so.6
+	libbz2.so.1 (libc6,x86-64) => /lib64/libbz2.so.1
+	libbz2.so (libc6,x86-64) => /usr/lib64/libbz2.so
+	libbtparser.so.2 (libc6,x86-64) => /usr/lib64/libbtparser.so.2
+	libboost_wserialization.so.5 (libc6,x86-64) => /usr/lib64/libboost_wserialization.so.5
+	libboost_wserialization.so (libc6,x86-64) => /usr/lib64/libboost_wserialization.so
+	libboost_wserialization-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_wserialization-mt.so.5
+	libboost_wserialization-mt.so (libc6,x86-64) => /usr/lib64/libboost_wserialization-mt.so
+	libboost_wave-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_wave-mt.so.5
+	libboost_wave-mt.so (libc6,x86-64) => /usr/lib64/libboost_wave-mt.so
+	libboost_unit_test_framework.so.5 (libc6,x86-64) => /usr/lib64/libboost_unit_test_framework.so.5
+	libboost_unit_test_framework.so (libc6,x86-64) => /usr/lib64/libboost_unit_test_framework.so
+	libboost_unit_test_framework-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_unit_test_framework-mt.so.5
+	libboost_unit_test_framework-mt.so (libc6,x86-64) => /usr/lib64/libboost_unit_test_framework-mt.so
+	libboost_thread-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_thread-mt.so.5
+	libboost_thread-mt.so (libc6,x86-64) => /usr/lib64/libboost_thread-mt.so
+	libboost_system.so.5 (libc6,x86-64) => /usr/lib64/libboost_system.so.5
+	libboost_system.so (libc6,x86-64) => /usr/lib64/libboost_system.so
+	libboost_system-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_system-mt.so.5
+	libboost_system-mt.so (libc6,x86-64) => /usr/lib64/libboost_system-mt.so
+	libboost_signals.so.5 (libc6,x86-64) => /usr/lib64/libboost_signals.so.5
+	libboost_signals.so (libc6,x86-64) => /usr/lib64/libboost_signals.so
+	libboost_signals-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_signals-mt.so.5
+	libboost_signals-mt.so (libc6,x86-64) => /usr/lib64/libboost_signals-mt.so
+	libboost_serialization.so.5 (libc6,x86-64) => /usr/lib64/libboost_serialization.so.5
+	libboost_serialization.so (libc6,x86-64) => /usr/lib64/libboost_serialization.so
+	libboost_serialization-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_serialization-mt.so.5
+	libboost_serialization-mt.so (libc6,x86-64) => /usr/lib64/libboost_serialization-mt.so
+	libboost_regex.so.5 (libc6,x86-64) => /usr/lib64/libboost_regex.so.5
+	libboost_regex.so (libc6,x86-64) => /usr/lib64/libboost_regex.so
+	libboost_regex-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_regex-mt.so.5
+	libboost_regex-mt.so (libc6,x86-64) => /usr/lib64/libboost_regex-mt.so
+	libboost_python.so.5 (libc6,x86-64) => /usr/lib64/libboost_python.so.5
+	libboost_python.so (libc6,x86-64) => /usr/lib64/libboost_python.so
+	libboost_python-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_python-mt.so.5
+	libboost_python-mt.so (libc6,x86-64) => /usr/lib64/libboost_python-mt.so
+	libboost_program_options.so.5 (libc6,x86-64) => /usr/lib64/libboost_program_options.so.5
+	libboost_program_options.so (libc6,x86-64) => /usr/lib64/libboost_program_options.so
+	libboost_program_options-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_program_options-mt.so.5
+	libboost_program_options-mt.so (libc6,x86-64) => /usr/lib64/libboost_program_options-mt.so
+	libboost_prg_exec_monitor.so.5 (libc6,x86-64) => /usr/lib64/libboost_prg_exec_monitor.so.5
+	libboost_prg_exec_monitor.so (libc6,x86-64) => /usr/lib64/libboost_prg_exec_monitor.so
+	libboost_prg_exec_monitor-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_prg_exec_monitor-mt.so.5
+	libboost_prg_exec_monitor-mt.so (libc6,x86-64) => /usr/lib64/libboost_prg_exec_monitor-mt.so
+	libboost_math_tr1l.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1l.so.5
+	libboost_math_tr1l.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1l.so
+	libboost_math_tr1l-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1l-mt.so.5
+	libboost_math_tr1l-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1l-mt.so
+	libboost_math_tr1f.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1f.so.5
+	libboost_math_tr1f.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1f.so
+	libboost_math_tr1f-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1f-mt.so.5
+	libboost_math_tr1f-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1f-mt.so
+	libboost_math_tr1.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1.so.5
+	libboost_math_tr1.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1.so
+	libboost_math_tr1-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1-mt.so.5
+	libboost_math_tr1-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1-mt.so
+	libboost_math_c99l.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99l.so.5
+	libboost_math_c99l.so (libc6,x86-64) => /usr/lib64/libboost_math_c99l.so
+	libboost_math_c99l-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99l-mt.so.5
+	libboost_math_c99l-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_c99l-mt.so
+	libboost_math_c99f.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99f.so.5
+	libboost_math_c99f.so (libc6,x86-64) => /usr/lib64/libboost_math_c99f.so
+	libboost_math_c99f-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99f-mt.so.5
+	libboost_math_c99f-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_c99f-mt.so
+	libboost_math_c99.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99.so.5
+	libboost_math_c99.so (libc6,x86-64) => /usr/lib64/libboost_math_c99.so
+	libboost_math_c99-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99-mt.so.5
+	libboost_math_c99-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_c99-mt.so
+	libboost_iostreams.so.5 (libc6,x86-64) => /usr/lib64/libboost_iostreams.so.5
+	libboost_iostreams.so (libc6,x86-64) => /usr/lib64/libboost_iostreams.so
+	libboost_iostreams-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_iostreams-mt.so.5
+	libboost_iostreams-mt.so (libc6,x86-64) => /usr/lib64/libboost_iostreams-mt.so
+	libboost_graph.so.5 (libc6,x86-64) => /usr/lib64/libboost_graph.so.5
+	libboost_graph.so (libc6,x86-64) => /usr/lib64/libboost_graph.so
+	libboost_graph-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_graph-mt.so.5
+	libboost_graph-mt.so (libc6,x86-64) => /usr/lib64/libboost_graph-mt.so
+	libboost_filesystem.so.5 (libc6,x86-64) => /usr/lib64/libboost_filesystem.so.5
+	libboost_filesystem.so (libc6,x86-64) => /usr/lib64/libboost_filesystem.so
+	libboost_filesystem-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_filesystem-mt.so.5
+	libboost_filesystem-mt.so (libc6,x86-64) => /usr/lib64/libboost_filesystem-mt.so
+	libboost_date_time.so.5 (libc6,x86-64) => /usr/lib64/libboost_date_time.so.5
+	libboost_date_time.so (libc6,x86-64) => /usr/lib64/libboost_date_time.so
+	libboost_date_time-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_date_time-mt.so.5
+	libboost_date_time-mt.so (libc6,x86-64) => /usr/lib64/libboost_date_time-mt.so
+	libbonoboui-2.so.0 (libc6,x86-64) => /usr/lib64/libbonoboui-2.so.0
+	libbonobo-2.so.0 (libc6,x86-64) => /usr/lib64/libbonobo-2.so.0
+	libbonobo-activation.so.4 (libc6,x86-64) => /usr/lib64/libbonobo-activation.so.4
+	libblkid.so.1 (libc6,x86-64) => /lib64/libblkid.so.1
+	libbiosconfig_expat.so.0 (libc6,x86-64) => /usr/lib64/libbiosconfig_expat.so.0
+	libbiosconfig_expat.so (libc6,x86-64) => /usr/lib64/libbiosconfig_expat.so
+	libbind9.so.80 (libc6,x86-64) => /usr/lib64/libbind9.so.80
+	libbfd-2.20.51.0.2-5.43.el6.so (libc6,x86-64) => /usr/lib64/libbfd-2.20.51.0.2-5.43.el6.so
+	libbasicobjects.so.0 (libc6,x86-64) => /usr/lib64/libbasicobjects.so.0
+	liba2ps.so.1 (libc6,x86-64) => /usr/lib64/liba2ps.so.1
+	libavahi-glib.so.1 (libc6,x86-64) => /usr/lib64/libavahi-glib.so.1
+	libavahi-core.so.6 (libc6,x86-64) => /usr/lib64/libavahi-core.so.6
+	libavahi-common.so.3 (libc6,x86-64) => /usr/lib64/libavahi-common.so.3
+	libavahi-client.so.3 (libc6,x86-64) => /usr/lib64/libavahi-client.so.3
+	libauparse.so.0 (libc6,x86-64) => /lib64/libauparse.so.0
+	libaudit.so.1 (libc6,x86-64) => /lib64/libaudit.so.1
+	libattr.so.1 (libc6,x86-64) => /lib64/libattr.so.1
+	libattr.so (libc6,x86-64) => /lib64/libattr.so
+	libattr.so (libc6,x86-64) => /usr/lib64/libattr.so
+	libatk-1.0.so.0 (libc6,x86-64) => /usr/lib64/libatk-1.0.so.0
+	libatk-1.0.so (libc6,x86-64) => /usr/lib64/libatk-1.0.so
+	libatasmart.so.4 (libc6,x86-64) => /usr/lib64/libatasmart.so.4
+	libasound.so.2 (libc6,x86-64) => /lib64/libasound.so.2
+	libasm.so.1 (libc6,x86-64) => /usr/lib64/libasm.so.1
+	libart_lgpl_2.so.2 (libc6,x86-64) => /usr/lib64/libart_lgpl_2.so.2
+	libart_lgpl_2.so (libc6,x86-64) => /usr/lib64/libart_lgpl_2.so
+	libarmgr.so.1 (libc6,x86-64) => /usr/lib64/libarmgr.so.1
+	libarmgr.so (libc6,x86-64) => /usr/lib64/libarmgr.so
+	libaprutil-1.so.0 (libc6,x86-64) => /usr/lib64/libaprutil-1.so.0
+	libaprutil-1.so (libc6,x86-64) => /usr/lib64/libaprutil-1.so
+	libapr-1.so.0 (libc6,x86-64) => /usr/lib64/libapr-1.so.0
+	libapr-1.so (libc6,x86-64) => /usr/lib64/libapr-1.so
+	libanl.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libanl.so.1
+	libanl.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libanl.so.1
+	libanl.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libanl.so
+	libanl.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libanl.so
+	libaio.so.1.0.0 (libc6,x86-64) => /lib64/libaio.so.1.0.0
+	libaio.so.1 (libc6,x86-64) => /lib64/libaio.so.1
+	libaio.so (libc6,x86-64) => /usr/lib64/libaio.so
+	libacl.so.1 (libc6,x86-64) => /lib64/libacl.so.1
+	libacl.so (libc6,x86-64) => /lib64/libacl.so
+	libacl.so (libc6,x86-64) => /usr/lib64/libacl.so
+	libX11.so.6 (libc6,x86-64) => /usr/lib64/libX11.so.6
+	libX11.so.6 (libc6) => /usr/lib/libX11.so.6
+	libX11.so (libc6,x86-64) => /usr/lib64/libX11.so
+	libX11-xcb.so.1 (libc6,x86-64) => /usr/lib64/libX11-xcb.so.1
+	libX11-xcb.so.1 (libc6) => /usr/lib/libX11-xcb.so.1
+	libX11-xcb.so (libc6,x86-64) => /usr/lib64/libX11-xcb.so
+	libXxf86vm.so.1 (libc6,x86-64) => /usr/lib64/libXxf86vm.so.1
+	libXxf86vm.so.1 (libc6) => /usr/lib/libXxf86vm.so.1
+	libXxf86vm.so (libc6,x86-64) => /usr/lib64/libXxf86vm.so
+	libXxf86misc.so.1 (libc6,x86-64) => /usr/lib64/libXxf86misc.so.1
+	libXxf86dga.so.1 (libc6,x86-64) => /usr/lib64/libXxf86dga.so.1
+	libXv.so.1 (libc6,x86-64) => /usr/lib64/libXv.so.1
+	libXv.so (libc6,x86-64) => /usr/lib64/libXv.so
+	libXtst.so.6 (libc6,x86-64) => /usr/lib64/libXtst.so.6
+	libXtst.so.6 (libc6) => /usr/lib/libXtst.so.6
+	libXtst.so (libc6,x86-64) => /usr/lib64/libXtst.so
+	libXt.so.6 (libc6,x86-64) => /usr/lib64/libXt.so.6
+	libXt.so.6 (libc6) => /usr/lib/libXt.so.6
+	libXt.so (libc6,x86-64) => /usr/lib64/libXt.so
+	libXt.so (libc6) => /usr/lib/libXt.so
+	libXss.so.1 (libc6,x86-64) => /usr/lib64/libXss.so.1
+	libXrender.so.1 (libc6,x86-64) => /usr/lib64/libXrender.so.1
+	libXrender.so.1 (libc6) => /usr/lib/libXrender.so.1
+	libXrender.so (libc6,x86-64) => /usr/lib64/libXrender.so
+	libXrandr.so.2 (libc6,x86-64) => /usr/lib64/libXrandr.so.2
+	libXrandr.so (libc6,x86-64) => /usr/lib64/libXrandr.so
+	libXpm.so.4 (libc6,x86-64) => /usr/lib64/libXpm.so.4
+	libXpm.so.4 (libc6) => /usr/lib/libXpm.so.4
+	libXpm.so (libc6,x86-64) => /usr/lib64/libXpm.so
+	libXp.so.6 (libc6,x86-64) => /usr/lib64/libXp.so.6
+	libXp.so.6 (libc6) => /usr/lib/libXp.so.6
+	libXp.so (libc6,x86-64) => /usr/lib64/libXp.so
+	libXmuu.so.1 (libc6,x86-64) => /usr/lib64/libXmuu.so.1
+	libXmuu.so.1 (libc6) => /usr/lib/libXmuu.so.1
+	libXmuu.so (libc6,x86-64) => /usr/lib64/libXmuu.so
+	libXmu.so.6 (libc6,x86-64) => /usr/lib64/libXmu.so.6
+	libXmu.so.6 (libc6) => /usr/lib/libXmu.so.6
+	libXmu.so (libc6,x86-64) => /usr/lib64/libXmu.so
+	libXm.so.4 (libc6,x86-64) => /usr/lib64/libXm.so.4
+	libXm.so.4 (libc6) => /usr/lib/libXm.so.4
+	libXm.so.3 (libc6,x86-64) => /usr/lib64/libXm.so.3
+	libXm.so (libc6,x86-64) => /usr/lib64/libXm.so
+	libXm.so (libc6) => /usr/lib/libXm.so
+	libXinerama.so.1 (libc6,x86-64) => /usr/lib64/libXinerama.so.1
+	libXinerama.so (libc6,x86-64) => /usr/lib64/libXinerama.so
+	libXi.so.6 (libc6,x86-64) => /usr/lib64/libXi.so.6
+	libXi.so.6 (libc6) => /usr/lib/libXi.so.6
+	libXi.so (libc6,x86-64) => /usr/lib64/libXi.so
+	libXft.so.2 (libc6,x86-64) => /usr/lib64/libXft.so.2
+	libXft.so.2 (libc6) => /usr/lib/libXft.so.2
+	libXft.so (libc6,x86-64) => /usr/lib64/libXft.so
+	libXfont.so.1 (libc6,x86-64) => /usr/lib64/libXfont.so.1
+	libXfixes.so.3 (libc6,x86-64) => /usr/lib64/libXfixes.so.3
+	libXfixes.so.3 (libc6) => /usr/lib/libXfixes.so.3
+	libXfixes.so (libc6,x86-64) => /usr/lib64/libXfixes.so
+	libXext.so.6 (libc6,x86-64) => /usr/lib64/libXext.so.6
+	libXext.so.6 (libc6) => /usr/lib/libXext.so.6
+	libXext.so (libc6,x86-64) => /usr/lib64/libXext.so
+	libXdmcp.so.6 (libc6,x86-64) => /usr/lib64/libXdmcp.so.6
+	libXdmcp.so (libc6,x86-64) => /usr/lib64/libXdmcp.so
+	libXdamage.so.1 (libc6,x86-64) => /usr/lib64/libXdamage.so.1
+	libXdamage.so.1 (libc6) => /usr/lib/libXdamage.so.1
+	libXdamage.so (libc6,x86-64) => /usr/lib64/libXdamage.so
+	libXcursor.so.1 (libc6,x86-64) => /usr/lib64/libXcursor.so.1
+	libXcursor.so (libc6,x86-64) => /usr/lib64/libXcursor.so
+	libXcomposite.so.1 (libc6,x86-64) => /usr/lib64/libXcomposite.so.1
+	libXcomposite.so (libc6,x86-64) => /usr/lib64/libXcomposite.so
+	libXaw3d.so.7 (libc6,x86-64) => /usr/lib64/libXaw3d.so.7
+	libXaw.so.7 (libc6,x86-64) => /usr/lib64/libXaw.so.7
+	libXaw.so (libc6,x86-64) => /usr/lib64/libXaw.so
+	libXau.so.6 (libc6,x86-64) => /usr/lib64/libXau.so.6
+	libXau.so.6 (libc6) => /usr/lib/libXau.so.6
+	libXau.so (libc6,x86-64) => /usr/lib64/libXau.so
+	libUil.so.4 (libc6,x86-64) => /usr/lib64/libUil.so.4
+	libUil.so.4 (libc6) => /usr/lib/libUil.so.4
+	libUil.so.3 (libc6,x86-64) => /usr/lib64/libUil.so.3
+	libUil.so (libc6,x86-64) => /usr/lib64/libUil.so
+	libUil.so (libc6) => /usr/lib/libUil.so
+	libTix.so (libc6,x86-64) => /usr/lib64/tcl8.5/libTix.so
+	libSegFault.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libSegFault.so
+	libSegFault.so (libc6, OS ABI: Linux 2.6.18) => /lib/libSegFault.so
+	libSM.so.6 (libc6,x86-64) => /usr/lib64/libSM.so.6
+	libSM.so.6 (libc6) => /usr/lib/libSM.so.6
+	libSM.so (libc6,x86-64) => /usr/lib64/libSM.so
+	libSDL-1.2.so.0 (libc6,x86-64) => /usr/lib64/libSDL-1.2.so.0
+	libQt3Support.so.4 (libc6,x86-64) => /usr/lib64/libQt3Support.so.4
+	libQt3Support.so (libc6,x86-64) => /usr/lib64/libQt3Support.so
+	libQtXmlPatterns.so.4 (libc6,x86-64) => /usr/lib64/libQtXmlPatterns.so.4
+	libQtXmlPatterns.so (libc6,x86-64) => /usr/lib64/libQtXmlPatterns.so
+	libQtXml.so.4 (libc6,x86-64) => /usr/lib64/libQtXml.so.4
+	libQtXml.so (libc6,x86-64) => /usr/lib64/libQtXml.so
+	libQtTest.so.4 (libc6,x86-64) => /usr/lib64/libQtTest.so.4
+	libQtTest.so (libc6,x86-64) => /usr/lib64/libQtTest.so
+	libQtSvg.so.4 (libc6,x86-64) => /usr/lib64/libQtSvg.so.4
+	libQtSvg.so (libc6,x86-64) => /usr/lib64/libQtSvg.so
+	libQtSql.so.4 (libc6,x86-64) => /usr/lib64/libQtSql.so.4
+	libQtSql.so (libc6,x86-64) => /usr/lib64/libQtSql.so
+	libQtScriptTools.so.4 (libc6,x86-64) => /usr/lib64/libQtScriptTools.so.4
+	libQtScriptTools.so (libc6,x86-64) => /usr/lib64/libQtScriptTools.so
+	libQtScript.so.4 (libc6,x86-64) => /usr/lib64/libQtScript.so.4
+	libQtScript.so (libc6,x86-64) => /usr/lib64/libQtScript.so
+	libQtOpenGL.so.4 (libc6,x86-64) => /usr/lib64/libQtOpenGL.so.4
+	libQtOpenGL.so (libc6,x86-64) => /usr/lib64/libQtOpenGL.so
+	libQtNetwork.so.4 (libc6,x86-64) => /usr/lib64/libQtNetwork.so.4
+	libQtNetwork.so (libc6,x86-64) => /usr/lib64/libQtNetwork.so
+	libQtMultimedia.so.4 (libc6,x86-64) => /usr/lib64/libQtMultimedia.so.4
+	libQtMultimedia.so (libc6,x86-64) => /usr/lib64/libQtMultimedia.so
+	libQtHelp.so.4 (libc6,x86-64) => /usr/lib64/libQtHelp.so.4
+	libQtHelp.so (libc6,x86-64) => /usr/lib64/libQtHelp.so
+	libQtGui.so.4 (libc6,x86-64) => /usr/lib64/libQtGui.so.4
+	libQtGui.so (libc6,x86-64) => /usr/lib64/libQtGui.so
+	libQtDesignerComponents.so.4 (libc6,x86-64) => /usr/lib64/libQtDesignerComponents.so.4
+	libQtDesignerComponents.so (libc6,x86-64) => /usr/lib64/libQtDesignerComponents.so
+	libQtDesigner.so.4 (libc6,x86-64) => /usr/lib64/libQtDesigner.so.4
+	libQtDesigner.so (libc6,x86-64) => /usr/lib64/libQtDesigner.so
+	libQtDBus.so.4 (libc6,x86-64) => /usr/lib64/libQtDBus.so.4
+	libQtDBus.so (libc6,x86-64) => /usr/lib64/libQtDBus.so
+	libQtCore.so.4 (libc6,x86-64) => /usr/lib64/libQtCore.so.4
+	libQtCore.so (libc6,x86-64) => /usr/lib64/libQtCore.so
+	libQtCLucene.so.4 (libc6,x86-64) => /usr/lib64/libQtCLucene.so.4
+	libQtCLucene.so (libc6,x86-64) => /usr/lib64/libQtCLucene.so
+	libQtAssistantClient.so.4 (libc6,x86-64) => /usr/lib64/libQtAssistantClient.so.4
+	libQtAssistantClient.so (libc6,x86-64) => /usr/lib64/libQtAssistantClient.so
+	libOpenIPMIutils.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMIutils.so.0
+	libOpenIPMIui.so.1 (libc6,x86-64) => /usr/lib64/libOpenIPMIui.so.1
+	libOpenIPMIpthread.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMIpthread.so.0
+	libOpenIPMIposix.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMIposix.so.0
+	libOpenIPMIglib.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMIglib.so.0
+	libOpenIPMIcmdlang.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMIcmdlang.so.0
+	libOpenIPMI.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMI.so.0
+	libOpenCL.so.1 (libc6,x86-64) => /usr/lib64/libOpenCL.so.1
+	libOpenCL.so (libc6,x86-64) => /usr/lib64/libOpenCL.so
+	libOSMesa32.so.6 (libc6,x86-64) => /usr/lib64/libOSMesa32.so.6
+	libOSMesa32.so (libc6,x86-64) => /usr/lib64/libOSMesa32.so
+	libOSMesa16.so.6 (libc6,x86-64) => /usr/lib64/libOSMesa16.so.6
+	libOSMesa16.so (libc6,x86-64) => /usr/lib64/libOSMesa16.so
+	libOSMesa.so.6 (libc6,x86-64) => /usr/lib64/libOSMesa.so.6
+	libOSMesa.so (libc6,x86-64) => /usr/lib64/libOSMesa.so
+	libORBitCosNaming-2.so.0 (libc6,x86-64) => /usr/lib64/libORBitCosNaming-2.so.0
+	libORBit-2.so.0 (libc6,x86-64) => /usr/lib64/libORBit-2.so.0
+	libORBit-imodule-2.so.0 (libc6,x86-64) => /usr/lib64/libORBit-imodule-2.so.0
+	libMrm.so.4 (libc6,x86-64) => /usr/lib64/libMrm.so.4
+	libMrm.so.4 (libc6) => /usr/lib/libMrm.so.4
+	libMrm.so.3 (libc6,x86-64) => /usr/lib64/libMrm.so.3
+	libMrm.so (libc6,x86-64) => /usr/lib64/libMrm.so
+	libMrm.so (libc6) => /usr/lib/libMrm.so
+	libMagickWand.so.5 (libc6,x86-64) => /usr/lib64/libMagickWand.so.5
+	libMagickWand.so (libc6,x86-64) => /usr/lib64/libMagickWand.so
+	libMagickCore.so.5 (libc6,x86-64) => /usr/lib64/libMagickCore.so.5
+	libMagickCore.so (libc6,x86-64) => /usr/lib64/libMagickCore.so
+	libMagick++.so.5 (libc6,x86-64) => /usr/lib64/libMagick++.so.5
+	libMagick++.so (libc6,x86-64) => /usr/lib64/libMagick++.so
+	libLLVM-3.4-mesa.so (libc6,x86-64) => /usr/lib64/libLLVM-3.4-mesa.so
+	libLLVM-3.4-mesa.so (libc6) => /usr/lib/libLLVM-3.4-mesa.so
+	libImlib2.so.1 (libc6,x86-64) => /usr/lib64/libImlib2.so.1
+	libImath.so.6 (libc6,x86-64) => /usr/lib64/libImath.so.6
+	libIlmThread.so.6 (libc6,x86-64) => /usr/lib64/libIlmThread.so.6
+	libIlmImf.so.6 (libc6,x86-64) => /usr/lib64/libIlmImf.so.6
+	libIex.so.6 (libc6,x86-64) => /usr/lib64/libIex.so.6
+	libIPMIlanserv.so.0 (libc6,x86-64) => /usr/lib64/libIPMIlanserv.so.0
+	libIDL-2.so.0 (libc6,x86-64) => /usr/lib64/libIDL-2.so.0
+	libIDL-2.so (libc6,x86-64) => /usr/lib64/libIDL-2.so
+	libICE.so.6 (libc6,x86-64) => /usr/lib64/libICE.so.6
+	libICE.so.6 (libc6) => /usr/lib/libICE.so.6
+	libICE.so (libc6,x86-64) => /usr/lib64/libICE.so
+	libHalf.so.6 (libc6,x86-64) => /usr/lib64/libHalf.so.6
+	libGLU.so.1 (libc6,x86-64) => /usr/lib64/libGLU.so.1
+	libGLU.so.1 (libc6) => /usr/lib/libGLU.so.1
+	libGLU.so (libc6,x86-64) => /usr/lib64/libGLU.so
+	libGLESv2.so.2 (libc6,x86-64) => /usr/lib64/libGLESv2.so.2
+	libGLESv2.so (libc6,x86-64) => /usr/lib64/libGLESv2.so
+	libGLESv1_CM.so.1 (libc6,x86-64) => /usr/lib64/libGLESv1_CM.so.1
+	libGLESv1_CM.so (libc6,x86-64) => /usr/lib64/libGLESv1_CM.so
+	libGL.so.1 (libc6,x86-64) => /usr/lib64/libGL.so.1
+	libGL.so (libc6,x86-64) => /usr/lib64/libGL.so
+	libEGL.so.1 (libc6,x86-64) => /usr/lib64/libEGL.so.1
+	libEGL.so (libc6,x86-64) => /usr/lib64/libEGL.so
+	libBrokenLocale.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libBrokenLocale.so.1
+	libBrokenLocale.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libBrokenLocale.so.1
+	libBrokenLocale.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libBrokenLocale.so
+	libBrokenLocale.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libBrokenLocale.so
+	ld-linux.so.2 (ELF) => /lib/ld-linux.so.2
+	ld-linux-x86-64.so.2 (libc6,x86-64) => /lib64/ld-linux-x86-64.so.2
+
+---------------
+df
+---------------
+Filesystem               1K-blocks          Used     Available Use% Mounted on
+10.9.103.1@o2ib3:10.9.103.2@o2ib3:/imapps
+                      135286266880    1152540156  132778126904   1% /plush/dugong
+10.9.103.1@o2ib3:10.9.103.2@o2ib3:/imapps
+                      135286266880    1152540156  132778126904   1% /opt
+/dev/ram                     10240          2172          8068  22% /ram
+none                      16487440           156      16487284   1% /dev
+none                      16493680            12      16493668   1% /dev/shm
+none                        102400            12        102388   1% /tmp
+/dev/sda3                460903324      14426592     423057504   4% /jobfs/local
+10.9.103.3@o2ib3:10.9.103.4@o2ib3:/homsys
+                      228379092480   26697598608  199393051556  12% /home
+10.9.103.3@o2ib3:10.9.103.4@o2ib3:/homsys
+                      228379092480   26697598608  199393051556  12% /system
+10.9.103.1@o2ib3:10.9.103.2@o2ib3:/imapps
+                      135286266880    1152540156  132778126904   1% /apps
+10.9.103.5@o2ib3:10.9.103.6@o2ib3:/short
+                     8256412275200 3991409927708 3861059348032  51% /projects
+10.9.103.5@o2ib3:10.9.103.6@o2ib3:/short
+                     8256412275200 3991409927708 3861059348032  51% /short
+10.12.0.11@o2ib4:10.12.0.12@o2ib4:/gdata1
+                     8119865446200 6383548336708 1330013450516  83% /g/data1
+10.13.0.13@o2ib5:10.13.0.14@o2ib5:/gdata2
+                     7356150051840 5030910774232 1957309946740  72% /g/data2
+10.13.1.10@o2ib6:10.13.1.11@o2ib6:/gdata3
+                     7862421329280 5718343944844 1750820167136  77% /g/data3
+none                      16493680            12      16493668   1% /dev/shm
+none                        102400            12        102388   1% /tmp
+
+--------------------------------------------------
+-----------------SYSTEM SPECS END-----------------
+--------------------------------------------------
+2016-06-02T16:20:04 main.cpp 114: INFO: Own PID is '17737'
+---ORDER_FILE BEGIN---
+version = 2
+id = LS8-20150924
+Input:
+	satNum = 'Landsat8'
+	sensor = 'OLI_TIRS'
+	productType = 'MD'
+	linkInput = 'TRUE'
+	cleanBefore = 'TRUE'
+	cleanAfter = 'TRUE'
+	inputPath = /jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/source
+	workingFolder = /jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm
+	standardScene:
+	period:
+	floatingScene:
+
+
+Process Control:
+	Use max processing time = 'TRUE'
+		Max Processing Time:
+			Hours: 3
+			Minutes: 0
+			Seconds: 0
+
+Downloader Outputs:
+
+L0Ra Processing:
+	CPF:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>DIRECTORY: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile'
+	Output Path:
+		 = 'Extended mentadata = (FALSE) = '
+	Parameters:
+		May fallback on sensor: TRUE
+
+	Mrc:
+		Generate Mrc = FALSE
+		Orbit Number = -1
+
+
+L0Rp Processing:
+	Max Concurrent Scenes = 15
+	CPF:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>DIRECTORY: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile'
+	Output Path:
+		 = 'Extended mentadata = (FALSE) = '
+
+L1 Processing:
+	Max Concurrent Scenes = 15
+	Output Path:
+		 = 'Extended mentadata = (FALSE) = /jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/scenes'
+	EPH:
+	RLUT:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>DIRECTORY: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT'
+	BPF OLI:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>DIRECTORY: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09'
+	BPF TIRS:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>DIRECTORY: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09'
+	Estimated TIRS SSM position:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>FILE: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20160601.l8_tirs_estimated_ssm_position.txt'
+	L1T Processing:
+		DEM:
+			Path: '/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li'
+			Format: 'srtm90'
+		GCP:
+			Path: '/g/data/v10/eoancillarydata/GCP/Phase2_GCP'
+			Format: 'chips_30'
+		Parameters:
+			Minimum Required Gcps: '10'
+
+	Parameters:
+		LatitudeOfFirstStdParallel
+			L1G = 0.000000000000000
+			L1GT = 0.000000000000000
+			L1T = 0.000000000000000
+		LongitudeOfCentralMeridian
+			L1G = 0.000000000000000
+			L1GT = 0.000000000000000
+			L1T = 0.000000000000000
+		FalseEastingNorthingUnits
+			L1G = METERS
+			L1GT = METERS
+			L1T = METERS
+		FalseEasting
+			L1G = 0.000000000000000
+			L1GT = 0.000000000000000
+			L1T = 0.000000000000000
+		FalseNorthing
+			L1G = 0.000000000000000
+			L1GT = 0.000000000000000
+			L1T = 0.000000000000000
+		MaxScanGap
+			L1G = 2
+			L1GT = 2
+			L1T = 2
+		Resampler
+			L1G = CC
+			L1GT = CC
+			L1T = CC
+		Fallback Resampler
+			L1G = CC
+			L1GT = CC
+			L1T = CC
+		Hemisphere
+			L1G = S
+			L1GT = S
+			L1T = S
+		ScenePadding
+			L1G = 1.000000000000000
+			L1GT = 1.000000000000000
+			L1T = 1.000000000000000
+		PixelOrigin
+			L1G = UL
+			L1GT = UL
+			L1T = UL
+		Fallbacks
+			L1G = FALSE
+			L1GT = TRUE
+			L1R = FALSE
+		Orientation
+			L1G = NUP
+			L1GT = NUP
+			L1T = NUP
+		PixelSizesPan
+			L1G = 12.50000
+			L1GT = 12.50000
+			L1T = 12.50000
+		PixelSizesRef
+			L1G = 25.00000
+			L1GT = 25.00000
+			L1T = 25.00000
+		PixelSizesThm
+			L1G = 25.00000
+			L1GT = 25.00000
+			L1T = 25.00000
+		Datum
+			L1G = GDA_94
+			L1GT = GDA_94
+			L1T = GDA_94
+		Spheroid
+			L1G = GRS_80
+			L1GT = GRS_80
+			L1T = GRS_80
+		Projection
+			L1G = UTM
+			L1GT = UTM
+			L1T = UTM
+		Product Type = 'L1T'
+		Output format = 'GEOTIFF'
+
+
+---ORDER_FILE END---
+2016-06-02T16:20:04 Processor.cpp 149: INFO: Time out schedule to trigger at '2016-06-02 19:20:04'
+2016-06-02T16:20:04 Processor.cpp 112: INFO: Cleaning path '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm'
+2016-06-02T16:20:04 GenerateProcessChainLandsat.cpp 732: INFO: Creating log folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs'
+2016-06-02T16:20:04 GenerateProcessChainLandsat.cpp 191: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/MD'
+2016-06-02T16:20:04 GenerateProcessChainLandsat.cpp 66: INFO: Will link '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/source' to '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/MD'
+2016-06-02T16:20:04 GenerateProcessChainMdRcc2L0Ra.cpp 94: INFO: Creating L0Ra folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA'
+2016-06-02T16:20:04 AncDatabasePopulator.cpp 243: INFO: Locating all 'EPH' ancillary files
+2016-06-02T16:20:04 AncDatabasePopulator.cpp 243: INFO: Locating all 'CPF' ancillary files
+2016-06-02T16:21:24 AncDatabasePopulator.cpp 243: INFO: Locating all 'BPF' ancillary files
+2016-06-02T16:24:13 ProductMetadata.cpp 151: WARN: Path '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LO8BPF20150921110654_20150921124547.01' is not a Landsat product
+2016-06-02T16:26:42 AncDatabasePopulator.cpp 243: INFO: Locating all 'RLUT' ancillary files
+2016-06-02T16:26:44 ul_Hdf5Reader.cpp 534: ERROR: Failed to open HDF 5 file '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20130211_20241231v03.h5'
+2016-06-02T16:26:44 ul_Hdf5Reader.cpp 563: ERROR: Failure returned from StartUpCall()
+2016-06-02T16:26:44 ProductMetadataSensor.cpp 555: ERROR: Failure returned from CHdf5Reader::Parse()
+2016-06-02T16:26:44 ProductMetadataSensor.cpp 610: ERROR: Failed to read all ancillary metadata
+2016-06-02T16:26:44 ProductMetadata.cpp 140: ERROR: Failed to populate all ancillary metadata
+2016-06-02T16:26:44 ul_Hdf5Reader.cpp 534: ERROR: Failed to open HDF 5 file '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20130211_20241231v04.h5'
+2016-06-02T16:26:44 ul_Hdf5Reader.cpp 563: ERROR: Failure returned from StartUpCall()
+2016-06-02T16:26:44 ProductMetadataSensor.cpp 555: ERROR: Failure returned from CHdf5Reader::Parse()
+2016-06-02T16:26:44 ProductMetadataSensor.cpp 610: ERROR: Failed to read all ancillary metadata
+2016-06-02T16:26:44 ProductMetadata.cpp 140: ERROR: Failed to populate all ancillary metadata
+2016-06-02T16:26:44 ul_Hdf5Reader.cpp 534: ERROR: Failed to open HDF 5 file '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20130211_20241231v01.h5'
+2016-06-02T16:26:44 ul_Hdf5Reader.cpp 563: ERROR: Failure returned from StartUpCall()
+2016-06-02T16:26:44 ProductMetadataSensor.cpp 555: ERROR: Failure returned from CHdf5Reader::Parse()
+2016-06-02T16:26:44 ProductMetadataSensor.cpp 610: ERROR: Failed to read all ancillary metadata
+2016-06-02T16:26:44 ProductMetadata.cpp 140: ERROR: Failed to populate all ancillary metadata
+2016-06-02T16:26:44 ul_Hdf5Reader.cpp 534: ERROR: Failed to open HDF 5 file '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20130211_20241231v02.h5'
+2016-06-02T16:26:44 ul_Hdf5Reader.cpp 563: ERROR: Failure returned from StartUpCall()
+2016-06-02T16:26:44 ProductMetadataSensor.cpp 555: ERROR: Failure returned from CHdf5Reader::Parse()
+2016-06-02T16:26:44 ProductMetadataSensor.cpp 610: ERROR: Failed to read all ancillary metadata
+2016-06-02T16:26:44 ProductMetadata.cpp 140: ERROR: Failed to populate all ancillary metadata
+2016-06-02T16:26:44 AncDatabasePopulator.cpp 243: INFO: Locating all 'SSM' ancillary files
+2016-06-02T16:26:45 ProcessingStep.cpp 413: INFO: Starting processing step 'INGEST: MD -> L0Ra'
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_INGEST_PROCESS_0 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA_WO" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/MD" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "OLI_TIRS" "TRUE" "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20150701_20150930.03" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs" 2>&1'
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_INGEST_PROCESS_0 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA_WO" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/MD" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "OLI_TIRS" "TRUE" "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20150701_20150930.03" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs" 2>&1' output =
+--------------------------------------------------
+-------------DPAS INGEST PROCESS------------------
+--------------------------------------------------
+Processing (ADC) ..... DONE
+Processing (LG) ..... DONE
+Processing (SFC) ..... DONE
+Processing (MG) ..... DONE
+
+2016-06-02T16:29:49 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_073_073')'
+2016-06-02T16:29:49 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_075_075')'
+2016-06-02T16:29:49 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_074_074')'
+2016-06-02T16:29:49 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_076_076')'
+2016-06-02T16:29:49 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_077_077')'
+2016-06-02T16:29:49 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_078_078')'
+2016-06-02T16:29:49 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_079_079')'
+2016-06-02T16:29:49 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_081_081')'
+2016-06-02T16:29:49 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_082_082')'
+2016-06-02T16:29:49 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_080_080')'
+2016-06-02T16:29:49 PreProcessingStepL0Ra2L0Rp.cpp 41: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP'
+2016-06-02T16:29:49 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_073_073'
+2016-06-02T16:29:49 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_074_074'
+2016-06-02T16:29:49 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_079_079'
+2016-06-02T16:29:49 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_075_075'
+2016-06-02T16:29:49 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_081_081'
+2016-06-02T16:29:49 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_082_082'
+2016-06-02T16:29:49 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_076_076'
+2016-06-02T16:29:49 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_078_078'
+2016-06-02T16:29:49 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_080_080'
+2016-06-02T16:29:49 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_077_077'
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_1 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_073_073" "" "114" "73" "73" "2015:267:02:14:20.0150005" "2015:267:02:14:27.6390005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_073_073" "LC81140740812015267LGN00" "LC81140732015267LGN00" 2>&1'
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_2 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_074_074" "" "114" "74" "74" "2015:267:02:14:21.5610005" "2015:267:02:14:53.3310005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_074_074" "LC81140740812015267LGN00" "LC81140742015267LGN00" 2>&1'
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_3 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_079_079" "" "114" "79" "79" "2015:267:02:16:21.2740005" "2015:267:02:16:53.0440005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_079_079" "LC81140740812015267LGN00" "LC81140792015267LGN00" 2>&1'
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_4 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_075_075" "" "114" "75" "75" "2015:267:02:14:45.5030005" "2015:267:02:15:17.2730005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_075_075" "LC81140740812015267LGN00" "LC81140752015267LGN00" 2>&1'
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_5 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_081_081" "" "114" "81" "81" "2015:267:02:17:09.1710005" "2015:267:02:17:40.9410005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_081_081" "LC81140740812015267LGN00" "LC81140812015267LGN00" 2>&1'
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_6 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_082_082" "" "114" "82" "82" "2015:267:02:17:34.8750005" "2015:267:02:17:42.5080005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_082_082" "LC81140740812015267LGN00" "LC81140822015267LGN00" 2>&1'
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_7 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_076_076" "" "114" "76" "76" "2015:267:02:15:09.4400005" "2015:267:02:15:41.2100005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_076_076" "LC81140740812015267LGN00" "LC81140762015267LGN00" 2>&1'
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_8 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_078_078" "" "114" "78" "78" "2015:267:02:15:57.3280005" "2015:267:02:16:29.0980005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_078_078" "LC81140740812015267LGN00" "LC81140782015267LGN00" 2>&1'
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_9 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_080_080" "" "114" "80" "80" "2015:267:02:16:45.2250005" "2015:267:02:17:16.9950005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_080_080" "LC81140740812015267LGN00" "LC81140802015267LGN00" 2>&1'
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_10 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_077_077" "" "114" "77" "77" "2015:267:02:15:33.3860005" "2015:267:02:16:05.1560005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_077_077" "LC81140740812015267LGN00" "LC81140772015267LGN00" 2>&1'
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_1 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_073_073" "" "114" "73" "73" "2015:267:02:14:20.0150005" "2015:267:02:14:27.6390005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_073_073" "LC81140740812015267LGN00" "LC81140732015267LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_6 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_082_082" "" "114" "82" "82" "2015:267:02:17:34.8750005" "2015:267:02:17:42.5080005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_082_082" "LC81140740812015267LGN00" "LC81140822015267LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_2 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_074_074" "" "114" "74" "74" "2015:267:02:14:21.5610005" "2015:267:02:14:53.3310005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_074_074" "LC81140740812015267LGN00" "LC81140742015267LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_10 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_077_077" "" "114" "77" "77" "2015:267:02:15:33.3860005" "2015:267:02:16:05.1560005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_077_077" "LC81140740812015267LGN00" "LC81140772015267LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_3 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_079_079" "" "114" "79" "79" "2015:267:02:16:21.2740005" "2015:267:02:16:53.0440005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_079_079" "LC81140740812015267LGN00" "LC81140792015267LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_4 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_075_075" "" "114" "75" "75" "2015:267:02:14:45.5030005" "2015:267:02:15:17.2730005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_075_075" "LC81140740812015267LGN00" "LC81140752015267LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_5 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_081_081" "" "114" "81" "81" "2015:267:02:17:09.1710005" "2015:267:02:17:40.9410005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_081_081" "LC81140740812015267LGN00" "LC81140812015267LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_7 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_076_076" "" "114" "76" "76" "2015:267:02:15:09.4400005" "2015:267:02:15:41.2100005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_076_076" "LC81140740812015267LGN00" "LC81140762015267LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_8 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_078_078" "" "114" "78" "78" "2015:267:02:15:57.3280005" "2015:267:02:16:29.0980005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_078_078" "LC81140740812015267LGN00" "LC81140782015267LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_9 "LANDSAT8" "OLI_TIRS" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RA" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_080_080" "" "114" "80" "80" "2015:267:02:16:45.2250005" "2015:267:02:17:16.9950005" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_080_080" "LC81140740812015267LGN00" "LC81140802015267LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+2016-06-02T16:30:34 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_082_082')'
+2016-06-02T16:30:34 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_076_076')'
+2016-06-02T16:30:34 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_078_078')'
+2016-06-02T16:30:34 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_079_079')'
+2016-06-02T16:30:34 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_080_080')'
+2016-06-02T16:30:34 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_073_073')'
+2016-06-02T16:30:34 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_075_075')'
+2016-06-02T16:30:34 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_077_077')'
+2016-06-02T16:30:34 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_074_074')'
+2016-06-02T16:30:34 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_081_081')'
+2016-06-02T16:30:34 PreProcessingStepL0Rp2L1.cpp 71: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1'
+2016-06-02T16:30:34 PreProcessingStepL0Rp2L1.cpp 82: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_073_073'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_073_073'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_082_082'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_077_077'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_077_077'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_079_079'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_079_079'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_078_078'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_075_075'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_082_082'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_081_081'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_076_076'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_076_076'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_078_078'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_075_075'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_081_081'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_080_080'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_074_074'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_080_080'
+2016-06-02T16:30:35 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_074_074'
+<--------L1 Order ODL-------->
+<--START--(114_073_073)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2015-09-24"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LO8BPF20150924014805_20150924022908.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LT8BPF20150924014411_20150924023017.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20150701_20150930.03"
+  ORDER_ID = "114_073_073"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20160601.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 73
+  WRS_PATH = 114
+  WRS_START_ROW = 73
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_073_073)--END-->
+<--------L1 Order ODL-------->
+<--START--(114_077_077)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2015-09-24"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LO8BPF20150924014805_20150924022908.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LT8BPF20150924014411_20150924023017.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20150701_20150930.03"
+  ORDER_ID = "114_077_077"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20160601.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 77
+  WRS_PATH = 114
+  WRS_START_ROW = 77
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_077_077)--END-->
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_11 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_073_073" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_073_073" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_073_073" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_073_073" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_073_073/114_073_073.odl" 2>&1'
+<--------L1 Order ODL-------->
+<--START--(114_079_079)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2015-09-24"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LO8BPF20150924014805_20150924022908.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LT8BPF20150924014411_20150924023017.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20150701_20150930.03"
+  ORDER_ID = "114_079_079"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20160601.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 79
+  WRS_PATH = 114
+  WRS_START_ROW = 79
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_079_079)--END-->
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_12 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_077_077" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_077_077" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_077_077" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_077_077" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_077_077/114_077_077.odl" 2>&1'
+<--------L1 Order ODL-------->
+<--START--(114_082_082)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2015-09-24"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LO8BPF20150924014805_20150924022908.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LT8BPF20150924014411_20150924023017.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20150701_20150930.03"
+  ORDER_ID = "114_082_082"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20160601.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -49
+  WRS_END_ROW = 82
+  WRS_PATH = 114
+  WRS_START_ROW = 82
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_082_082)--END-->
+<--------L1 Order ODL-------->
+<--START--(114_076_076)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2015-09-24"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LO8BPF20150924014805_20150924022908.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LT8BPF20150924014411_20150924023017.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20150701_20150930.03"
+  ORDER_ID = "114_076_076"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20160601.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 76
+  WRS_PATH = 114
+  WRS_START_ROW = 76
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_076_076)--END-->
+<--------L1 Order ODL-------->
+<--START--(114_075_075)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2015-09-24"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LO8BPF20150924014805_20150924022908.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LT8BPF20150924014411_20150924023017.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20150701_20150930.03"
+  ORDER_ID = "114_075_075"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20160601.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 75
+  WRS_PATH = 114
+  WRS_START_ROW = 75
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_075_075)--END-->
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_13 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_076_076" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_076_076" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_076_076" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_076_076" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_076_076/114_076_076.odl" 2>&1'
+<--------L1 Order ODL-------->
+<--START--(114_081_081)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2015-09-24"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LO8BPF20150924014805_20150924022908.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LT8BPF20150924014411_20150924023017.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20150701_20150930.03"
+  ORDER_ID = "114_081_081"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20160601.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -49
+  WRS_END_ROW = 81
+  WRS_PATH = 114
+  WRS_START_ROW = 81
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_081_081)--END-->
+<--------L1 Order ODL-------->
+<--START--(114_080_080)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2015-09-24"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LO8BPF20150924014805_20150924022908.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LT8BPF20150924014411_20150924023017.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20150701_20150930.03"
+  ORDER_ID = "114_080_080"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20160601.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 80
+  WRS_PATH = 114
+  WRS_START_ROW = 80
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_080_080)--END-->
+<--------L1 Order ODL-------->
+<--START--(114_074_074)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2015-09-24"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LO8BPF20150924014805_20150924022908.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LT8BPF20150924014411_20150924023017.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20150701_20150930.03"
+  ORDER_ID = "114_074_074"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20160601.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 74
+  WRS_PATH = 114
+  WRS_START_ROW = 74
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_074_074)--END-->
+<--------L1 Order ODL-------->
+<--START--(114_078_078)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2015-09-24"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LO8BPF20150924014805_20150924022908.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2015/09/LT8BPF20150924014411_20150924023017.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20150701_20150930.03"
+  ORDER_ID = "114_078_078"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20160601.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 78
+  WRS_PATH = 114
+  WRS_START_ROW = 78
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_078_078)--END-->
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_14 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_074_074" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_074_074" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_074_074" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_074_074" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_074_074/114_074_074.odl" 2>&1'
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_15 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_082_082" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_082_082" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_082_082" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_082_082" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_082_082/114_082_082.odl" 2>&1'
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_16 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_079_079" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_079_079" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_079_079" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_079_079" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_079_079/114_079_079.odl" 2>&1'
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_17 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_078_078" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_078_078" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_078_078" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_078_078" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_078_078/114_078_078.odl" 2>&1'
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_18 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_081_081" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_081_081" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_081_081" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_081_081" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_081_081/114_081_081.odl" 2>&1'
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_19 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_075_075" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_075_075" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_075_075" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_075_075" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_075_075/114_075_075.odl" 2>&1'
+Execute command = '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_20 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_080_080" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_080_080" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_080_080" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_080_080" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_080_080/114_080_080.odl" 2>&1'
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_11 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_073_073" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_073_073" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_073_073" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_073_073" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_073_073/114_073_073.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... FAILED
+Failure returned from CallIt()
+Failure returned from ExecRunLpgs() for L1T
+Processing a 'L1GT' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_15 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_082_082" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_082_082" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_082_082" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_082_082" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_082_082/114_082_082.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... FAILED
+Failure returned from CallIt()
+Failure returned from ExecRunLpgs() for L1T
+Processing a 'L1GT' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_20 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_080_080" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_080_080" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_080_080" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_080_080" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_080_080/114_080_080.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_16 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_079_079" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_079_079" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_079_079" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_079_079" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_079_079/114_079_079.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_14 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_074_074" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_074_074" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_074_074" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_074_074" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_074_074/114_074_074.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_19 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_075_075" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_075_075" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_075_075" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_075_075" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_075_075/114_075_075.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_17 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_078_078" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_078_078" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_078_078" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_078_078" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_078_078/114_078_078.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_12 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_077_077" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_077_077" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_077_077" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_077_077" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_077_077/114_077_077.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_18 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_081_081" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_081_081" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_081_081" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_081_081" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_081_081/114_081_081.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_13 "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L0RP/114_076_076" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1/114_076_076" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO/114_076_076" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/Logs/114_076_076" "/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm/L1_WO_ODL/114_076_076/114_076_076.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+2016-06-02T16:52:08 Processor.cpp 112: INFO: Cleaning path '/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm'
+Output XML = 
+<LandsatProcessingResult status="success">
+	<Message>Processing was successful</Message>
+	<LandsatProcessingRequest id="LS8-20150924" version="2">
+		<Input format="MD" satellite="LANDSAT8" sensor="OLI_TIRS">
+			<WorkingFolder cleanBefore="TRUE" cleanAfter="TRUE">/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/pm</WorkingFolder>
+			<InputPath linkInput="TRUE">/jobfs/local/6654022.r-man2/lpgs-work427KPU/LS8_OLITIRS_STD-MD_P00_LC81140740812015267LGN00_114_074-081_20150924T031413Z20150924T031604/lpgs-work/source</InputPath>
+		</Input>
+	</LandsatProcessingRequest>
+	<Version>4.1.4110</Version>
+	<HostName>r928</HostName>
+	<StartTime>2016-06-02T16:20:03</StartTime>
+	<StopTime>2016-06-02T16:52:08</StopTime>
+	<TotalTime>00:32:05</TotalTime>
+	<L0RaProcessing status="succeeded"/>
+	<L0RpProcessing maxConcurrentScenes="15" fail="0" busy="0" queued="0" success="10" canceled="0" timedout="0">
+		<Succeeded sceneType="partial">114_073_073</Succeeded>
+		<Succeeded sceneType="full">114_074_074</Succeeded>
+		<Succeeded sceneType="full">114_075_075</Succeeded>
+		<Succeeded sceneType="full">114_076_076</Succeeded>
+		<Succeeded sceneType="full">114_077_077</Succeeded>
+		<Succeeded sceneType="full">114_078_078</Succeeded>
+		<Succeeded sceneType="full">114_079_079</Succeeded>
+		<Succeeded sceneType="full">114_080_080</Succeeded>
+		<Succeeded sceneType="full">114_081_081</Succeeded>
+		<Succeeded sceneType="partial">114_082_082</Succeeded>
+	</L0RpProcessing>
+	<L1Processing maxConcurrentScenes="15" fail="0" busy="0" queued="0" success="10" canceled="0" timedout="0" L1R="0" L1G="0" L1Gt="2" L1T="8">
+		<Succeeded sceneType="full" level="L1T">114_076_076</Succeeded>
+		<Succeeded sceneType="partial" level="L1GT">114_082_082</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_078_078</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_079_079</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_075_075</Succeeded>
+		<Succeeded sceneType="partial" level="L1GT">114_073_073</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_080_080</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_077_077</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_081_081</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_074_074</Succeeded>
+	</L1Processing>
+</LandsatProcessingResult>
+

--- a/integration_tests/data/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926/additional/20160926_20140804_B6_gverify.log
+++ b/integration_tests/data/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926/additional/20160926_20140804_B6_gverify.log
@@ -1,0 +1,190 @@
+2016-12-20T13:39:27 main.cpp 34: INFO: Arguments
+gridSize = '26'
+resampleType  = 'BI'
+nullValue = '0.000000000000000'
+chipGenType = 'FIXED_LOCATION'
+fixedChipLocationFile = '/g/data/v10/eoancillarydata/GCP/Fix_QA_points/114/080/points.txt
+correlationThreshold = '0.750000000000000'
+referenceImage = 
+'	pathToImage = '/g/data/v10/eoancillarydata/GCP/GQA_v3/wrs2/114/080/LC81140802014216LGN00_B6.TIF'
+	proj4Str = '''
+inputImage = 
+'	pathToImage = '/g/data/v10/reprocess/ls8/level1/2016/09/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926/product/LC81140802016270LGN00_B6.TIF'
+	proj4Str = '''
+logPath = '/g/data/v10/reprocess/gqa/ls8/2016/09/output/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926.gqa-work'
+outputPath = '/g/data/v10/reprocess/gqa/ls8/2016/09/output/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926.gqa-work'
+threadCount = '4'
+usePhaseCorrelation = 'FALSE'
+workingDirectory = '/g/data/v10/reprocess/gqa/ls8/2016/09/output/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926.gqa-work'
+chipSize = '31'
+amountOfPyramids = '5'
+
+
+2016-12-20T13:39:31 ul_Reproject.cpp 133: INFO: Projecting 100%   
+2016-12-20T13:39:34 ul_Reproject.cpp 173: INFO: Generate translation map 100%   
+2016-12-20T13:39:34 ul_Resampler.h 476: INFO: Resample map is of type 'double'
+2016-12-20T13:39:35 ul_Resampler.h 97: INFO: Resampler is bilinear
+2016-12-20T13:39:39 ul_Resampler.h 326: INFO: Resampling 100%     
+2016-12-20T13:39:43 ul_ImageOverlap.cpp 356: INFO: Save new overlapped image to '/g/data/v10/reprocess/gqa/ls8/2016/09/output/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926.gqa-work/MinMaxBox/Input/warpedInput_LC81140802016270LGN00_B6.TIF'
+2016-12-20T13:39:47 ul_ImageOverlap.cpp 356: INFO: Save new overlapped image to '/g/data/v10/reprocess/gqa/ls8/2016/09/output/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926.gqa-work/MinMaxBox/Reference/LC81140802014216LGN00_B6.TIF'
+2016-12-20T13:39:52 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T13:39:58 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T13:40:06 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T13:40:11 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T13:40:20 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T13:40:26 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T13:40:29 ul_TiledGaussianPyramidTiePointGenerator.cpp 534: INFO: <<----------------------------------------------------------->>
+2016-12-20T13:40:29 ul_TiledGaussianPyramidTiePointGenerator.cpp 535: INFO:  <----TILE LOOP (1/2)----------------->
+2016-12-20T13:40:29 ul_TiledGaussianPyramidTiePointGenerator.cpp 536: INFO: <<----------------------------------------------------------->>
+2016-12-20T13:40:29 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '2' of '5' for image 'Input_1_1'
+2016-12-20T13:40:31 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '3' of '5' for image 'Input_1_1'
+2016-12-20T13:40:32 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '4' of '5' for image 'Input_1_1'
+2016-12-20T13:40:32 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '5' of '5' for image 'Input_1_1'
+2016-12-20T13:40:32 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '2' of '5' for image 'Reference_1_1'
+2016-12-20T13:40:34 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '3' of '5' for image 'Reference_1_1'
+2016-12-20T13:40:35 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '4' of '5' for image 'Reference_1_1'
+2016-12-20T13:40:35 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '5' of '5' for image 'Reference_1_1'
+2016-12-20T13:40:35 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (1/5)----------------->>
+2016-12-20T13:40:35 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:40:35 ul_FixedLocationChips.cpp 171: INFO: Generated '217' chips
+2016-12-20T13:40:35 ul_TiePointGenerator.cpp 166: INFO: Correlating '217' chips of size '31x31' on a search window of size '52x52' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:40:35 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:40:36 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:40:36 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:40:36 ul_TiePointGenerator.cpp 285: INFO: Obtained '217' chips
+2016-12-20T13:40:36 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T13:40:36 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '1/5' is 'x = 0.003366440787691 y = -0.005289874290138' pixels
+2016-12-20T13:40:36 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (2/5)----------------->>
+2016-12-20T13:40:37 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:40:37 ul_FixedLocationChips.cpp 171: INFO: Generated '291' chips
+2016-12-20T13:40:37 ul_TiePointGenerator.cpp 166: INFO: Correlating '291' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:40:37 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:40:37 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:40:37 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:40:37 ul_TiePointGenerator.cpp 285: INFO: Obtained '291' chips
+2016-12-20T13:40:37 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T13:40:37 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '2/5' is 'x = 0.003728280223307 y = -0.008053842805880' pixels
+2016-12-20T13:40:37 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (3/5)----------------->>
+2016-12-20T13:40:37 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:40:37 ul_FixedLocationChips.cpp 171: INFO: Generated '306' chips
+2016-12-20T13:40:37 ul_TiePointGenerator.cpp 166: INFO: Correlating '306' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:40:37 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:40:38 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:40:38 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:40:38 ul_TiePointGenerator.cpp 285: INFO: Obtained '306' chips
+2016-12-20T13:40:38 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T13:40:38 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '3/5' is 'x = 0.005203393754169 y = -0.013317783287777' pixels
+2016-12-20T13:40:38 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (4/5)----------------->>
+2016-12-20T13:40:38 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:40:38 ul_FixedLocationChips.cpp 171: INFO: Generated '320' chips
+2016-12-20T13:40:38 ul_TiePointGenerator.cpp 166: INFO: Correlating '320' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:40:39 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:40:39 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:40:39 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:40:39 ul_TiePointGenerator.cpp 285: INFO: Obtained '320' chips
+2016-12-20T13:40:39 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T13:40:39 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '4/5' is 'x = 0.019862204535735 y = -0.016763880840031' pixels
+2016-12-20T13:40:39 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (5/5)----------------->>
+2016-12-20T13:40:40 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:40:40 ul_FixedLocationChips.cpp 171: INFO: Generated '328' chips
+2016-12-20T13:40:40 ul_TiePointGenerator.cpp 166: INFO: Correlating '328' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:40:42 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:40:43 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:40:43 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:40:43 ul_TiePointGenerator.cpp 285: INFO: Obtained '328' chips
+2016-12-20T13:40:44 ul_GcpHullRejection.cpp 264: INFO: Hull trim size is '31'
+2016-12-20T13:40:47 ul_ConvKernelToImage.h 178: INFO: 100%   
+2016-12-20T13:40:47 ul_ConvKernelToImage.h 178: INFO: 100%   
+2016-12-20T13:40:47 ul_ConvexHull.cpp 142: INFO: Sorting '591363' data points
+2016-12-20T13:40:47 ul_ConvexHull.cpp 142: INFO: Sorting '827935' data points
+2016-12-20T13:40:47 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T13:40:47 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T13:40:48 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T13:40:48 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T13:40:52 ul_GcpOutlierTestingHullGenThread.cpp 235: INFO: TrimHullArea 100%     
+2016-12-20T13:40:54 ul_GcpOutlierTestingHullGenThread.cpp 235: INFO: TrimHullArea 100%     
+2016-12-20T13:40:55 ul_GcpHullRejection.cpp 155: INFO: RejectGcps 100%     
+2016-12-20T13:40:55 ul_GcpHullRejection.cpp 275: INFO: Rejected a total of '3' GCP on the outer hull edges
+2016-12-20T13:40:55 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 205: INFO: Average shift in pixels are 'x = 0.023339647400945 y = 0.009610903329615'
+2016-12-20T13:40:55 ul_TiledGaussianPyramidTiePointGenerator.cpp 534: INFO: <<----------------------------------------------------------->>
+2016-12-20T13:40:55 ul_TiledGaussianPyramidTiePointGenerator.cpp 535: INFO:  <----TILE LOOP (2/2)----------------->
+2016-12-20T13:40:55 ul_TiledGaussianPyramidTiePointGenerator.cpp 536: INFO: <<----------------------------------------------------------->>
+2016-12-20T13:40:55 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '2' of '5' for image 'Input_2_1'
+2016-12-20T13:40:57 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '3' of '5' for image 'Input_2_1'
+2016-12-20T13:40:59 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '4' of '5' for image 'Input_2_1'
+2016-12-20T13:40:59 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '5' of '5' for image 'Input_2_1'
+2016-12-20T13:40:59 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '2' of '5' for image 'Reference_2_1'
+2016-12-20T13:41:02 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '3' of '5' for image 'Reference_2_1'
+2016-12-20T13:41:03 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '4' of '5' for image 'Reference_2_1'
+2016-12-20T13:41:03 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '5' of '5' for image 'Reference_2_1'
+2016-12-20T13:41:03 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (1/5)----------------->>
+2016-12-20T13:41:03 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:41:03 ul_FixedLocationChips.cpp 171: INFO: Generated '42' chips
+2016-12-20T13:41:03 ul_TiePointGenerator.cpp 166: INFO: Correlating '42' chips of size '31x31' on a search window of size '52x52' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:41:03 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:41:03 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:41:03 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:41:03 ul_TiePointGenerator.cpp 285: INFO: Obtained '42' chips
+2016-12-20T13:41:03 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T13:41:03 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '1/5' is 'x = 0.014122703481782 y = 0.004447877661212' pixels
+2016-12-20T13:41:03 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (2/5)----------------->>
+2016-12-20T13:41:03 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:41:03 ul_FixedLocationChips.cpp 171: INFO: Generated '63' chips
+2016-12-20T13:41:03 ul_TiePointGenerator.cpp 166: INFO: Correlating '63' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:41:03 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:41:04 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:41:04 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:41:04 ul_TiePointGenerator.cpp 285: INFO: Obtained '63' chips
+2016-12-20T13:41:04 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T13:41:04 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '2/5' is 'x = 0.021426878564258 y = 0.006762774123531' pixels
+2016-12-20T13:41:04 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (3/5)----------------->>
+2016-12-20T13:41:04 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:41:04 ul_FixedLocationChips.cpp 171: INFO: Generated '76' chips
+2016-12-20T13:41:04 ul_TiePointGenerator.cpp 166: INFO: Correlating '76' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:41:04 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:41:04 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:41:04 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:41:04 ul_TiePointGenerator.cpp 285: INFO: Obtained '76' chips
+2016-12-20T13:41:04 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T13:41:04 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '3/5' is 'x = -0.005474825420835 y = 0.005154264941812' pixels
+2016-12-20T13:41:04 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (4/5)----------------->>
+2016-12-20T13:41:04 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:41:04 ul_FixedLocationChips.cpp 171: INFO: Generated '88' chips
+2016-12-20T13:41:04 ul_TiePointGenerator.cpp 166: INFO: Correlating '88' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:41:04 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:41:05 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:41:05 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:41:05 ul_TiePointGenerator.cpp 285: INFO: Obtained '88' chips
+2016-12-20T13:41:05 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T13:41:05 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '4/5' is 'x = 0.007857799540432 y = 0.000398980073270' pixels
+2016-12-20T13:41:05 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (5/5)----------------->>
+2016-12-20T13:41:05 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:41:05 ul_FixedLocationChips.cpp 171: INFO: Generated '95' chips
+2016-12-20T13:41:05 ul_TiePointGenerator.cpp 166: INFO: Correlating '95' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:41:07 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:41:08 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:41:08 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:41:08 ul_TiePointGenerator.cpp 285: INFO: Obtained '95' chips
+2016-12-20T13:41:09 ul_GcpHullRejection.cpp 264: INFO: Hull trim size is '31'
+2016-12-20T13:41:12 ul_ConvKernelToImage.h 178: INFO: 100%   
+2016-12-20T13:41:12 ul_ConvKernelToImage.h 178: INFO: 100%   
+2016-12-20T13:41:12 ul_ConvexHull.cpp 142: INFO: Sorting '526054' data points
+2016-12-20T13:41:12 ul_ConvexHull.cpp 142: INFO: Sorting '1083116' data points
+2016-12-20T13:41:13 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T13:41:13 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T13:41:13 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T13:41:13 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T13:41:18 ul_GcpOutlierTestingHullGenThread.cpp 235: INFO: TrimHullArea 100%     
+2016-12-20T13:41:19 ul_GcpOutlierTestingHullGenThread.cpp 235: INFO: TrimHullArea 100%     
+2016-12-20T13:41:20 ul_GcpHullRejection.cpp 155: INFO: RejectGcps 100%     
+2016-12-20T13:41:20 ul_GcpHullRejection.cpp 275: INFO: Rejected a total of '1' GCP on the outer hull edges
+2016-12-20T13:41:20 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 205: INFO: Average shift in pixels are 'x = 0.010796772761923 y = -0.001197990804326'
+2016-12-20T13:41:20 ul_TiledGaussianPyramidTiePointGenerator.cpp 457: INFO: Removing duplicate GCPs
+2016-12-20T13:41:20 ul_TiledGaussianPyramidTiePointGenerator.cpp 481: INFO: Removed '7' duplicate GCPs
+2016-12-20T13:41:32 GenerateResults.cpp 57: INFO: Residual X = 0.112185873154427 Y = 0.135500685890115
+2016-12-20T13:41:32 GenerateResults.cpp 81: INFO: Residual histogram
+	Green 257
+	Teal 8
+	Blue 0
+	Yellow 0
+	Red 1

--- a/integration_tests/data/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926/additional/LPGS.log
+++ b/integration_tests/data/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926/additional/LPGS.log
@@ -1,0 +1,936 @@
+Thu Oct 13 20:53:29 AEDT 2016
+ 
+DMS Setup Work Order (DSW)
+ 
+2016-10-13 20:53:29  setup_work_order    28174 setup_work_order.c        91  INFO Initiated
+2016-10-13 20:53:29  setup_work_order    28174 read_l0r_metadata.c       91  INFO Reading L0R metadata from l0r_symlink/LC81140802016270LGN00
+2016-10-13 20:53:29  setup_work_order    28174 setup_work_order.c       554  INFO Successful completion
+ 
+setup_work_order execution completed with status of 0
+ 
+Thu Oct 13 20:53:29 AEDT 2016
+Thu Oct 13 20:53:31 AEDT 2016
+ 
+DMS Retrieve Elevation (DRE)
+ 
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s28_e112_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s28_e112_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s28e112
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s28_e113_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s28_e113_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s28e113
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s28_e114_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s28_e114_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s28e114
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s28_e115_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s28_e115_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s28e115
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s29_e112_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s29_e112_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s29e112
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s29_e113_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s29_e113_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s29e113
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s29_e114_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s29_e114_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s29e114
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s29_e115_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s29_e115_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s29e115
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s30_e112_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s30_e112_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s30e112
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s30_e113_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s30_e113_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s30e113
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s30_e114_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s30_e114_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s30e114
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s30_e115_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s30_e115_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s30e115
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s31_e112_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s31_e112_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s31e112
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s31_e113_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s31_e113_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s31e113
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s31_e114_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s31_e114_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s31e114
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s31_e115_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s31_e115_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s31e115
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           180  INFO Mosaicing GLS DEM tiles...
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:41  retrieve_elevation    28288 retrieve_elevation.c     416  INFO DEM data retrieval successfully completed.
+ 
+retrieve_elevation execution completed with status of 0
+ 
+Thu Oct 13 20:53:41 AEDT 2016
+Thu Oct 13 20:53:42 AEDT 2016
+ 
+DMS Ground Control (DGC)
+ 
+2016-10-13T09:53:43 LoadChips.cpp 766: INFO: Found chips at '/g/data/v10/eoancillarydata/GCP/Phase2_GCP/114/080/GCPLib'
+2016-10-13T09:53:50 SaveChips.cpp 385: INFO: Saving tile as version '2'
+ 
+lpgs-chip-loader execution completed with status of 0
+ 
+Thu Oct 13 20:53:50 AEDT 2016
+Thu Oct 13 20:53:51 AEDT 2016
+ 
+Ancillary Data Preprocessor (ADP)
+ 
+2016-10-13 20:53:51  ancillary_data_preprocessor    28499 ancillary_data_preprocessor.c     100  INFO Initiated
+2016-10-13 20:53:51  ancillary_data_preprocessor    28499 ias_ancillary_smooth_ephemeris.c     172  INFO L0R ephemeris record count = 226
+2016-10-13 20:53:51  ancillary_data_preprocessor    28499 ias_ancillary_identify_quaternion_outliers.c     268  INFO Number of attitude quaternion points 11300
+2016-10-13 20:53:51  ancillary_data_preprocessor    28499 ias_ancillary_convert_imu_to_acs.c     350  INFO Bounds on IMU time 528128129.895857, 528128355.875101
+2016-10-13 20:53:51  ancillary_data_preprocessor    28499 ias_ancillary_extract_valid_imu_data_window.c      60  INFO Ephemeris times --- start 528128130.900064, end 528128355.900064 -> center 528128243.400064
+2016-10-13 20:53:51  ancillary_data_preprocessor    28499 ancillary_data_preprocessor.c     232  INFO Successful completion
+ 
+ancillary_data_preprocessor execution completed with status of 0
+ 
+Thu Oct 13 20:53:51 AEDT 2016
+Thu Oct 13 20:53:53 AEDT 2016
+ 
+Create Line of Sight Model Initialization (L8INIT)
+ 
+2016-10-13 20:53:53  create_los_model    28549 read_parameters.c        302  INFO Overriding the estimated TIRS SSM position file with '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt'
+2016-10-13 20:53:53  create_los_model    28549 create_los_model.c        76  INFO Create LOS Model started
+2016-10-13 20:53:54  create_los_model    28549 ias_sensor_set_ssm_from_l0r.c     180  WARN MCE mode 0 in use, not mode 4 as expected
+2016-10-13 20:53:54  create_los_model    28549 ias_sensor_set_ssm_from_l0r.c     193  WARN Operating in MCE mode 0 without valid SSM encoder data!
+2016-10-13 20:53:54  create_los_model    28549 ias_sensor_check_ssm_encoder_data.c     313  WARN No valid SSM angles found; using nominal value
+2016-10-13 20:53:54  create_los_model    28549 ias_sensor_set_ssm_from_l0r.c     778  INFO Using estimated SSM encoder data from /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt to replace missing mirror telemetry
+2016-10-13 20:53:54  create_los_model    28549 create_los_model.c       271  INFO Create LOS Model finished
+ 
+create_los_model execution completed with status of 0
+ 
+Thu Oct 13 20:53:54 AEDT 2016
+Thu Oct 13 20:53:56 AEDT 2016
+ 
+Create Level 1R (L8RPS)
+ 
+2016-10-13 20:53:56  create_l1r    28623 rps_main.c                71  INFO Initiated create_l1r
+2016-10-13 20:53:59  create_l1r    28623 process_scas.c            46  INFO Processing band 1
+2016-10-13 20:54:26  create_l1r    28623 process_scas.c            46  INFO Processing band 2
+2016-10-13 20:54:34  create_l1r    28623 process_scas.c            46  INFO Processing band 3
+2016-10-13 20:54:45  create_l1r    28623 process_scas.c            46  INFO Processing band 4
+2016-10-13 20:54:56  create_l1r    28623 process_scas.c            46  INFO Processing band 5
+2016-10-13 20:55:07  create_l1r    28623 process_scas.c            46  INFO Processing band 6
+2016-10-13 20:55:19  create_l1r    28623 process_scas.c            46  INFO Processing band 7
+2016-10-13 20:55:29  create_l1r    28623 process_scas.c            46  INFO Processing band 8
+2016-10-13 20:56:33  create_l1r    28623 process_scas.c            46  INFO Processing band 9
+2016-10-13 20:56:50  create_l1r    28623 process_scas.c            46  INFO Processing band 10
+2016-10-13 20:56:52  create_l1r    28623 process_scas.c            46  INFO Processing band 11
+2016-10-13 20:56:54  create_l1r    28623 api/api_striping_characterization.c     329  INFO Overall striping metric not calculated due to report and database storage flags being false
+2016-10-13 20:56:54  create_l1r    28623 rps_main.c               261  INFO Successful completion
+ 
+create_l1r execution completed with status of 0
+ 
+Thu Oct 13 20:56:54 AEDT 2016
+Thu Oct 13 20:56:56 AEDT 2016
+ 
+Create Systematic Grid (L8GRID_SYS)
+ 
+2016-10-13 20:56:56  create_grid    29141 get_parms_and_initialize_grid.c    1228  INFO Pixel origin will be 'UL'
+2016-10-13 20:56:56  create_grid    29141 create_grid.c            173  INFO Initiate Create Grid...
+2016-10-13 20:56:56  create_grid    29141 create_grid.c            284  INFO Elevation range   -40.00   419.00
+2016-10-13 20:56:56  create_grid    29141 pad_corners.c             58  INFO Scene padding size is 30.000000
+2016-10-13 20:56:56  create_grid    29141 build_grid.c             259  INFO Processing band number 6
+2016-10-13 20:56:59  create_grid    29141 build_grid.c              93  INFO Writing grid band number 6
+2016-10-13 20:56:59  create_grid    29141 create_grid.c            869  INFO Writing output grid file headers
+2016-10-13 20:56:59  create_grid    29141 create_grid.c            929  INFO Successful completion
+ 
+create_grid execution completed with status of 0
+ 
+Thu Oct 13 20:56:59 AEDT 2016
+Thu Oct 13 20:57:00 AEDT 2016
+ 
+Make the Geometric Terrain Grid (GRID_TERRAIN)
+ 
+2016-10-13 20:57:00  Makegeomgrid    29193 make_geom_grid.c         100  INFO Initiated
+2016-10-13 20:57:00  Makegeomgrid    29193 make_geom_grid.c         189  INFO Using band number 6 from the TARGET_FRAME_FILE
+2016-10-13 20:57:00  Makegeomgrid    29193 make_geom_grid.c         607  INFO Successful Completion
+ 
+makegeomgrid execution completed with status of 0
+ 
+Thu Oct 13 20:57:00 AEDT 2016
+Thu Oct 13 20:57:03 AEDT 2016
+ 
+Geometric Terrain Resample (RESAMPLE_TERRAIN)
+ 
+2016-10-13 20:57:03  Geomresample    29227 geomresample.c            93  INFO Geometric Resample Initiated
+2016-10-13 20:57:03  Geomresample    29227 geomresample.c           112  INFO Reading Grid
+2016-10-13 20:57:03  Geomresample    29227 geomresample.c           219  INFO Resampling band 1
+2016-10-13 20:57:03  Geomresample    29227 scanman.c                250  INFO resampling lines 0 through 800
+2016-10-13 20:57:03  Geomresample    29227 scanman.c                250  INFO resampling lines 650 through 1450
+2016-10-13 20:57:03  Geomresample    29227 scanman.c                250  INFO resampling lines 1300 through 2100
+2016-10-13 20:57:03  Geomresample    29227 scanman.c                250  INFO resampling lines 1950 through 2750
+2016-10-13 20:57:03  Geomresample    29227 scanman.c                250  INFO resampling lines 2600 through 3400
+2016-10-13 20:57:04  Geomresample    29227 scanman.c                250  INFO resampling lines 3250 through 4050
+2016-10-13 20:57:04  Geomresample    29227 scanman.c                250  INFO resampling lines 3900 through 4700
+2016-10-13 20:57:04  Geomresample    29227 scanman.c                250  INFO resampling lines 4550 through 5350
+2016-10-13 20:57:04  Geomresample    29227 scanman.c                250  INFO resampling lines 5200 through 6000
+2016-10-13 20:57:04  Geomresample    29227 scanman.c                250  INFO resampling lines 5850 through 6650
+2016-10-13 20:57:05  Geomresample    29227 scanman.c                250  INFO resampling lines 6500 through 7300
+2016-10-13 20:57:05  Geomresample    29227 scanman.c                250  INFO resampling lines 7150 through 7950
+2016-10-13 20:57:05  Geomresample    29227 scanman.c                250  INFO resampling lines 7800 through 8600
+2016-10-13 20:57:05  Geomresample    29227 scanman.c                250  INFO resampling lines 8450 through 9250
+2016-10-13 20:57:06  Geomresample    29227 scanman.c                250  INFO resampling lines 9100 through 9900
+2016-10-13 20:57:06  Geomresample    29227 scanman.c                250  INFO resampling lines 9750 through 10550
+2016-10-13 20:57:06  Geomresample    29227 scanman.c                250  INFO resampling lines 10400 through 11200
+2016-10-13 20:57:06  Geomresample    29227 scanman.c                250  INFO resampling lines 11050 through 11850
+2016-10-13 20:57:06  Geomresample    29227 scanman.c                250  INFO resampling lines 11700 through 12500
+2016-10-13 20:57:06  Geomresample    29227 scanman.c                250  INFO resampling lines 12350 through 13093
+2016-10-13 20:57:06  Geomresample    29227 geomresample.c           330  INFO Geometric Resample Successful Completion
+ 
+geomresample execution completed with status of 0
+ 
+Thu Oct 13 20:57:06 AEDT 2016
+Thu Oct 13 20:57:08 AEDT 2016
+ 
+Systematic L8 Resample (L8RESAMPLE_SYS)
+ 
+2016-10-13 20:57:08  Resample    29290 resample.c               115  INFO Initiated
+2016-10-13 20:57:10  Resample    29290 process_band.c            80  INFO Resampling band number 6
+2016-10-13 20:57:37  Resample    29290 resample.c               789  INFO Successful Completion
+ 
+resample execution completed with status of 0
+ 
+Thu Oct 13 20:57:37 AEDT 2016
+Thu Oct 13 20:57:39 AEDT 2016
+ 
+L8 GCP Correlation for Precision (L8PRECISION_GCP)
+ 
+2016-10-13 20:57:39  gcpcorrelate    29481 GCPcorrelate.c            84  INFO Initiated
+2016-10-13 20:57:39  gcpcorrelate    29481 GCPcorrelate.c            87  INFO Reading gcp_lib/GCPLib
+2016-10-13 20:57:39  gcpcorrelate    29481 ias_gcp_read_gcplib.c     292  INFO Reading gcp_lib/GCPLib
+2016-10-13 20:57:39  gcpcorrelate    29481 ias_gcp_read_gcplib.c     313  INFO Read 408 GCPs
+2016-10-13 20:57:39  gcpcorrelate    29481 ias_gcp_read_gcplib.c     135  INFO Pixel alignment will be 'UL', hemisphere is 'S', datum = 'GDA_94'
+2016-10-13 20:57:39  gcpcorrelate    29481 GCPcorrelate.c           116  INFO Read 408 GCPs
+2016-10-13 20:57:39  gcpcorrelate    29481 process_gcp.c            236  INFO Processing 1 SCA(s) in image sys_l1g.h5
+2016-10-13 20:57:39  gcpcorrelate    29481 process_gcp.c            375  INFO Using image chips from gcp_lib
+2016-10-13 20:57:39  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 0 to SCA 0
+2016-10-13 20:57:39  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 40 to SCA 0
+2016-10-13 20:57:39  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 80 to SCA 0
+2016-10-13 20:57:39  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 120 to SCA 0
+2016-10-13 20:57:39  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 160 to SCA 0
+2016-10-13 20:57:40  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 200 to SCA 0
+2016-10-13 20:57:40  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 240 to SCA 0
+2016-10-13 20:57:40  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 280 to SCA 0
+2016-10-13 20:57:40  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 320 to SCA 0
+2016-10-13 20:57:40  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 360 to SCA 0
+2016-10-13 20:57:41  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 400 to SCA 0
+2016-10-13 20:57:41  gcpcorrelate    29481 process_gcp.c            694  INFO Points inside image 408, Number used 408, Last used 0
+2016-10-13 20:57:41  gcpcorrelate    29481 process_gcp.c            759  INFO 318 of 408 points correlated
+2016-10-13 20:57:41  gcpcorrelate    29481 GCPcorrelate.c           151  INFO Successful completion
+ 
+gcpcorrelate execution completed with status of 0
+ 
+Thu Oct 13 20:57:41 AEDT 2016
+Thu Oct 13 20:57:42 AEDT 2016
+ 
+L8 Precision Correction (L8PRECISION_SOLVE)
+ 
+2016-10-13 20:57:42  correct_los_model    29494 correct_los_model.c      116  INFO Initiated correct_los_model
+2016-10-13 20:57:43  correct_los_model    29494 correct_los_model.c      298  INFO Finished getting satellite time and position
+2016-10-13 20:57:44  correct_los_model    29494 correct_los_model.c      369  INFO Finished calculating the precision corrections
+2016-10-13 20:57:44  correct_los_model    29494 correct_los_model.c      402  INFO Pre-fit RMS residuals:   X =  11.154 meters  Y =   8.346 meters
+2016-10-13 20:57:44  correct_los_model    29494 correct_los_model.c      405  INFO Post-fit RMS residuals:  X =   4.256 meters  Y =   4.797 meters
+2016-10-13 20:57:44  correct_los_model    29494 correct_los_model.c      409  INFO GCP Outlier Percentage:  11.01 percent
+2016-10-13 20:57:45  correct_los_model    29494 correct_los_model.c      544  INFO Successful completion
+ 
+correct_los_model exection completed with status of 0
+ 
+Thu Oct 13 20:57:45 AEDT 2016
+Thu Oct 13 20:57:47 AEDT 2016
+ 
+Geodetic Accuracy Characterization (GEODETIC)
+ 
+2016-10-13 20:57:47  geodetic    29518 geodetic_char.c           89  INFO Geodetic Accuracy Assessment initiated
+2016-10-13 20:57:47  geodetic    29518 geodetic_char.c          235  INFO Successful Completion
+ 
+geodetic execution completed with status of 0
+ 
+Thu Oct 13 20:57:47 AEDT 2016
+Thu Oct 13 20:57:49 AEDT 2016
+ 
+Create Grid for Precision (L8GRID_PREC)
+ 
+2016-10-13 20:57:49  create_grid    29543 get_parms_and_initialize_grid.c    1228  INFO Pixel origin will be 'UL'
+2016-10-13 20:57:49  create_grid    29543 create_grid.c            173  INFO Initiate Create Grid...
+2016-10-13 20:57:49  create_grid    29543 create_grid.c            284  INFO Elevation range   -40.00   419.00
+2016-10-13 20:57:49  create_grid    29543 pad_corners.c             58  INFO Scene padding size is 25.000000
+2016-10-13 20:57:49  create_grid    29543 get_frame_minbox.c       189  INFO 123825.000000 351750.000000 6687925.000000 6918600.000000
+
+2016-10-13 20:57:49  create_grid    29543 build_grid.c             259  INFO Processing band number 1
+2016-10-13 20:57:52  create_grid    29543 build_grid.c             259  INFO Processing band number 2
+2016-10-13 20:57:53  create_grid    29543 build_grid.c              93  INFO Writing grid band number 1
+2016-10-13 20:57:55  create_grid    29543 build_grid.c             259  INFO Processing band number 3
+2016-10-13 20:57:56  create_grid    29543 build_grid.c              93  INFO Writing grid band number 2
+2016-10-13 20:57:58  create_grid    29543 build_grid.c             259  INFO Processing band number 4
+2016-10-13 20:57:59  create_grid    29543 build_grid.c              93  INFO Writing grid band number 3
+2016-10-13 20:58:02  create_grid    29543 build_grid.c             259  INFO Processing band number 5
+2016-10-13 20:58:02  create_grid    29543 build_grid.c              93  INFO Writing grid band number 4
+2016-10-13 20:58:05  create_grid    29543 build_grid.c             259  INFO Processing band number 6
+2016-10-13 20:58:06  create_grid    29543 build_grid.c              93  INFO Writing grid band number 5
+2016-10-13 20:58:08  create_grid    29543 build_grid.c             259  INFO Processing band number 7
+2016-10-13 20:58:09  create_grid    29543 build_grid.c              93  INFO Writing grid band number 6
+2016-10-13 20:58:12  create_grid    29543 build_grid.c             259  INFO Processing band number 8
+2016-10-13 20:58:13  create_grid    29543 build_grid.c              93  INFO Writing grid band number 7
+2016-10-13 20:58:15  create_grid    29543 build_grid.c             259  INFO Processing band number 9
+2016-10-13 20:58:16  create_grid    29543 build_grid.c              93  INFO Writing grid band number 8
+2016-10-13 20:58:18  create_grid    29543 build_grid.c             259  INFO Processing band number 10
+2016-10-13 20:58:19  create_grid    29543 build_grid.c             259  INFO Processing band number 11
+2016-10-13 20:58:19  create_grid    29543 build_grid.c              93  INFO Writing grid band number 9
+2016-10-13 20:58:22  create_grid    29543 build_grid.c              93  INFO Writing grid band number 10
+2016-10-13 20:58:25  create_grid    29543 build_grid.c              93  INFO Writing grid band number 11
+2016-10-13 20:58:25  create_grid    29543 create_grid.c            869  INFO Writing output grid file headers
+2016-10-13 20:58:25  create_grid    29543 create_grid.c            929  INFO Successful completion
+ 
+create_grid execution completed with status of 0
+ 
+Thu Oct 13 20:58:25 AEDT 2016
+Thu Oct 13 20:58:27 AEDT 2016
+ 
+Grid Terrain Second Pass (GRID_TERRAIN_PASS2)
+ 
+2016-10-13 20:58:27  Makegeomgrid    29746 make_geom_grid.c         100  INFO Initiated
+2016-10-13 20:58:27  Makegeomgrid    29746 make_geom_grid.c         189  INFO Using band number 6 from the TARGET_FRAME_FILE
+2016-10-13 20:58:27  Makegeomgrid    29746 make_geom_grid.c         607  INFO Successful Completion
+ 
+makegeomgrid execution completed with status of 0
+ 
+Thu Oct 13 20:58:27 AEDT 2016
+Thu Oct 13 20:58:29 AEDT 2016
+ 
+Resample Terrain Second Pass (RESAMPLE_TERRAIN_PASS2)
+ 
+2016-10-13 20:58:29  Geomresample    29762 geomresample.c            93  INFO Geometric Resample Initiated
+2016-10-13 20:58:29  Geomresample    29762 geomresample.c           112  INFO Reading Grid
+2016-10-13 20:58:29  Geomresample    29762 geomresample.c           219  INFO Resampling band 1
+2016-10-13 20:58:29  Geomresample    29762 scanman.c                250  INFO resampling lines 0 through 800
+2016-10-13 20:58:30  Geomresample    29762 scanman.c                250  INFO resampling lines 650 through 1450
+2016-10-13 20:58:30  Geomresample    29762 scanman.c                250  INFO resampling lines 1300 through 2100
+2016-10-13 20:58:30  Geomresample    29762 scanman.c                250  INFO resampling lines 1950 through 2750
+2016-10-13 20:58:30  Geomresample    29762 scanman.c                250  INFO resampling lines 2600 through 3400
+2016-10-13 20:58:30  Geomresample    29762 scanman.c                250  INFO resampling lines 3250 through 4050
+2016-10-13 20:58:30  Geomresample    29762 scanman.c                250  INFO resampling lines 3900 through 4700
+2016-10-13 20:58:31  Geomresample    29762 scanman.c                250  INFO resampling lines 4550 through 5350
+2016-10-13 20:58:31  Geomresample    29762 scanman.c                250  INFO resampling lines 5200 through 6000
+2016-10-13 20:58:31  Geomresample    29762 scanman.c                250  INFO resampling lines 5850 through 6650
+2016-10-13 20:58:31  Geomresample    29762 scanman.c                250  INFO resampling lines 6500 through 7300
+2016-10-13 20:58:32  Geomresample    29762 scanman.c                250  INFO resampling lines 7150 through 7950
+2016-10-13 20:58:32  Geomresample    29762 scanman.c                250  INFO resampling lines 7800 through 8600
+2016-10-13 20:58:32  Geomresample    29762 scanman.c                250  INFO resampling lines 8450 through 9250
+2016-10-13 20:58:33  Geomresample    29762 scanman.c                250  INFO resampling lines 9100 through 9900
+2016-10-13 20:58:33  Geomresample    29762 scanman.c                250  INFO resampling lines 9750 through 10550
+2016-10-13 20:58:33  Geomresample    29762 scanman.c                250  INFO resampling lines 10400 through 11200
+2016-10-13 20:58:33  Geomresample    29762 scanman.c                250  INFO resampling lines 11050 through 11850
+2016-10-13 20:58:33  Geomresample    29762 scanman.c                250  INFO resampling lines 11700 through 12500
+2016-10-13 20:58:34  Geomresample    29762 scanman.c                250  INFO resampling lines 12350 through 13093
+2016-10-13 20:58:34  Geomresample    29762 geomresample.c           330  INFO Geometric Resample Successful Completion
+ 
+geomresample execution completed with status of 0
+ 
+Thu Oct 13 20:58:34 AEDT 2016
+Thu Oct 13 20:58:35 AEDT 2016
+ 
+L8 Resample Precision (L8RESAMPLE_PREC)
+ 
+2016-10-13 20:58:35  Resample    29793 resample.c               115  INFO Initiated
+2016-10-13 20:58:36  Resample    29793 process_band.c            80  INFO Resampling band number 1
+2016-10-13 20:59:14  Resample    29793 process_band.c            80  INFO Resampling band number 2
+2016-10-13 20:59:56  Resample    29793 process_band.c            80  INFO Resampling band number 3
+2016-10-13 21:00:33  Resample    29793 process_band.c            80  INFO Resampling band number 4
+2016-10-13 21:01:13  Resample    29793 process_band.c            80  INFO Resampling band number 5
+2016-10-13 21:01:52  Resample    29793 process_band.c            80  INFO Resampling band number 6
+2016-10-13 21:02:30  Resample    29793 process_band.c            80  INFO Resampling band number 7
+2016-10-13 21:03:03  Resample    29793 process_band.c            80  INFO Resampling band number 8
+2016-10-13 21:05:36  Resample    29793 process_band.c            80  INFO Resampling band number 9
+2016-10-13 21:06:07  Resample    29793 process_band.c            80  INFO Resampling band number 10
+2016-10-13 21:06:40  Resample    29793 process_band.c            80  INFO Resampling band number 11
+2016-10-13 21:07:10  Resample    29793 resample.c               789  INFO Successful Completion
+ 
+resample execution completed with status of 0
+ 
+Thu Oct 13 21:07:10 AEDT 2016
+Thu Oct 13 21:07:12 AEDT 2016
+ 
+L8 GCP Correlation for Precision Second Pass (L8PRECISION_GCP_PASS2)
+ 
+2016-10-13 21:07:12  gcpcorrelate    30362 GCPcorrelate.c            84  INFO Initiated
+2016-10-13 21:07:12  gcpcorrelate    30362 GCPcorrelate.c            87  INFO Reading gcp_lib/GCPLib
+2016-10-13 21:07:12  gcpcorrelate    30362 ias_gcp_read_gcplib.c     292  INFO Reading gcp_lib/GCPLib
+2016-10-13 21:07:12  gcpcorrelate    30362 ias_gcp_read_gcplib.c     313  INFO Read 408 GCPs
+2016-10-13 21:07:12  gcpcorrelate    30362 ias_gcp_read_gcplib.c     135  INFO Pixel alignment will be 'UL', hemisphere is 'S', datum = 'GDA_94'
+2016-10-13 21:07:12  gcpcorrelate    30362 GCPcorrelate.c           116  INFO Read 408 GCPs
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            236  INFO Processing 1 SCA(s) in image l1t.h5
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            375  INFO Using image chips from gcp_lib
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 0 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800156 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800374 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800184 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800061 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800142 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800367 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800305 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800194 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800116 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800379 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800252 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800370 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800361 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800113 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800090 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800060 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800327 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800259 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800198 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800378 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800042 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800393 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800025 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800328 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800261 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800039 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800139 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800188 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800024 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800056 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800206 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800064 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800217 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800164 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800015 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800363 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800218 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800291 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800301 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800020 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 40 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800284 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800197 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800294 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800234 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800272 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800009 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800154 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800346 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800058 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800038 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800109 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800005 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800223 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800114 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800099 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800022 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800317 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800120 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800176 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800250 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800322 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800130 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800246 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800028 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800092 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800210 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800170 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800135 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800107 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800225 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800310 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800131 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800079 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800260 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800040 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800181 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800100 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800345 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800076 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800125 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 80 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800012 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800175 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800354 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800282 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800018 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800240 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800088 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800280 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800073 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800117 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800318 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800375 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800033 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800239 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800035 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800150 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800059 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800147 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800074 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800362 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800377 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800172 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800032 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800249 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800288 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800395 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800245 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800192 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800258 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800050 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800075 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800340 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800004 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800148 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800081 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800247 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800315 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800337 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800266 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800052 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 120 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800201 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800065 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800224 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800145 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800338 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800086 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800205 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800163 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800271 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800091 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800066 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800041 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800263 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800143 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800069 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800037 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800297 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800119 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800264 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800230 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800231 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800151 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800110 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800391 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800278 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800190 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800355 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800002 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800057 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800146 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800168 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800098 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800084 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800102 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800221 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800166 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800289 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800352 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800237 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800296 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 160 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800128 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800277 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800106 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800394 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800101 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800017 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800406 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800158 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800254 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800108 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800169 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800211 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800085 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800356 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800177 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800202 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800093 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800126 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800123 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800178 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800314 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800072 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800173 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800381 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800220 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800403 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800311 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800319 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800010 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800019 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800400 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800236 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800044 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800062 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800384 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800267 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800304 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800273 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800321 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800227 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 200 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800121 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800144 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800115 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800386 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800342 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800171 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800083 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800161 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800251 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800281 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800071 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800390 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800193 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800335 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800348 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800136 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800360 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800174 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800298 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800213 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800129 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800183 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800134 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800215 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800388 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800330 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800292 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800248 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800182 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800396 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800089 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800299 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800212 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800034 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800257 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800207 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800047 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800255 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800339 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800419 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 240 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800068 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800343 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800222 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800167 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800372 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800195 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800233 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800313 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800031 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800235 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800006 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800373 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800189 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800295 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800208 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800138 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800080 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800347 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800104 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800358 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800268 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800132 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800013 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800199 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800269 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800275 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800325 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800127 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800229 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800357 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800320 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800293 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800232 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800054 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800111 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800279 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800265 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800341 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800287 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800118 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 280 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800124 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800141 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800187 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800368 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800228 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800001 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800140 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800155 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800014 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800308 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800196 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800369 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800326 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800112 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800048 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800276 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800316 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800046 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800380 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800094 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800003 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800398 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800149 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800331 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800152 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800336 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800133 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800055 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800097 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800021 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800185 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800385 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800165 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800027 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800290 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800137 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800366 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800179 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800191 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800051 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 320 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800382 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800200 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800333 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800204 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800365 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800371 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800043 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800383 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800323 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800226 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800306 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800351 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800392 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800359 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800334 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800399 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800159 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800045 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800096 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800303 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800387 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800067 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800008 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800016 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800186 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800030 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800162 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800241 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800350 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800302 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800283 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800397 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800103 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800153 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800312 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800349 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800082 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800011 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800216 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800332 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 360 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800244 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800242 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800344 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800087 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800353 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800389 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800270 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800324 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800238 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800243 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800023 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800364 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800274 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800105 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800077 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800253 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800286 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800285 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800122 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800029 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800307 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800063 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800219 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800095 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800007 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800157 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800300 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800070 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800214 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800078 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800180 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800053 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800036 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800376 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800407 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800026 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800049 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800405 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800309 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800160 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 400 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800404 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800203 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800262 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800402 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800209 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800418 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800416 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800329 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            694  INFO Points inside image 0, Number used 0, Last used 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            755  WARN No points correlated successfully
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            759  INFO 0 of 408 points correlated
+2016-10-13 21:07:12  gcpcorrelate    30362 GCPcorrelate.c           151  INFO Successful completion
+ 
+gcpcorrelate execution completed with status of 0
+ 
+Thu Oct 13 21:07:12 AEDT 2016
+Thu Oct 13 21:07:14 AEDT 2016
+ 
+Geometric Accuracy Characterization (GEOMETRIC)
+ 
+2016-10-13 21:07:14  geometric    30375 geometric_char.c         104  INFO Geometric Accuracy Assessment Characterization initiated
+2016-10-13 21:07:14  geometric    30375 geometric_char.c         143  WARN Number of correlated validation GCPs read 0 is below the minimum threshold 20, so geometric results should not be used
+ 
+geometric execution completed with status of 0
+ 
+Thu Oct 13 21:07:14 AEDT 2016
+Thu Oct 13 21:07:17 AEDT 2016
+ 
+Terrain Occlusion (TERRAIN_OCCLUSION)
+ 
+2016-10-13 21:07:17  terrain_occlusion    30387 terrain_occlusion.c       86  INFO Initiate ...
+2016-10-13 21:07:20  terrain_occlusion    30387 terrain_occlusion.c      269  INFO Elevation range on unresampled DEM: -40 to 419
+
+2016-10-13 21:07:20  terrain_occlusion    30387 occlusion_threading.c     348  INFO Starting terrain occlusion with 4 threads
+2016-10-13 21:07:20  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 0
+2016-10-13 21:07:22  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 1
+2016-10-13 21:07:23  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 2
+2016-10-13 21:07:25  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 3
+2016-10-13 21:07:26  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 4
+2016-10-13 21:07:27  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 5
+2016-10-13 21:07:29  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 6
+2016-10-13 21:07:30  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 7
+2016-10-13 21:07:31  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 8
+2016-10-13 21:07:32  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 9
+2016-10-13 21:07:33  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 10
+2016-10-13 21:07:34  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 11
+2016-10-13 21:07:35  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 12
+2016-10-13 21:07:36  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 13
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 0: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 1: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 2: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 3: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 4: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 5: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 6: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 7: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 8: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 9: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 10: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 11: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 12: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 13: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     381  INFO Total occluded pixels: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 write_l1g.c               61  INFO Writing occlusion file occlusion_mask.h5
+2016-10-13 21:07:38  terrain_occlusion    30387 terrain_occlusion.c      330  INFO Successful completion.
+ 
+terrain_occlusion execution completed with a status of 0
+ 
+Thu Oct 13 21:07:39 AEDT 2016
+Thu Oct 13 21:07:40 AEDT 2016
+ 
+Assess Cloud Cover (ASSESS_CLOUD_COVER)
+ 
+2016-10-13 21:07:40  assess_cloud_cover    30473 assess_cloud_cover.c    2061  INFO assess_cloud_cover l1t.h5
+2016-10-13 21:07:40  assess_cloud_cover    30473 ias_cpf_parse_cloud_cover_assessment.c     122  WARN Only 1 parameter read in from the CPF for Cirrus Threshold
+2016-10-13 21:07:40  assess_cloud_cover    30473 algorithm.c              359  INFO Using ACCA algorithm
+2016-10-13 21:07:40  assess_cloud_cover    30473 algorithm.c              359  INFO Using Cirrus algorithm
+2016-10-13 21:07:40  assess_cloud_cover    30473 algorithm.c              359  INFO Using See5 algorithm
+2016-10-13 21:07:44  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line    0/9228 (0%)
+2016-10-13 21:07:47  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line  922/9228 (10%)
+2016-10-13 21:07:52  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 1844/9228 (20%)
+2016-10-13 21:07:57  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 2766/9228 (30%)
+2016-10-13 21:08:04  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 3688/9228 (40%)
+2016-10-13 21:08:08  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 4610/9228 (50%)
+2016-10-13 21:08:12  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 5532/9228 (60%)
+2016-10-13 21:08:17  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 6454/9228 (70%)
+2016-10-13 21:08:22  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 7376/9228 (80%)
+2016-10-13 21:08:26  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 8298/9228 (90%)
+2016-10-13 21:08:28  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 9220/9228 (100%)
+2016-10-13 21:08:28  assess_cloud_cover    30473 assess_cloud_cover.c    1633  INFO Processing line 9228/9228 (100%)
+2016-10-13 21:08:28  assess_cloud_cover    30473 assess_cloud_cover.c    1971  INFO Cloud Score l1t.h5: 5.48%
+2016-10-13 21:08:28  assess_cloud_cover    30473 assess_cloud_cover.c    1972  INFO Snow/Ice Score l1t.h5: 0.16%
+2016-10-13 21:08:28  assess_cloud_cover    30473 assess_cloud_cover.c    1974  INFO Land Cloud Cover Score l1t.h5: 0.09%
+2016-10-13 21:08:28  assess_cloud_cover    30473 assess_cloud_cover.c    1975  INFO Created quality band image: quality_band.h5
+2016-10-13 21:08:28  assess_cloud_cover    30473 assess_cloud_cover.c    1976  INFO assess_cloud_cover took 48 seconds
+ 
+assess_cloud_cover execution completed with a status of 0
+ 
+Thu Oct 13 21:08:28 AEDT 2016
+Thu Oct 13 21:08:30 AEDT 2016
+ 
+DMS Format and Package (DFP)
+ 
+2016-10-13 21:08:30  format_and_package    30607 format_and_package.c     244  INFO DMS Format & Package started
+2016-10-13 21:08:30  format_and_package    30607 format_and_package.c     245  INFO Pixel origin is UL
+2016-10-13 21:08:30  format_and_package    30607 convert_band.c            92  INFO Converting band 1
+2016-10-13 21:08:31  format_and_package    30607 convert_band.c            92  INFO Converting band 2
+2016-10-13 21:08:33  format_and_package    30607 convert_band.c            92  INFO Converting band 3
+2016-10-13 21:08:35  format_and_package    30607 convert_band.c            92  INFO Converting band 4
+2016-10-13 21:08:36  format_and_package    30607 convert_band.c            92  INFO Converting band 5
+2016-10-13 21:08:37  format_and_package    30607 convert_band.c            92  INFO Converting band 6
+2016-10-13 21:08:39  format_and_package    30607 convert_band.c            92  INFO Converting band 7
+2016-10-13 21:08:40  format_and_package    30607 convert_band.c            92  INFO Converting band 8
+2016-10-13 21:08:45  format_and_package    30607 convert_band.c            92  INFO Converting band 9
+2016-10-13 21:08:47  format_and_package    30607 convert_band.c            92  INFO Converting band 10
+2016-10-13 21:08:49  format_and_package    30607 convert_band.c            92  INFO Converting band 11
+2016-10-13 21:08:51  format_and_package    30607 convert_band.c            95  INFO Converting quality band
+2016-10-13 21:08:53  format_and_package    30607 format_and_package.c     532  INFO Creating the angle coefficients file
+2016-10-13 21:08:53  format_and_package    30607 write_metadata.c        1557  INFO Creating the L1G metadata file
+2016-10-13 21:08:53  format_and_package    30607 format_and_package.c     616  INFO Successful completion of DMS Format & Package
+ 
+format_and_package execution completed with status of 0
+ 
+Thu Oct 13 21:08:53 AEDT 2016

--- a/integration_tests/data/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926/additional/OLI_TIRS_subsetter.log
+++ b/integration_tests/data/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926/additional/OLI_TIRS_subsetter.log
@@ -1,0 +1,5 @@
+CMD = '"/projects/v10/PinkMatter/LPGS4.1.4110/build/LAM/ot_subsetter" LC81140740812016270LGN00 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_080_080" --scene LC81140802016270LGN00'
+-------------------------------------------------------
+2016-10-13 20:52:15  Subsetter    27827 src/OTS/ot_subsetter.c     231  INFO scene_id LC81140802016270LGN00
+2016-10-13 20:52:15  Subsetter    27827 src/OTS/ot_subroutines.c    1730  INFO oli start: 34288
+2016-10-13 20:52:15  Subsetter    27827 src/OTS/ot_subroutines.c    1731  INFO oli stop: 41788

--- a/integration_tests/data/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926/additional/landsat-processor.log
+++ b/integration_tests/data/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926/additional/landsat-processor.log
@@ -1,0 +1,7611 @@
+2016-10-13T20:42:06 ComServer.cpp 90: INFO: Trying to host communication server on port '15000'
+2016-10-13T20:42:06 SystemSpecLogThread.cpp 73: WARN: Failed to obtain all system logs
+--------------------------------------------------
+----------------SYSTEM SPECS BEGIN----------------
+--------------------------------------------------
+---------------
+/proc/cpuinfo
+---------------
+processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 0
+cpu cores	: 8
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 1
+cpu cores	: 8
+apicid		: 2
+initial apicid	: 2
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 2
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 2
+cpu cores	: 8
+apicid		: 4
+initial apicid	: 4
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 3
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 3
+cpu cores	: 8
+apicid		: 6
+initial apicid	: 6
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 4
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 4
+cpu cores	: 8
+apicid		: 8
+initial apicid	: 8
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 5
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 5
+cpu cores	: 8
+apicid		: 10
+initial apicid	: 10
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 6
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 6
+cpu cores	: 8
+apicid		: 12
+initial apicid	: 12
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 7
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 7
+cpu cores	: 8
+apicid		: 14
+initial apicid	: 14
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 8
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 0
+cpu cores	: 8
+apicid		: 32
+initial apicid	: 32
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 9
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 1
+cpu cores	: 8
+apicid		: 34
+initial apicid	: 34
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 10
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 2
+cpu cores	: 8
+apicid		: 36
+initial apicid	: 36
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 11
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 3
+cpu cores	: 8
+apicid		: 38
+initial apicid	: 38
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 12
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 4
+cpu cores	: 8
+apicid		: 40
+initial apicid	: 40
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 13
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 5
+cpu cores	: 8
+apicid		: 42
+initial apicid	: 42
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 14
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 6
+cpu cores	: 8
+apicid		: 44
+initial apicid	: 44
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 15
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 7
+cpu cores	: 8
+apicid		: 46
+initial apicid	: 46
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 16
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 0
+cpu cores	: 8
+apicid		: 1
+initial apicid	: 1
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 17
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 1
+cpu cores	: 8
+apicid		: 3
+initial apicid	: 3
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 18
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 2
+cpu cores	: 8
+apicid		: 5
+initial apicid	: 5
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 19
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 3
+cpu cores	: 8
+apicid		: 7
+initial apicid	: 7
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 20
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 4
+cpu cores	: 8
+apicid		: 9
+initial apicid	: 9
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 21
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 5
+cpu cores	: 8
+apicid		: 11
+initial apicid	: 11
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 22
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 6
+cpu cores	: 8
+apicid		: 13
+initial apicid	: 13
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 23
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 7
+cpu cores	: 8
+apicid		: 15
+initial apicid	: 15
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 24
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 0
+cpu cores	: 8
+apicid		: 33
+initial apicid	: 33
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 25
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 1
+cpu cores	: 8
+apicid		: 35
+initial apicid	: 35
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 26
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 2
+cpu cores	: 8
+apicid		: 37
+initial apicid	: 37
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 27
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 3
+cpu cores	: 8
+apicid		: 39
+initial apicid	: 39
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 28
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 4
+cpu cores	: 8
+apicid		: 41
+initial apicid	: 41
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 29
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 5
+cpu cores	: 8
+apicid		: 43
+initial apicid	: 43
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 30
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 6
+cpu cores	: 8
+apicid		: 45
+initial apicid	: 45
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 31
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 7
+cpu cores	: 8
+apicid		: 47
+initial apicid	: 47
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+
+---------------
+/proc/meminfo
+---------------
+MemTotal:       32987140 kB
+MemFree:        18408804 kB
+Buffers:            1888 kB
+Cached:         10703376 kB
+SwapCached:        64384 kB
+Active:          3611468 kB
+Inactive:        7153440 kB
+Active(anon):      24972 kB
+Inactive(anon):    88320 kB
+Active(file):    3586496 kB
+Inactive(file):  7065120 kB
+Unevictable:       51816 kB
+Mlocked:               0 kB
+SwapTotal:      12000252 kB
+SwapFree:       11905224 kB
+Dirty:             11868 kB
+Writeback:             0 kB
+AnonPages:         84520 kB
+Mapped:            15632 kB
+Shmem:                40 kB
+Slab:            2977688 kB
+SReclaimable:     104508 kB
+SUnreclaim:      2873180 kB
+KernelStack:       17088 kB
+PageTables:         3728 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:    28493820 kB
+Committed_AS:     745792 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:      550096 kB
+VmallocChunk:   34340571272 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:         0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+DirectMap4k:        4096 kB
+DirectMap2M:     2084864 kB
+DirectMap1G:    31457280 kB
+
+---------------
+/proc/swaps
+---------------
+Filename				Type		Size	Used	Priority
+/dev/sda2                               partition	12000252	95028	-1
+
+---------------
+/proc/version
+---------------
+Linux version 2.6.32-642.1.1.el6.x86_64 (mockbuild@worker1.bsys.centos.org) (gcc version 4.4.7 20120313 (Red Hat 4.4.7-17) (GCC) ) #1 SMP Tue May 31 21:57:07 UTC 2016
+
+---------------
+export
+---------------
+export BASH_ENV="/home/547/lpgs/.bashrc"
+export BBCP_BASE="/apps/bbcp/15.02.03.01.1"
+export BBCP_ROOT="/apps/bbcp/15.02.03.01.1"
+export BBCP_VERSION="15.02.03.01.1"
+export BLAS="/g/data/v10/private/modules/core/lib64/libblas.so"
+export CC="gcc"
+export CONCURRENT_LPGS_SCENES="15"
+export CPATH="/g/data/v10/private/modules/core/include"
+export CSV_FILE="/g/data/v10/reprocess/work/ls8/level1/2016/log/20161013T152002/0/datasets.csv"
+export CXX="g++"
+export EDITOR="vim"
+export ENV="/home/547/lpgs/.bashrc"
+export ENVIRONMENT="BATCH"
+export FPATH="/opt/Modules/krutsh/commands"
+export GCC_BASE="/apps/gcc/5.2.0"
+export GCC_ROOT="/apps/gcc/5.2.0"
+export GCC_VERSION="5.2.0"
+export GDAL_DATA="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/gdal/share/gdal"
+export GDAL_DRIVER_PATH="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/gdal/gdalplugins"
+export GEOTIFF_CSV="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/libgeotiff/share/epsg_csv"
+export HDF5_PLUGIN_PATH="/g/data/v10/private/modules/core/hdf5-plugins/lib/plugin"
+export HISTSIZE="1000"
+export HOME="/home/547/lpgs"
+export HOST="r2353"
+export HOSTNAME="r2353"
+export HPCLPGS_HOME="/projects/v10/NEMO/hpc-lpgs"
+export IASBIN="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/bin"
+export IASDEM="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/GEOID"
+export IASSYS="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/share/sys"
+export IASYS="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/share/sys"
+export IAS_BIN="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/bin"
+export IAS_BIN2="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS2/bin"
+export IAS_DATA_DIR2="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS2/share"
+export IAS_SERVICES="DUMMY"
+export IAS_SYS_DIR2="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS2"
+export INFOPATH="/g/data/v10/private/modules/core/share/info"
+export INPUTRC="/etc/inputrc"
+export JPLDE421="/projects/v10/PinkMatter/LPGS4.1.4110/build/COTS64/novas3.1/data/lnxp1900p2053.421"
+export LANDSAT_INSTALL_DIR="/projects/v10/PinkMatter/LPGS4.1.4110"
+export LANG="C.UTF-8"
+export LAPACK="/g/data/v10/private/modules/core/lib64/liblapack.so"
+export LC_ALL="en_AU.utf8"
+export LD_LIBRARY_PATH="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/COTS64/unixodbc/lib64:/projects/v10/PinkMatter/LPGS4.1.4110/build/LACS/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/LAM/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/DPAS/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/tiff/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/libgeotiff/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/openjpeg/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/OpenThreads/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/allegro/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/proj4/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/geos/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/gdal/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/fann/lib"
+export LD_RUN_PATH="/apps/gcc/5.2.0/lib64"
+export LEAP_SECONDS_FILE="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/LeapSeconds/leap_seconds.odl"
+export LEVEL1_MODE="LPGS"
+export LIBRARY_PATH="/g/data/v10/private/modules/core/lib64:/g/data/v10/private/modules/core/lib:/apps/gcc/5.2.0/lib64"
+export LOADEDMODULES="pbs:bbcp/15.02.03.01.1:gcc/5.2.0:core/1.0:eodatasets/0.8:gaip/4.2.2:galpgs-py2-env/1.3.7"
+export LOGNAME="lpgs"
+export LOG_PATH="/g/data/v10/reprocess/work/ls8/level1/2016/log/20161013T152002/0"
+export LPGS_NOTIFY_EMAIL="Earth.Observation@ga.gov.au"
+export LPGS_SYS_DIR2="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS2"
+export LPS_TABLE_PATH="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPS/tables"
+export LP_MAX_PORT="15025"
+export LP_MIN_PORT="15000"
+export LUIGI_WORKERS="12"
+export MACHTYPE="x86_64"
+export MAIL="/var/spool/mail/lpgs"
+export MANPATH="/g/data/v10/private/modules/core/share/man:/apps/gcc/5.2.0/share/man:/opt/pbs/default/man:/usr/share/man:/opt/man:/opt/Modules/default/man"
+export MODULEPATH="/g/data/v10/private/modules/modulefiles:/projects/u46/opt/modules/modulefiles:/projects/u46/opt/modules/modulefiles:/apps/.mf:/opt/Modules/modulefiles:/apps/Modules/modulefiles:"
+export MODULESHOME="/opt/Modules/3.2.6"
+export MODULE_VERSION="3.2.6"
+export MODULE_VERSION_STACK="3.2.6"
+export NCPUS="16"
+export NF_MODULES_LOADED="YES"
+export OLDPWD
+export OMP_NUM_THREADS="1"
+export OPSBIN="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/bin"
+export OSSIM_BIN="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/bin"
+export OSSIM_INC="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/include"
+export OSSIM_LIB="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/lib"
+export OSSIM_PREFS_FILE="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/ossim_preferences"
+export PATH="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/libgeotiff/bin:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/tiff/bin:/projects/v10/PinkMatter/LPGS4.1.4110/build/landsat_Pinkmatter:/g/data/v10/private/modules/galpgs-py2-env/1.3.7/bin:/g/data/v10/private/modules/gaip/4.2.2/ga-neo-landsat-processor/workflow:/g/data/v10/private/modules/eodatasets/0.8/bin:/g/data/v10/private/modules/core/bin:/apps/gcc/5.2.0/wrapper:/apps/gcc/5.2.0/bin:/projects/v10/NEMO/hpc-lpgs/bin:/home/547/lpgs/bin:/home/547/lpgs/local/bin:/apps/bbcp/15.02.03.01.1/bin:/opt/bin:/bin:/usr/bin:/opt/pbs/default/bin:/projects/v10/PinkMatter/LPGS4.1.4110/build/LAM/perl5lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/bin:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/gdal/bin"
+export PBS_ENVIRONMENT="PBS_BATCH"
+export PBS_JOBCOOKIE="000000003DFF07AD00000000697E2079"
+export PBS_JOBDIR="/home/547/lpgs"
+export PBS_JOBFS="/jobfs/local/9456756.r-man2"
+export PBS_JOBID="9456756.r-man2"
+export PBS_JOBNAME="ls8-2016-lvl1-0"
+export PBS_MOMPORT="15003"
+export PBS_NCI_FS_GDATA1="1"
+export PBS_NCI_FS_GDATA2="1"
+export PBS_NCI_FS_GDATA3="1"
+export PBS_NCI_HT="0"
+export PBS_NCI_JOBFS_GLOBAL="966367641600b"
+export PBS_NCI_WD="1"
+export PBS_NCPUS="32"
+export PBS_NGPUS="0"
+export PBS_NODENUM="1"
+export PBS_O_HOME="/home/547/lpgs"
+export PBS_O_HOST="raijin1"
+export PBS_O_LANG="C.UTF-8"
+export PBS_O_LOGNAME="lpgs"
+export PBS_O_MAIL="/var/spool/mail/lpgs"
+export PBS_O_PATH="/g/data/v10/private/modules/galpgs-py2-env/1.3.7/bin:/g/data/v10/private/modules/gaip/4.2.2/ga-neo-landsat-processor/workflow:/g/data/v10/private/modules/eodatasets/0.8/bin:/g/data/v10/private/modules/core/bin:/apps/gcc/5.2.0/wrapper:/apps/gcc/5.2.0/bin:/projects/v10/NEMO/hpc-lpgs/bin:/home/547/lpgs/bin:/home/547/lpgs/local/bin:/apps/bbcp/15.02.03.01.1/bin:/opt/bin:/bin:/usr/bin:/opt/pbs/default/bin"
+export PBS_O_QUEUE="normal"
+export PBS_O_SHELL="/bin/bash"
+export PBS_O_SYSTEM="Linux"
+export PBS_O_WORKDIR="/g/data/v10/projects/gaip-scripts"
+export PBS_QUEUE="normal-def"
+export PBS_TASKNUM="04000001"
+export PBS_VMEM="68719476736"
+export PERL5LIB="/projects/v10/PinkMatter/LPGS4.1.4110/build/landsat_Pinkmatter/perl5lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/perl/lib/5.10.0/x86_64-linux-thread-multi:/projects/v10/PinkMatter/LPGS4.1.4110/build/COTS/lib/perl:/projects/v10/PinkMatter/LPGS4.1.4110/build/perl/lib"
+export PINKMATTER_LPGS_HOME="/projects/v10/PinkMatter/LPGS3616"
+export PKG_CONFIG_PATH="/g/data/v10/private/modules/core/lib64/pkgconfig:/g/data/v10/private/modules/core/lib/pkgconfig"
+export PROCESSING_CENTER="GA"
+export PROCESSING_SYSTEM="LPGS_LDCM"
+export PROJECT="v10"
+export PROJ_LIB="/g/data/v10/private/modules/core/lib/python2.7/site-packages/rasterio/proj_data"
+export PWD="/short/global_jobfs/9456756.r-man2/r2353/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work"
+export PYTHONPATH="/g/data/v10/private/modules/galpgs-py2-env/1.3.7/lib/python2.7/site-packages:/g/data/v10/private/modules/gaip/4.2.2/ga-neo-landsat-processor:/g/data/v10/private/modules/eodatasets/0.8/lib/python2.7/site-packages:/g/data/v10/private/modules/core/lib/python2.7/site-packages:/projects/v10/NEMO/hpc-lpgs/python:"
+export SHLVL="3"
+export STATUS_PATH="/g/data/v10/reprocess/work/ls8/level1/2016/status"
+export TCLLIBPATH="/apps/modext/default/lib/tcl"
+export TMPDIR="/jobfs/local/9456756.r-man2"
+export TMSS_HOME="/projects/v10/PinkMatter/LPGS4.1.4110/build/LAM/TMSS"
+export ULTRA_INSTALL_DIR="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA"
+export USER="lpgs"
+export _="/projects/v10/PinkMatter/LPGS4.1.4110/build/landsat_Pinkmatter/landsat_processor"
+export _LMFILES_="/opt/Modules/modulefiles/pbs:/apps/Modules/modulefiles/bbcp/15.02.03.01.1:/apps/Modules/modulefiles/gcc/5.2.0:/g/data/v10/private/modules/modulefiles/core/1.0:/g/data/v10/private/modules/modulefiles/eodatasets/0.8:/g/data/v10/private/modules/modulefiles/gaip/4.2.2:/g/data/v10/private/modules/modulefiles/galpgs-py2-env/1.3.7"
+export galpgs_module_path="/g/data/v10/private/modules/modulefiles"
+export needed_modules="gaip/4.2.2 galpgs-py2-env/1.3.7"
+
+---------------
+/sbin/ldconfig -p
+---------------
+1246 libs found in cache `/etc/ld.so.cache'
+	libz.so.1 (libc6,x86-64) => /lib64/libz.so.1
+	libz.so.1 (libc6) => /lib/libz.so.1
+	libz.so (libc6,x86-64) => /usr/lib64/libz.so
+	libxtables.so.4 (libc6,x86-64) => /lib64/libxtables.so.4
+	libxslt.so.1 (libc6,x86-64) => /usr/lib64/libxslt.so.1
+	libxslt.so (libc6,x86-64) => /usr/lib64/libxslt.so
+	libxshmfence.so.1 (libc6,x86-64) => /usr/lib64/libxshmfence.so.1
+	libxml2.so.2 (libc6,x86-64) => /usr/lib64/libxml2.so.2
+	libxml2.so (libc6,x86-64) => /usr/lib64/libxml2.so
+	libxmlsec1.so.1 (libc6,x86-64) => /usr/lib64/libxmlsec1.so.1
+	libxmlsec1.so (libc6,x86-64) => /usr/lib64/libxmlsec1.so
+	libxmlsec1-openssl.so.1 (libc6,x86-64) => /usr/lib64/libxmlsec1-openssl.so.1
+	libxmlsec1-openssl.so (libc6,x86-64) => /usr/lib64/libxmlsec1-openssl.so
+	libxmlrpc_util.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_util.so.3
+	libxmlrpc_server_cgi.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_server_cgi.so.3
+	libxmlrpc_server_abyss.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_server_abyss.so.3
+	libxmlrpc_server.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_server.so.3
+	libxmlrpc_client.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_client.so.3
+	libxmlrpc_abyss.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_abyss.so.3
+	libxmlrpc.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc.so.3
+	libxkbfile.so.1 (libc6,x86-64) => /usr/lib64/libxkbfile.so.1
+	libxerces-c-3.0.so (libc6,x86-64) => /usr/lib64/libxerces-c-3.0.so
+	libxdot.so.4 (libc6,x86-64) => /usr/lib64/libxdot.so.4
+	libxcb.so.1 (libc6,x86-64) => /usr/lib64/libxcb.so.1
+	libxcb.so.1 (libc6) => /usr/lib/libxcb.so.1
+	libxcb.so (libc6,x86-64) => /usr/lib64/libxcb.so
+	libxcb-xvmc.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xvmc.so.0
+	libxcb-xvmc.so.0 (libc6) => /usr/lib/libxcb-xvmc.so.0
+	libxcb-xvmc.so (libc6,x86-64) => /usr/lib64/libxcb-xvmc.so
+	libxcb-xv.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xv.so.0
+	libxcb-xv.so.0 (libc6) => /usr/lib/libxcb-xv.so.0
+	libxcb-xv.so (libc6,x86-64) => /usr/lib64/libxcb-xv.so
+	libxcb-xtest.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xtest.so.0
+	libxcb-xtest.so.0 (libc6) => /usr/lib/libxcb-xtest.so.0
+	libxcb-xtest.so (libc6,x86-64) => /usr/lib64/libxcb-xtest.so
+	libxcb-xselinux.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xselinux.so.0
+	libxcb-xselinux.so.0 (libc6) => /usr/lib/libxcb-xselinux.so.0
+	libxcb-xselinux.so (libc6,x86-64) => /usr/lib64/libxcb-xselinux.so
+	libxcb-xkb.so.1 (libc6,x86-64) => /usr/lib64/libxcb-xkb.so.1
+	libxcb-xkb.so.1 (libc6) => /usr/lib/libxcb-xkb.so.1
+	libxcb-xkb.so (libc6,x86-64) => /usr/lib64/libxcb-xkb.so
+	libxcb-xinerama.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xinerama.so.0
+	libxcb-xinerama.so.0 (libc6) => /usr/lib/libxcb-xinerama.so.0
+	libxcb-xinerama.so (libc6,x86-64) => /usr/lib64/libxcb-xinerama.so
+	libxcb-xf86dri.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xf86dri.so.0
+	libxcb-xf86dri.so.0 (libc6) => /usr/lib/libxcb-xf86dri.so.0
+	libxcb-xf86dri.so (libc6,x86-64) => /usr/lib64/libxcb-xf86dri.so
+	libxcb-xfixes.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xfixes.so.0
+	libxcb-xfixes.so.0 (libc6) => /usr/lib/libxcb-xfixes.so.0
+	libxcb-xfixes.so (libc6,x86-64) => /usr/lib64/libxcb-xfixes.so
+	libxcb-xevie.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xevie.so.0
+	libxcb-xevie.so.0 (libc6) => /usr/lib/libxcb-xevie.so.0
+	libxcb-xevie.so (libc6,x86-64) => /usr/lib64/libxcb-xevie.so
+	libxcb-util.so.1 (libc6,x86-64) => /usr/lib64/libxcb-util.so.1
+	libxcb-sync.so.1 (libc6,x86-64) => /usr/lib64/libxcb-sync.so.1
+	libxcb-sync.so.1 (libc6) => /usr/lib/libxcb-sync.so.1
+	libxcb-sync.so (libc6,x86-64) => /usr/lib64/libxcb-sync.so
+	libxcb-shm.so.0 (libc6,x86-64) => /usr/lib64/libxcb-shm.so.0
+	libxcb-shm.so.0 (libc6) => /usr/lib/libxcb-shm.so.0
+	libxcb-shm.so (libc6,x86-64) => /usr/lib64/libxcb-shm.so
+	libxcb-shape.so.0 (libc6,x86-64) => /usr/lib64/libxcb-shape.so.0
+	libxcb-shape.so.0 (libc6) => /usr/lib/libxcb-shape.so.0
+	libxcb-shape.so (libc6,x86-64) => /usr/lib64/libxcb-shape.so
+	libxcb-screensaver.so.0 (libc6,x86-64) => /usr/lib64/libxcb-screensaver.so.0
+	libxcb-screensaver.so.0 (libc6) => /usr/lib/libxcb-screensaver.so.0
+	libxcb-screensaver.so (libc6,x86-64) => /usr/lib64/libxcb-screensaver.so
+	libxcb-res.so.0 (libc6,x86-64) => /usr/lib64/libxcb-res.so.0
+	libxcb-res.so.0 (libc6) => /usr/lib/libxcb-res.so.0
+	libxcb-res.so (libc6,x86-64) => /usr/lib64/libxcb-res.so
+	libxcb-reply.so.1 (libc6,x86-64) => /usr/lib64/libxcb-reply.so.1
+	libxcb-render.so.0 (libc6,x86-64) => /usr/lib64/libxcb-render.so.0
+	libxcb-render.so.0 (libc6) => /usr/lib/libxcb-render.so.0
+	libxcb-render.so (libc6,x86-64) => /usr/lib64/libxcb-render.so
+	libxcb-record.so.0 (libc6,x86-64) => /usr/lib64/libxcb-record.so.0
+	libxcb-record.so.0 (libc6) => /usr/lib/libxcb-record.so.0
+	libxcb-record.so (libc6,x86-64) => /usr/lib64/libxcb-record.so
+	libxcb-randr.so.0 (libc6,x86-64) => /usr/lib64/libxcb-randr.so.0
+	libxcb-randr.so.0 (libc6) => /usr/lib/libxcb-randr.so.0
+	libxcb-randr.so (libc6,x86-64) => /usr/lib64/libxcb-randr.so
+	libxcb-property.so.1 (libc6,x86-64) => /usr/lib64/libxcb-property.so.1
+	libxcb-present.so.0 (libc6,x86-64) => /usr/lib64/libxcb-present.so.0
+	libxcb-present.so.0 (libc6) => /usr/lib/libxcb-present.so.0
+	libxcb-present.so (libc6,x86-64) => /usr/lib64/libxcb-present.so
+	libxcb-keysyms.so.1 (libc6,x86-64) => /usr/lib64/libxcb-keysyms.so.1
+	libxcb-icccm.so.1 (libc6,x86-64) => /usr/lib64/libxcb-icccm.so.1
+	libxcb-glx.so.0 (libc6,x86-64) => /usr/lib64/libxcb-glx.so.0
+	libxcb-glx.so.0 (libc6) => /usr/lib/libxcb-glx.so.0
+	libxcb-glx.so (libc6,x86-64) => /usr/lib64/libxcb-glx.so
+	libxcb-event.so.1 (libc6,x86-64) => /usr/lib64/libxcb-event.so.1
+	libxcb-dri3.so.0 (libc6,x86-64) => /usr/lib64/libxcb-dri3.so.0
+	libxcb-dri3.so.0 (libc6) => /usr/lib/libxcb-dri3.so.0
+	libxcb-dri3.so (libc6,x86-64) => /usr/lib64/libxcb-dri3.so
+	libxcb-dri2.so.0 (libc6,x86-64) => /usr/lib64/libxcb-dri2.so.0
+	libxcb-dri2.so.0 (libc6) => /usr/lib/libxcb-dri2.so.0
+	libxcb-dri2.so (libc6,x86-64) => /usr/lib64/libxcb-dri2.so
+	libxcb-dpms.so.0 (libc6,x86-64) => /usr/lib64/libxcb-dpms.so.0
+	libxcb-dpms.so.0 (libc6) => /usr/lib/libxcb-dpms.so.0
+	libxcb-dpms.so (libc6,x86-64) => /usr/lib64/libxcb-dpms.so
+	libxcb-damage.so.0 (libc6,x86-64) => /usr/lib64/libxcb-damage.so.0
+	libxcb-damage.so.0 (libc6) => /usr/lib/libxcb-damage.so.0
+	libxcb-damage.so (libc6,x86-64) => /usr/lib64/libxcb-damage.so
+	libxcb-composite.so.0 (libc6,x86-64) => /usr/lib64/libxcb-composite.so.0
+	libxcb-composite.so.0 (libc6) => /usr/lib/libxcb-composite.so.0
+	libxcb-composite.so (libc6,x86-64) => /usr/lib64/libxcb-composite.so
+	libxcb-aux.so.0 (libc6,x86-64) => /usr/lib64/libxcb-aux.so.0
+	libxcb-atom.so.1 (libc6,x86-64) => /usr/lib64/libxcb-atom.so.1
+	libwx_gtk2u_xrc-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_xrc-2.8.so.0
+	libwx_gtk2u_xrc-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_xrc-2.8.so
+	libwx_gtk2u_svg-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_svg-2.8.so.0
+	libwx_gtk2u_svg-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_svg-2.8.so
+	libwx_gtk2u_stc-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_stc-2.8.so.0
+	libwx_gtk2u_stc-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_stc-2.8.so
+	libwx_gtk2u_richtext-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_richtext-2.8.so.0
+	libwx_gtk2u_richtext-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_richtext-2.8.so
+	libwx_gtk2u_qa-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_qa-2.8.so.0
+	libwx_gtk2u_qa-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_qa-2.8.so
+	libwx_gtk2u_ogl-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_ogl-2.8.so.0
+	libwx_gtk2u_ogl-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_ogl-2.8.so
+	libwx_gtk2u_media-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_media-2.8.so.0
+	libwx_gtk2u_media-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_media-2.8.so
+	libwx_gtk2u_html-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_html-2.8.so.0
+	libwx_gtk2u_html-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_html-2.8.so
+	libwx_gtk2u_gl-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gl-2.8.so.0
+	libwx_gtk2u_gl-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gl-2.8.so
+	libwx_gtk2u_gizmos_xrc-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gizmos_xrc-2.8.so.0
+	libwx_gtk2u_gizmos_xrc-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gizmos_xrc-2.8.so
+	libwx_gtk2u_gizmos-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gizmos-2.8.so.0
+	libwx_gtk2u_gizmos-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gizmos-2.8.so
+	libwx_gtk2u_core-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_core-2.8.so.0
+	libwx_gtk2u_core-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_core-2.8.so
+	libwx_gtk2u_aui-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_aui-2.8.so.0
+	libwx_gtk2u_aui-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_aui-2.8.so
+	libwx_gtk2u_adv-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_adv-2.8.so.0
+	libwx_gtk2u_adv-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_adv-2.8.so
+	libwx_baseu_xml-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_baseu_xml-2.8.so.0
+	libwx_baseu_xml-2.8.so (libc6,x86-64) => /usr/lib64/libwx_baseu_xml-2.8.so
+	libwx_baseu_net-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_baseu_net-2.8.so.0
+	libwx_baseu_net-2.8.so (libc6,x86-64) => /usr/lib64/libwx_baseu_net-2.8.so
+	libwx_baseu-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_baseu-2.8.so.0
+	libwx_baseu-2.8.so (libc6,x86-64) => /usr/lib64/libwx_baseu-2.8.so
+	libwrap.so.0 (libc6,x86-64) => /lib64/libwrap.so.0
+	libwmflite-0.2.so.7 (libc6,x86-64) => /usr/lib64/libwmflite-0.2.so.7
+	libwmf-0.2.so.7 (libc6,x86-64) => /usr/lib64/libwmf-0.2.so.7
+	libvsl.so (libc6,x86-64) => /usr/lib/fio/libvsl.so
+	libvorbisfile.so.3 (libc6,x86-64) => /usr/lib64/libvorbisfile.so.3
+	libvorbisenc.so.2 (libc6,x86-64) => /usr/lib64/libvorbisenc.so.2
+	libvorbis.so.0 (libc6,x86-64) => /usr/lib64/libvorbis.so.0
+	libvma.so.6 (libc6,x86-64) => /usr/lib64/libvma.so.6
+	libvma.so (libc6,x86-64) => /usr/lib64/libvma.so
+	libvisual-0.4.so.0 (libc6,x86-64) => /usr/lib64/libvisual-0.4.so.0
+	libverto.so.0 (libc6,x86-64) => /usr/lib64/libverto.so.0
+	libverto.so (libc6,x86-64) => /usr/lib64/libverto.so
+	libverto-k5ev.so.0 (libc6,x86-64) => /usr/lib64/libverto-k5ev.so.0
+	libverto-k5ev.so (libc6,x86-64) => /usr/lib64/libverto-k5ev.so
+	libvdpau_trace.so (libc6,x86-64) => /usr/lib64/libvdpau_trace.so
+	libvdpau_nvidia.so (libc6,x86-64, OS ABI: Linux 2.3.99) => /usr/lib64/libvdpau_nvidia.so
+	libvdpau.so.1 (libc6,x86-64) => /usr/lib64/libvdpau.so.1
+	libvdpau.so (libc6,x86-64) => /usr/lib64/libvdpau.so
+	libuuid.so.1 (libc6,x86-64) => /lib64/libuuid.so.1
+	libuuid.so.1 (libc6) => /lib/libuuid.so.1
+	libuuid.so (libc6,x86-64) => /usr/lib64/libuuid.so
+	libutil.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libutil.so.1
+	libutil.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libutil.so.1
+	libutil.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libutil.so
+	libutil.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libutil.so
+	libutempter.so.0 (libc6,x86-64) => /usr/lib64/libutempter.so.0
+	libustr-1.0.so.1 (libc6,x86-64) => /usr/lib64/libustr-1.0.so.1
+	libuser.so.1 (libc6,x86-64) => /usr/lib64/libuser.so.1
+	libusbpp-0.1.so.4 (libc6,x86-64) => /usr/lib64/libusbpp-0.1.so.4
+	libusb-1.0.so.0 (libc6,x86-64) => /usr/lib64/libusb-1.0.so.0
+	libusb-0.1.so.4 (libc6,x86-64) => /usr/lib64/libusb-0.1.so.4
+	libunistring.so.0 (libc6,x86-64) => /usr/lib64/libunistring.so.0
+	libunique-1.0.so.0 (libc6,x86-64) => /usr/lib64/libunique-1.0.so.0
+	libungif.so.4 (libc6,x86-64) => /usr/lib64/libungif.so.4
+	libungif.so (libc6,x86-64) => /usr/lib64/libungif.so
+	libudf.so.0 (libc6,x86-64) => /usr/lib64/libudf.so.0
+	libudev.so.0 (libc6,x86-64) => /lib64/libudev.so.0
+	libt1x.so.5 (libc6,x86-64) => /usr/lib64/libt1x.so.5
+	libt1.so.5 (libc6,x86-64) => /usr/lib64/libt1.so.5
+	libturbojpeg.so (libc6,x86-64) => /usr/lib64/libturbojpeg.so
+	libtt-1.0.0.so (libc6,x86-64) => /usr/lib64/libtt-1.0.0.so
+	libtk8.5.so (libc6,x86-64) => /usr/lib64/libtk8.5.so
+	libtirpc.so.1 (libc6,x86-64) => /lib64/libtirpc.so.1
+	libtinfo.so.5 (libc6,x86-64) => /lib64/libtinfo.so.5
+	libtinfo.so.5 (libc6) => /lib/libtinfo.so.5
+	libtinfo.so (libc6,x86-64) => /usr/lib64/libtinfo.so
+	libtinfo.so (libc6) => /usr/lib/libtinfo.so
+	libtiffxx.so.3 (libc6,x86-64) => /usr/lib64/libtiffxx.so.3
+	libtiffxx.so.3 (libc6) => /usr/lib/libtiffxx.so.3
+	libtiffxx.so (libc6,x86-64) => /usr/lib64/libtiffxx.so
+	libtiff.so.3 (libc6,x86-64) => /usr/lib64/libtiff.so.3
+	libtiff.so.3 (libc6) => /usr/lib/libtiff.so.3
+	libtiff.so (libc6,x86-64) => /usr/lib64/libtiff.so
+	libtic.so.5 (libc6,x86-64) => /usr/lib64/libtic.so.5
+	libtic.so.5 (libc6) => /usr/lib/libtic.so.5
+	libtic.so (libc6,x86-64) => /usr/lib64/libtic.so
+	libtic.so (libc6) => /usr/lib/libtic.so
+	libthread_db.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libthread_db.so.1
+	libthread_db.so.1 (libc6, hwcap: 0x0028000000000000, OS ABI: Linux 2.6.18) => /lib/i686/nosegneg/libthread_db.so.1
+	libthread_db.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libthread_db.so.1
+	libthread_db.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libthread_db.so
+	libthread_db.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libthread_db.so
+	libtheoraenc.so.1 (libc6,x86-64) => /usr/lib64/libtheoraenc.so.1
+	libtheoradec.so.1 (libc6,x86-64) => /usr/lib64/libtheoradec.so.1
+	libtheora.so.0 (libc6,x86-64) => /usr/lib64/libtheora.so.0
+	libthai.so.0 (libc6,x86-64) => /usr/lib64/libthai.so.0
+	libtevent.so.0 (libc6,x86-64) => /usr/lib64/libtevent.so.0
+	libtevent-util.so.0 (libc6,x86-64) => /usr/lib64/libtevent-util.so.0
+	libtdb.so.1 (libc6,x86-64) => /usr/lib64/libtdb.so.1
+	libtcl8.5.so (libc6,x86-64) => /usr/lib64/libtcl8.5.so
+	libtclx8.4.so (libc6,x86-64) => /usr/lib64/tcl8.5/tclx8.4/libtclx8.4.so
+	libtasn1.so.3 (libc6,x86-64) => /usr/lib64/libtasn1.so.3
+	libtar.so.1 (libc6,x86-64) => /usr/lib64/libtar.so.1
+	libtalloc.so.2 (libc6,x86-64) => /usr/lib64/libtalloc.so.2
+	libsysfs.so.2 (libc6,x86-64) => /usr/lib64/libsysfs.so.2
+	libsvn_wc-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_wc-1.so.0
+	libsvn_swig_py-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_swig_py-1.so.0
+	libsvn_swig_perl-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_swig_perl-1.so.0
+	libsvn_subr-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_subr-1.so.0
+	libsvn_repos-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_repos-1.so.0
+	libsvn_ra_svn-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_ra_svn-1.so.0
+	libsvn_ra_neon-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_ra_neon-1.so.0
+	libsvn_ra_local-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_ra_local-1.so.0
+	libsvn_ra-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_ra-1.so.0
+	libsvn_fs_util-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_fs_util-1.so.0
+	libsvn_fs_fs-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_fs_fs-1.so.0
+	libsvn_fs_base-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_fs_base-1.so.0
+	libsvn_fs-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_fs-1.so.0
+	libsvn_diff-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_diff-1.so.0
+	libsvn_delta-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_delta-1.so.0
+	libsvn_client-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_client-1.so.0
+	libstdc++.so.6 (libc6,x86-64) => /usr/lib64/libstdc++.so.6
+	libstdc++.so.6 (libc6) => /usr/lib/libstdc++.so.6
+	libstdc++.so.5 (libc6,x86-64) => /usr/lib64/libstdc++.so.5
+	libstdc++.so.5 (libc6) => /usr/lib/libstdc++.so.5
+	libstartup-notification-1.so.0 (libc6,x86-64) => /usr/lib64/libstartup-notification-1.so.0
+	libsss_sudo.so (libc6,x86-64) => /usr/lib64/libsss_sudo.so
+	libsss_idmap.so.0 (libc6,x86-64) => /usr/lib64/libsss_idmap.so.0
+	libssl3.so (libc6,x86-64) => /usr/lib64/libssl3.so
+	libssl.so.10 (libc6,x86-64) => /usr/lib64/libssl.so.10
+	libssl.so (libc6,x86-64) => /usr/lib64/libssl.so
+	libssh2.so.1 (libc6,x86-64) => /usr/lib64/libssh2.so.1
+	libss.so.2 (libc6,x86-64) => /lib64/libss.so.2
+	libsqlite3.so.0 (libc6,x86-64) => /usr/lib64/libsqlite3.so.0
+	libsqlite3.so (libc6,x86-64) => /usr/lib64/libsqlite3.so
+	libspectre.so.1 (libc6,x86-64) => /usr/lib64/libspectre.so.1
+	libsoup-2.4.so.1 (libc6,x86-64) => /usr/lib64/libsoup-2.4.so.1
+	libsoup-gnome-2.4.so.1 (libc6,x86-64) => /usr/lib64/libsoup-gnome-2.4.so.1
+	libsoftokn3.so (libc6,x86-64) => /usr/lib64/libsoftokn3.so
+	libsnmp.so.20 (libc6,x86-64) => /usr/lib64/libsnmp.so.20
+	libsnappy.so.1 (libc6,x86-64) => /usr/lib64/libsnappy.so.1
+	libsmime3.so (libc6,x86-64) => /usr/lib64/libsmime3.so
+	libsmbldap.so.0 (libc6,x86-64) => /usr/lib64/libsmbldap.so.0
+	libsmbconf.so.0 (libc6,x86-64) => /usr/lib64/libsmbconf.so.0
+	libsmbclient-raw.so.0 (libc6,x86-64) => /usr/lib64/libsmbclient-raw.so.0
+	libslang.so.2 (libc6,x86-64) => /usr/lib64/libslang.so.2
+	libsgutils2.so.2 (libc6,x86-64) => /usr/lib64/libsgutils2.so.2
+	libsepol.so.1 (libc6,x86-64) => /lib64/libsepol.so.1
+	libsepol.so (libc6,x86-64) => /usr/lib64/libsepol.so
+	libsensors.so.4 (libc6,x86-64) => /usr/lib64/libsensors.so.4
+	libsemanage.so.1 (libc6,x86-64) => /lib64/libsemanage.so.1
+	libselinux.so.1 (libc6,x86-64) => /lib64/libselinux.so.1
+	libselinux.so.1 (libc6) => /lib/libselinux.so.1
+	libselinux.so (libc6,x86-64) => /usr/lib64/libselinux.so
+	libsasl2.so.2 (libc6,x86-64) => /usr/lib64/libsasl2.so.2
+	libsasl2.so (libc6,x86-64) => /usr/lib64/libsasl2.so
+	libsamdb.so.0 (libc6,x86-64) => /usr/lib64/libsamdb.so.0
+	libsamba-util.so.0 (libc6,x86-64) => /usr/lib64/libsamba-util.so.0
+	libsamba-policy.so.0 (libc6,x86-64) => /usr/lib64/libsamba-policy.so.0
+	libsamba-passdb.so.0 (libc6,x86-64) => /usr/lib64/libsamba-passdb.so.0
+	libsamba-hostconfig.so.0 (libc6,x86-64) => /usr/lib64/libsamba-hostconfig.so.0
+	libsamba-credentials.so.0 (libc6,x86-64) => /usr/lib64/libsamba-credentials.so.0
+	libruby.so.1.8 (libc6,x86-64) => /usr/lib64/libruby.so.1.8
+	libruby.so (libc6,x86-64) => /usr/lib64/libruby.so
+	librt.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/librt.so.1
+	librt.so.1 (libc6, hwcap: 0x0028000000000000, OS ABI: Linux 2.6.18) => /lib/i686/nosegneg/librt.so.1
+	librt.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/librt.so.1
+	librt.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/librt.so
+	librt.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/librt.so
+	librsvg-2.so.2 (libc6,x86-64) => /usr/lib64/librsvg-2.so.2
+	librrd_th.so.4 (libc6,x86-64) => /usr/lib64/librrd_th.so.4
+	librrd_th.so (libc6,x86-64) => /usr/lib64/librrd_th.so
+	librrd.so.4 (libc6,x86-64) => /usr/lib64/librrd.so.4
+	librrd.so (libc6,x86-64) => /usr/lib64/librrd.so
+	librpmio.so.1 (libc6,x86-64) => /usr/lib64/librpmio.so.1
+	librpmbuild.so.1 (libc6,x86-64) => /usr/lib64/librpmbuild.so.1
+	librpm.so.1 (libc6,x86-64) => /usr/lib64/librpm.so.1
+	librpcsecgss.so.3 (libc6,x86-64) => /usr/lib64/librpcsecgss.so.3
+	libresolv.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libresolv.so.2
+	libresolv.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libresolv.so.2
+	libresolv.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libresolv.so
+	libresolv.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libresolv.so
+	libregistry.so.0 (libc6,x86-64) => /usr/lib64/libregistry.so.0
+	libreg.so (libc6,x86-64) => /usr/lib64/libreg.so
+	libref_array.so.1 (libc6,x86-64) => /usr/lib64/libref_array.so.1
+	libreadline.so.6 (libc6,x86-64) => /lib64/libreadline.so.6
+	libreadline.so.5 (libc6,x86-64) => /lib64/libreadline.so.5
+	libreadline.so (libc6,x86-64) => /usr/lib64/libreadline.so
+	librdmacm.so.1 (libc6,x86-64) => /usr/lib64/librdmacm.so.1
+	librdmacm.so (libc6,x86-64) => /usr/lib64/librdmacm.so
+	librarian.so.0 (libc6,x86-64) => /usr/lib64/librarian.so.0
+	libqui.so.1 (libc6,x86-64) => /usr/lib64/qt-3.3/lib/libqui.so.1
+	libqt-mt.so.3 (libc6,x86-64) => /usr/lib64/qt-3.3/lib/libqt-mt.so.3
+	libp11-kit.so.0 (libc6,x86-64) => /usr/lib64/libp11-kit.so.0
+	libpython2.6.so.1.0 (libc6,x86-64) => /usr/lib64/libpython2.6.so.1.0
+	libpython2.6.so (libc6,x86-64) => /usr/lib64/libpython2.6.so
+	libpytalloc-util.so.2 (libc6,x86-64) => /usr/lib64/libpytalloc-util.so.2
+	libpyglib-2.0-python.so.0 (libc6,x86-64) => /usr/lib64/libpyglib-2.0-python.so.0
+	libpyglib-2.0-python.so (libc6,x86-64) => /usr/lib64/libpyglib-2.0-python.so
+	libpthread.so.0 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libpthread.so.0
+	libpthread.so.0 (libc6, hwcap: 0x0028000000000000, OS ABI: Linux 2.6.18) => /lib/i686/nosegneg/libpthread.so.0
+	libpthread.so.0 (libc6, OS ABI: Linux 2.6.18) => /lib/libpthread.so.0
+	libpth.so.20 (libc6,x86-64) => /usr/lib64/libpth.so.20
+	libpsm_infinipath.so.1 (libc6,x86-64) => /usr/lib64/libpsm_infinipath.so.1
+	libpsm_infinipath.so (libc6,x86-64) => /usr/lib64/libpsm_infinipath.so
+	libproxy.so.0 (libc6,x86-64) => /usr/lib64/libproxy.so.0
+	libproj.so.0 (libc6,x86-64) => /usr/lib64/libproj.so.0
+	libproc-3.2.8.so (libc6,x86-64) => /lib64/libproc-3.2.8.so
+	libpq.so.5 (libc6,x86-64) => /usr/lib64/libpq.so.5
+	libpq.so (libc6,x86-64) => /usr/lib64/libpq.so
+	libppl_c.so.2 (libc6,x86-64) => /usr/lib64/libppl_c.so.2
+	libppl.so.7 (libc6,x86-64) => /usr/lib64/libppl.so.7
+	libpopt.so.0 (libc6,x86-64) => /lib64/libpopt.so.0
+	libpopt.so (libc6,x86-64) => /usr/lib64/libpopt.so
+	libpoppler.so.5 (libc6,x86-64) => /usr/lib64/libpoppler.so.5
+	libpoppler-glib.so.4 (libc6,x86-64) => /usr/lib64/libpoppler-glib.so.4
+	libpolkit-gobject-1.so.0 (libc6,x86-64) => /usr/lib64/libpolkit-gobject-1.so.0
+	libpolkit-backend-1.so.0 (libc6,x86-64) => /usr/lib64/libpolkit-backend-1.so.0
+	libpolkit-agent-1.so.0 (libc6,x86-64) => /usr/lib64/libpolkit-agent-1.so.0
+	libpng12.so.0 (libc6,x86-64) => /usr/lib64/libpng12.so.0
+	libpng12.so.0 (libc6) => /usr/lib/libpng12.so.0
+	libpng12.so (libc6,x86-64) => /usr/lib64/libpng12.so
+	libpng.so.3 (libc6,x86-64) => /usr/lib64/libpng.so.3
+	libpng.so.3 (libc6) => /usr/lib/libpng.so.3
+	libply.so.2 (libc6,x86-64) => /lib64/libply.so.2
+	libply-splash-core.so.2 (libc6,x86-64) => /lib64/libply-splash-core.so.2
+	libply-boot-client.so.2 (libc6,x86-64) => /usr/lib64/libply-boot-client.so.2
+	libplds4.so (libc6,x86-64) => /lib64/libplds4.so
+	libplds4.so (libc6,x86-64) => /usr/lib64/libplds4.so
+	libplc4.so (libc6,x86-64) => /lib64/libplc4.so
+	libplc4.so (libc6,x86-64) => /usr/lib64/libplc4.so
+	libpixman-1.so.0 (libc6,x86-64) => /usr/lib64/libpixman-1.so.0
+	libpixman-1.so (libc6,x86-64) => /usr/lib64/libpixman-1.so
+	libphonon.so.4 (libc6,x86-64) => /usr/lib64/libphonon.so.4
+	libphonon.so (libc6,x86-64) => /usr/lib64/libphonon.so
+	libpgtypes.so.3 (libc6,x86-64) => /usr/lib64/libpgtypes.so.3
+	libpgtypes.so (libc6,x86-64) => /usr/lib64/libpgtypes.so
+	libpcreposix.so.0 (libc6,x86-64) => /usr/lib64/libpcreposix.so.0
+	libpcreposix.so (libc6,x86-64) => /usr/lib64/libpcreposix.so
+	libpcrecpp.so.0 (libc6,x86-64) => /usr/lib64/libpcrecpp.so.0
+	libpcrecpp.so (libc6,x86-64) => /usr/lib64/libpcrecpp.so
+	libpcre.so.0 (libc6,x86-64) => /lib64/libpcre.so.0
+	libpcre.so (libc6,x86-64) => /usr/lib64/libpcre.so
+	libpcprofile.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libpcprofile.so
+	libpcprofile.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libpcprofile.so
+	libpciaccess.so.0 (libc6,x86-64) => /usr/lib64/libpciaccess.so.0
+	libpciaccess.so.0 (libc6) => /usr/lib/libpciaccess.so.0
+	libpci.so.3 (libc6,x86-64) => /lib64/libpci.so.3
+	libpci.so (libc6,x86-64) => /usr/lib64/libpci.so
+	libpcap.so.1 (libc6,x86-64) => /usr/lib64/libpcap.so.1
+	libpathplan.so.4 (libc6,x86-64) => /usr/lib64/libpathplan.so.4
+	libpath_utils.so.1 (libc6,x86-64) => /usr/lib64/libpath_utils.so.1
+	libparted-2.1.so.0 (libc6,x86-64) => /lib64/libparted-2.1.so.0
+	libpaper.so.1 (libc6,x86-64) => /usr/lib64/libpaper.so.1
+	libpangoxft-1.0.so.0 (libc6,x86-64) => /usr/lib64/libpangoxft-1.0.so.0
+	libpangoxft-1.0.so (libc6,x86-64) => /usr/lib64/libpangoxft-1.0.so
+	libpangox-1.0.so.0 (libc6,x86-64) => /usr/lib64/libpangox-1.0.so.0
+	libpangox-1.0.so (libc6,x86-64) => /usr/lib64/libpangox-1.0.so
+	libpangoft2-1.0.so.0 (libc6,x86-64) => /usr/lib64/libpangoft2-1.0.so.0
+	libpangoft2-1.0.so (libc6,x86-64) => /usr/lib64/libpangoft2-1.0.so
+	libpangocairo-1.0.so.0 (libc6,x86-64) => /usr/lib64/libpangocairo-1.0.so.0
+	libpangocairo-1.0.so (libc6,x86-64) => /usr/lib64/libpangocairo-1.0.so
+	libpango-1.0.so.0 (libc6,x86-64) => /usr/lib64/libpango-1.0.so.0
+	libpango-1.0.so (libc6,x86-64) => /usr/lib64/libpango-1.0.so
+	libpanelw.so.5 (libc6,x86-64) => /usr/lib64/libpanelw.so.5
+	libpanelw.so.5 (libc6) => /usr/lib/libpanelw.so.5
+	libpanelw.so (libc6,x86-64) => /usr/lib64/libpanelw.so
+	libpanelw.so (libc6) => /usr/lib/libpanelw.so
+	libpanel.so.5 (libc6,x86-64) => /usr/lib64/libpanel.so.5
+	libpanel.so.5 (libc6) => /usr/lib/libpanel.so.5
+	libpanel.so (libc6,x86-64) => /usr/lib64/libpanel.so
+	libpanel.so (libc6) => /usr/lib/libpanel.so
+	libpamc.so.0 (libc6,x86-64) => /lib64/libpamc.so.0
+	libpam_misc.so.0 (libc6,x86-64) => /lib64/libpam_misc.so.0
+	libpam.so.0 (libc6,x86-64) => /lib64/libpam.so.0
+	libpakchois.so.0 (libc6,x86-64) => /usr/lib64/libpakchois.so.0
+	libotf.so.0 (libc6,x86-64) => /usr/lib64/libotf.so.0
+	libostyle.so.0 (libc6,x86-64) => /usr/lib64/libostyle.so.0
+	libospgrove.so.0 (libc6,x86-64) => /usr/lib64/libospgrove.so.0
+	libosp.so.5 (libc6,x86-64) => /usr/lib64/libosp.so.5
+	libosmvendor.so.3 (libc6,x86-64) => /usr/lib64/libosmvendor.so.3
+	libosmvendor.so (libc6,x86-64) => /usr/lib64/libosmvendor.so
+	libosmcomp.so.3 (libc6,x86-64) => /usr/lib64/libosmcomp.so.3
+	libosmcomp.so (libc6,x86-64) => /usr/lib64/libosmcomp.so
+	libopensm.so.5 (libc6,x86-64) => /usr/lib64/libopensm.so.5
+	libopensm.so (libc6,x86-64) => /usr/lib64/libopensm.so
+	libopenjpeg.so.2 (libc6,x86-64) => /usr/lib64/libopenjpeg.so.2
+	libopenjpeg.so (libc6,x86-64) => /usr/lib64/libopenjpeg.so
+	libopcodes-2.20.51.0.2-5.44.el6.so (libc6,x86-64) => /usr/lib64/libopcodes-2.20.51.0.2-5.44.el6.so
+	liboil-0.3.so.0 (libc6,x86-64) => /usr/lib64/liboil-0.3.so.0
+	libogrove.so.0 (libc6,x86-64) => /usr/lib64/libogrove.so.0
+	libogg.so.0 (libc6,x86-64) => /usr/lib64/libogg.so.0
+	libnvidia-tls.so.352.79 (libc6,x86-64, hwcap: 0x8000000000000000, OS ABI: Linux 2.3.99) => /usr/lib64/tls/libnvidia-tls.so.352.79
+	libnvidia-tls.so.352.79 (libc6,x86-64, OS ABI: Linux 2.2.5) => /usr/lib64/libnvidia-tls.so.352.79
+	libnvidia-opencl.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-opencl.so.1
+	libnvidia-ml.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-ml.so.1
+	libnvidia-ml.so (libc6,x86-64) => /usr/lib64/libnvidia-ml.so
+	libnvidia-ifr.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-ifr.so.1
+	libnvidia-ifr.so (libc6,x86-64) => /usr/lib64/libnvidia-ifr.so
+	libnvidia-gtk3.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-gtk3.so.352.79
+	libnvidia-gtk2.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-gtk2.so.352.79
+	libnvidia-glsi.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-glsi.so.352.79
+	libnvidia-glcore.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-glcore.so.352.79
+	libnvidia-fbc.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-fbc.so.1
+	libnvidia-fbc.so (libc6,x86-64) => /usr/lib64/libnvidia-fbc.so
+	libnvidia-encode.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-encode.so.1
+	libnvidia-encode.so (libc6,x86-64) => /usr/lib64/libnvidia-encode.so
+	libnvidia-eglcore.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-eglcore.so.352.79
+	libnvidia-compiler.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-compiler.so.352.79
+	libnvidia-cfg.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-cfg.so.1
+	libnvidia-cfg.so (libc6,x86-64) => /usr/lib64/libnvidia-cfg.so
+	libnvcuvid.so.1 (libc6,x86-64) => /usr/lib64/libnvcuvid.so.1
+	libnvcuvid.so (libc6,x86-64) => /usr/lib64/libnvcuvid.so
+	libnuma.so.1 (libc6,x86-64) => /usr/lib64/libnuma.so.1
+	libnuma.so (libc6,x86-64) => /usr/lib64/libnuma.so
+	libnss3.so (libc6,x86-64) => /usr/lib64/libnss3.so
+	libnssutil3.so (libc6,x86-64) => /usr/lib64/libnssutil3.so
+	libnsssysinit.so (libc6,x86-64) => /usr/lib64/libnsssysinit.so
+	libnsspem.so (libc6,x86-64) => /usr/lib64/libnsspem.so
+	libnssdbm3.so (libc6,x86-64) => /usr/lib64/libnssdbm3.so
+	libnssckbi.so (libc6,x86-64) => /usr/lib64/libnssckbi.so
+	libnss_sss.so.2 (libc6,x86-64) => /lib64/libnss_sss.so.2
+	libnss_nisplus.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_nisplus.so.2
+	libnss_nisplus.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_nisplus.so.2
+	libnss_nisplus.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_nisplus.so
+	libnss_nisplus.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_nisplus.so
+	libnss_nis.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_nis.so.2
+	libnss_nis.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_nis.so.2
+	libnss_nis.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_nis.so
+	libnss_nis.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_nis.so
+	libnss_ldap.so.2 (libc6,x86-64) => /lib64/libnss_ldap.so.2
+	libnss_ldap.so (libc6,x86-64) => /usr/lib64/libnss_ldap.so
+	libnss_hesiod.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_hesiod.so.2
+	libnss_hesiod.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_hesiod.so.2
+	libnss_hesiod.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_hesiod.so
+	libnss_hesiod.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_hesiod.so
+	libnss_files.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_files.so.2
+	libnss_files.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_files.so.2
+	libnss_files.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_files.so
+	libnss_files.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_files.so
+	libnss_dns.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_dns.so.2
+	libnss_dns.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_dns.so.2
+	libnss_dns.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_dns.so
+	libnss_dns.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_dns.so
+	libnss_compat.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_compat.so.2
+	libnss_compat.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_compat.so.2
+	libnss_compat.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_compat.so
+	libnss_compat.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_compat.so
+	libnspr4.so (libc6,x86-64) => /lib64/libnspr4.so
+	libnspr4.so (libc6,x86-64) => /usr/lib64/libnspr4.so
+	libnsl.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnsl.so.1
+	libnsl.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libnsl.so.1
+	libnsl.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnsl.so
+	libnsl.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnsl.so
+	libnl.so.1 (libc6,x86-64) => /lib64/libnl.so.1
+	libnl.so (libc6,x86-64) => /usr/lib64/libnl.so
+	libnl-3.so.200 (libc6,x86-64) => /usr/lib64/libnl-3.so.200
+	libnl-route-3.so.200 (libc6,x86-64) => /usr/lib64/libnl-route-3.so.200
+	libnl-nf-3.so.200 (libc6,x86-64) => /usr/lib64/libnl-nf-3.so.200
+	libnl-genl-3.so.200 (libc6,x86-64) => /usr/lib64/libnl-genl-3.so.200
+	libnih.so.1 (libc6,x86-64) => /lib64/libnih.so.1
+	libnih-dbus.so.1 (libc6,x86-64) => /lib64/libnih-dbus.so.1
+	libnfsidmap.so.0 (libc6,x86-64) => /usr/lib64/libnfsidmap.so.0
+	libnewt.so.0.52 (libc6,x86-64) => /usr/lib64/libnewt.so.0.52
+	libnetsnmptrapd.so.20 (libc6,x86-64) => /usr/lib64/libnetsnmptrapd.so.20
+	libnetsnmpmibs.so.20 (libc6,x86-64) => /usr/lib64/libnetsnmpmibs.so.20
+	libnetsnmphelpers.so.20 (libc6,x86-64) => /usr/lib64/libnetsnmphelpers.so.20
+	libnetsnmpagent.so.20 (libc6,x86-64) => /usr/lib64/libnetsnmpagent.so.20
+	libnetsnmp.so.20 (libc6,x86-64) => /usr/lib64/libnetsnmp.so.20
+	libnetpbm.so.10 (libc6,x86-64) => /usr/lib64/libnetpbm.so.10
+	libnetpbm.so (libc6,x86-64) => /usr/lib64/libnetpbm.so
+	libnes-rdmav2.so (libc6,x86-64) => /usr/lib64/libnes-rdmav2.so
+	libneon.so.27 (libc6,x86-64) => /usr/lib64/libneon.so.27
+	libndr.so.0 (libc6,x86-64) => /usr/lib64/libndr.so.0
+	libndr-standard.so.0 (libc6,x86-64) => /usr/lib64/libndr-standard.so.0
+	libndr-nbt.so.0 (libc6,x86-64) => /usr/lib64/libndr-nbt.so.0
+	libndr-krb5pac.so.0 (libc6,x86-64) => /usr/lib64/libndr-krb5pac.so.0
+	libncursesw.so.5 (libc6,x86-64) => /lib64/libncursesw.so.5
+	libncursesw.so.5 (libc6) => /lib/libncursesw.so.5
+	libncursesw.so (libc6,x86-64) => /usr/lib64/libncursesw.so
+	libncursesw.so (libc6) => /usr/lib/libncursesw.so
+	libncurses.so.5 (libc6,x86-64) => /lib64/libncurses.so.5
+	libncurses.so.5 (libc6) => /lib/libncurses.so.5
+	libncurses.so (libc6,x86-64) => /usr/lib64/libncurses.so
+	libncurses.so (libc6) => /usr/lib/libncurses.so
+	libnautilus-extension.so.1 (libc6,x86-64) => /usr/lib64/libnautilus-extension.so.1
+	libm17n.so.0 (libc6,x86-64) => /usr/lib64/libm17n.so.0
+	libm17n-flt.so.0 (libc6,x86-64) => /usr/lib64/libm17n-flt.so.0
+	libm17n-core.so.0 (libc6,x86-64) => /usr/lib64/libm17n-core.so.0
+	libmysqlclient_r.so.16 (libc6,x86-64) => /usr/lib64/mysql/libmysqlclient_r.so.16
+	libmysqlclient_r.so (libc6,x86-64) => /usr/lib64/mysql/libmysqlclient_r.so
+	libmysqlclient.so.16 (libc6,x86-64) => /usr/lib64/mysql/libmysqlclient.so.16
+	libmysqlclient.so (libc6,x86-64) => /usr/lib64/mysql/libmysqlclient.so
+	libmxm.so.2 (libc6,x86-64) => /opt/mellanox/mxm/lib/libmxm.so.2
+	libmxm.so (libc6,x86-64) => /opt/mellanox/mxm/lib/libmxm.so
+	libmunge.so.2 (libc6,x86-64) => /usr/lib64/libmunge.so.2
+	libmunge.so (libc6,x86-64) => /usr/lib64/libmunge.so
+	libmultipath.so (libc6,x86-64) => /lib64/libmultipath.so
+	libmtdev.so.1 (libc6,x86-64) => /usr/lib64/libmtdev.so.1
+	libmpfr.so.1 (libc6,x86-64) => /usr/lib64/libmpfr.so.1
+	libmpfr.so (libc6,x86-64) => /usr/lib64/libmpfr.so
+	libmpc.so.2 (libc6,x86-64) => /usr/lib64/libmpc.so.2
+	libmpc.so (libc6,x86-64) => /usr/lib64/libmpc.so
+	libmpathpersist.so.0 (libc6,x86-64) => /lib64/libmpathpersist.so.0
+	libmpathpersist.so (libc6,x86-64) => /lib64/libmpathpersist.so
+	libmp.so.3 (libc6,x86-64) => /usr/lib64/libmp.so.3
+	libmp.so (libc6,x86-64) => /usr/lib64/libmp.so
+	libmount.so.1 (libc6,x86-64) => /lib64/libmount.so.1
+	libmng.so.1 (libc6,x86-64) => /usr/lib64/libmng.so.1
+	libmng.so (libc6,x86-64) => /usr/lib64/libmng.so
+	libmlx5-rdmav2.so (libc6,x86-64) => /usr/lib64/libmlx5-rdmav2.so
+	libmlx4-rdmav2.so (libc6,x86-64) => /usr/lib64/libmlx4-rdmav2.so
+	libmenuw.so.5 (libc6,x86-64) => /usr/lib64/libmenuw.so.5
+	libmenuw.so.5 (libc6) => /usr/lib/libmenuw.so.5
+	libmenuw.so (libc6,x86-64) => /usr/lib64/libmenuw.so
+	libmenuw.so (libc6) => /usr/lib/libmenuw.so
+	libmenu.so.5 (libc6,x86-64) => /usr/lib64/libmenu.so.5
+	libmenu.so.5 (libc6) => /usr/lib/libmenu.so.5
+	libmenu.so (libc6,x86-64) => /usr/lib64/libmenu.so
+	libmenu.so (libc6) => /usr/lib/libmenu.so
+	libmemusage.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libmemusage.so
+	libmemusage.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libmemusage.so
+	libmcpp.so.0 (libc6,x86-64) => /usr/lib64/libmcpp.so.0
+	libmagic.so.1 (libc6,x86-64) => /usr/lib64/libmagic.so.1
+	libm.so.6 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libm.so.6
+	libm.so.6 (libc6, hwcap: 0x0028000000000000, OS ABI: Linux 2.6.18) => /lib/i686/nosegneg/libm.so.6
+	libm.so.6 (libc6, OS ABI: Linux 2.6.18) => /lib/libm.so.6
+	libm.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libm.so
+	libm.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libm.so
+	liblzo2.so.2 (libc6,x86-64) => /usr/lib64/liblzo2.so.2
+	liblzma.so.0 (libc6,x86-64) => /usr/lib64/liblzma.so.0
+	liblzma.so (libc6,x86-64) => /usr/lib64/liblzma.so
+	liblwres.so.80 (libc6,x86-64) => /usr/lib64/liblwres.so.80
+	liblvm2cmd.so.2.02 (libc6,x86-64) => /lib64/liblvm2cmd.so.2.02
+	liblvm2app.so.2.2 (libc6,x86-64) => /lib64/liblvm2app.so.2.2
+	liblustreapi.so (libc6,x86-64) => /usr/lib64/liblustreapi.so
+	liblustre.so (libc6,x86-64) => /usr/lib64/liblustre.so
+	liblua-5.1.so (libc6,x86-64) => /usr/lib64/liblua-5.1.so
+	libltdl.so.7 (libc6,x86-64) => /usr/lib64/libltdl.so.7
+	libldif-2.4.so.2 (libc6,x86-64) => /lib64/libldif-2.4.so.2
+	libldif-2.4.so.2 (libc6,x86-64) => /usr/lib64/libldif-2.4.so.2
+	libldb.so.1 (libc6,x86-64) => /usr/lib64/libldb.so.1
+	libldap_r-2.4.so.2 (libc6,x86-64) => /lib64/libldap_r-2.4.so.2
+	libldap_r-2.4.so.2 (libc6,x86-64) => /usr/lib64/libldap_r-2.4.so.2
+	libldap-2.4.so.2 (libc6,x86-64) => /lib64/libldap-2.4.so.2
+	libldap-2.4.so.2 (libc6,x86-64) => /usr/lib64/libldap-2.4.so.2
+	liblcms.so.1 (libc6,x86-64) => /usr/lib64/liblcms.so.1
+	liblcms.so (libc6,x86-64) => /usr/lib64/liblcms.so
+	liblber-2.4.so.2 (libc6,x86-64) => /lib64/liblber-2.4.so.2
+	liblber-2.4.so.2 (libc6,x86-64) => /usr/lib64/liblber-2.4.so.2
+	libk5crypto.so.3 (libc6,x86-64) => /lib64/libk5crypto.so.3
+	libk5crypto.so (libc6,x86-64) => /usr/lib64/libk5crypto.so
+	libkrb5support.so.0 (libc6,x86-64) => /lib64/libkrb5support.so.0
+	libkrb5support.so (libc6,x86-64) => /usr/lib64/libkrb5support.so
+	libkrb5.so.3 (libc6,x86-64) => /lib64/libkrb5.so.3
+	libkrb5.so (libc6,x86-64) => /usr/lib64/libkrb5.so
+	libkpathsea.so.4 (libc6,x86-64) => /usr/lib64/libkpathsea.so.4
+	libkeyutils.so.1 (libc6,x86-64) => /lib64/libkeyutils.so.1
+	libkeyutils.so (libc6,x86-64) => /usr/lib64/libkeyutils.so
+	libkdb5.so.6 (libc6,x86-64) => /usr/lib64/libkdb5.so.6
+	libkdb5.so (libc6,x86-64) => /usr/lib64/libkdb5.so
+	libkadm5srv_mit.so.8 (libc6,x86-64) => /usr/lib64/libkadm5srv_mit.so.8
+	libkadm5srv_mit.so (libc6,x86-64) => /usr/lib64/libkadm5srv_mit.so
+	libkadm5clnt_mit.so.8 (libc6,x86-64) => /usr/lib64/libkadm5clnt_mit.so.8
+	libkadm5clnt_mit.so (libc6,x86-64) => /usr/lib64/libkadm5clnt_mit.so
+	libjpeg.so.62 (libc6,x86-64) => /usr/lib64/libjpeg.so.62
+	libjpeg.so.62 (libc6) => /usr/lib/libjpeg.so.62
+	libjpeg.so (libc6,x86-64) => /usr/lib64/libjpeg.so
+	libjasper.so.1 (libc6,x86-64) => /usr/lib64/libjasper.so.1
+	libjasper.so (libc6,x86-64) => /usr/lib64/libjasper.so
+	libiw.so.29 (libc6,x86-64) => /lib64/libiw.so.29
+	libiso9660.so.7 (libc6,x86-64) => /usr/lib64/libiso9660.so.7
+	libiso9660++.so.0 (libc6,x86-64) => /usr/lib64/libiso9660++.so.0
+	libisccfg.so.82 (libc6,x86-64) => /usr/lib64/libisccfg.so.82
+	libisccc.so.80 (libc6,x86-64) => /usr/lib64/libisccc.so.80
+	libisc.so.83 (libc6,x86-64) => /usr/lib64/libisc.so.83
+	libip6tc.so.0 (libc6,x86-64) => /lib64/libip6tc.so.0
+	libip4tc.so.0 (libc6,x86-64) => /lib64/libip4tc.so.0
+	libiptc.so.0 (libc6,x86-64) => /lib64/libiptc.so.0
+	libipq.so.0 (libc6,x86-64) => /lib64/libipq.so.0
+	libipmimonitoring.so.5 (libc6,x86-64) => /usr/lib64/libipmimonitoring.so.5
+	libipmidetect.so.0 (libc6,x86-64) => /usr/lib64/libipmidetect.so.0
+	libipmiconsole.so.2 (libc6,x86-64) => /usr/lib64/libipmiconsole.so.2
+	libipathverbs-rdmav2.so (libc6,x86-64) => /usr/lib64/libipathverbs-rdmav2.so
+	libipa_hbac.so.0 (libc6,x86-64) => /usr/lib64/libipa_hbac.so.0
+	libini_config.so.5 (libc6,x86-64) => /usr/lib64/libini_config.so.5
+	libinfinipath.so.4 (libc6,x86-64) => /usr/lib64/libinfinipath.so.4
+	libinfinipath.so (libc6,x86-64) => /usr/lib64/libinfinipath.so
+	libijs-0.35.so (libc6,x86-64) => /usr/lib64/libijs-0.35.so
+	libidn.so.11 (libc6,x86-64) => /lib64/libidn.so.11
+	libidn.so (libc6,x86-64) => /usr/lib64/libidn.so
+	libicuuc.so.42 (libc6,x86-64) => /usr/lib64/libicuuc.so.42
+	libicutu.so.42 (libc6,x86-64) => /usr/lib64/libicutu.so.42
+	libiculx.so.42 (libc6,x86-64) => /usr/lib64/libiculx.so.42
+	libicule.so.42 (libc6,x86-64) => /usr/lib64/libicule.so.42
+	libicui18n.so.42 (libc6,x86-64) => /usr/lib64/libicui18n.so.42
+	libicuio.so.42 (libc6,x86-64) => /usr/lib64/libicuio.so.42
+	libicudata.so.42 (libc6,x86-64) => /usr/lib64/libicudata.so.42
+	libibverbs.so.1 (libc6,x86-64) => /usr/lib64/libibverbs.so.1
+	libibverbs.so (libc6,x86-64) => /usr/lib64/libibverbs.so
+	libibumad.so.3 (libc6,x86-64) => /usr/lib64/libibumad.so.3
+	libibumad.so (libc6,x86-64) => /usr/lib64/libibumad.so
+	libibsysapi.so.1 (libc6,x86-64) => /opt/ibutils/lib64/libibsysapi.so.1
+	libibsysapi.so (libc6,x86-64) => /opt/ibutils/lib64/libibsysapi.so
+	libibsysapi-2.1.1.so (libc6,x86-64) => /usr/lib64/libibsysapi-2.1.1.so
+	libibprof.so.0 (libc6,x86-64) => /opt/mellanox/libibperf/lib/libibprof.so.0
+	libibprof.so (libc6,x86-64) => /opt/mellanox/libibperf/lib/libibprof.so
+	libibnetdisc.so.5 (libc6,x86-64) => /usr/lib64/libibnetdisc.so.5
+	libibnetdisc.so (libc6,x86-64) => /usr/lib64/libibnetdisc.so
+	libibmscli.so.1 (libc6,x86-64) => /opt/ibutils/lib64/libibmscli.so.1
+	libibmscli.so (libc6,x86-64) => /opt/ibutils/lib64/libibmscli.so
+	libibmad.so.5 (libc6,x86-64) => /usr/lib64/libibmad.so.5
+	libibmad.so (libc6,x86-64) => /usr/lib64/libibmad.so
+	libibis-2.1.1.so (libc6,x86-64) => /usr/lib64/libibis-2.1.1.so
+	libibdmcom.so.1 (libc6,x86-64) => /opt/ibutils/lib64/libibdmcom.so.1
+	libibdmcom.so (libc6,x86-64) => /opt/ibutils/lib64/libibdmcom.so
+	libibdmcom-2.1.1.so (libc6,x86-64) => /usr/lib64/libibdmcom-2.1.1.so
+	libibdm.so.1 (libc6,x86-64) => /opt/ibutils/lib64/libibdm.so.1
+	libibdm.so (libc6,x86-64) => /opt/ibutils/lib64/libibdm.so
+	libibdiagnet_plugins_ifc-2.1.1.so (libc6,x86-64) => /usr/lib64/libibdiagnet_plugins_ifc-2.1.1.so
+	libibdiag-2.1.1.so (libc6,x86-64) => /usr/lib64/libibdiag-2.1.1.so
+	libibcm.so.1 (libc6,x86-64) => /usr/lib64/libibcm.so.1
+	libibcm.so (libc6,x86-64) => /usr/lib64/libibcm.so
+	libhwloc.so.5 (libc6,x86-64) => /usr/lib64/libhwloc.so.5
+	libhwloc.so.1 (libc6,x86-64) => /usr/lib64/libhwloc.so.1
+	libhwloc.so (libc6,x86-64) => /usr/lib64/libhwloc.so
+	libhunspell-1.2.so.0 (libc6,x86-64) => /usr/lib64/libhunspell-1.2.so.0
+	libhistory.so.6 (libc6,x86-64) => /usr/lib64/libhistory.so.6
+	libhistory.so.5 (libc6,x86-64) => /usr/lib64/libhistory.so.5
+	libhistory.so (libc6,x86-64) => /usr/lib64/libhistory.so
+	libhesiod.so.0 (libc6,x86-64) => /usr/lib64/libhesiod.so.0
+	libhandle.so.1 (libc6,x86-64) => /lib64/libhandle.so.1
+	libhandle.so (libc6,x86-64) => /usr/lib64/libhandle.so
+	libhal.so.1 (libc6,x86-64) => /usr/lib64/libhal.so.1
+	libhal-storage.so.1 (libc6,x86-64) => /usr/lib64/libhal-storage.so.1
+	libg2c.so.0 (libc6,x86-64) => /usr/lib64/libg2c.so.0
+	libgvpr.so.1 (libc6,x86-64) => /usr/lib64/libgvpr.so.1
+	libgvfscommon.so.0 (libc6,x86-64) => /usr/lib64/libgvfscommon.so.0
+	libgvfscommon-dnssd.so.0 (libc6,x86-64) => /usr/lib64/libgvfscommon-dnssd.so.0
+	libgvc.so.5 (libc6,x86-64) => /usr/lib64/libgvc.so.5
+	libguilereadline-v-17.so.17 (libc6,x86-64) => /usr/lib64/libguilereadline-v-17.so.17
+	libguilereadline-v-17.so (libc6,x86-64) => /usr/lib64/libguilereadline-v-17.so
+	libguile.so.17 (libc6,x86-64) => /usr/lib64/libguile.so.17
+	libguile.so (libc6,x86-64) => /usr/lib64/libguile.so
+	libguile-srfi-srfi-60-v-2.so.2 (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-60-v-2.so.2
+	libguile-srfi-srfi-60-v-2.so (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-60-v-2.so
+	libguile-srfi-srfi-13-14-v-3.so.3 (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-13-14-v-3.so.3
+	libguile-srfi-srfi-13-14-v-3.so (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-13-14-v-3.so
+	libguile-srfi-srfi-4-v-3.so.3 (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-4-v-3.so.3
+	libguile-srfi-srfi-4-v-3.so (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-4-v-3.so
+	libguile-srfi-srfi-1-v-3.so.3 (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-1-v-3.so.3
+	libguile-srfi-srfi-1-v-3.so (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-1-v-3.so
+	libgudev-1.0.so.0 (libc6,x86-64) => /usr/lib64/libgudev-1.0.so.0
+	libgtk-1.2.so.0 (libc6,x86-64) => /usr/lib64/libgtk-1.2.so.0
+	libgtk-x11-2.0.so.0 (libc6,x86-64) => /usr/lib64/libgtk-x11-2.0.so.0
+	libgtk-x11-2.0.so (libc6,x86-64) => /usr/lib64/libgtk-x11-2.0.so
+	libgthread-2.0.so.0 (libc6,x86-64) => /lib64/libgthread-2.0.so.0
+	libgthread-2.0.so (libc6,x86-64) => /usr/lib64/libgthread-2.0.so
+	libgthread-1.2.so.0 (libc6,x86-64) => /usr/lib64/libgthread-1.2.so.0
+	libgstvideo-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstvideo-0.10.so.0
+	libgsttag-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgsttag-0.10.so.0
+	libgstsdp-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstsdp-0.10.so.0
+	libgstrtsp-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstrtsp-0.10.so.0
+	libgstrtp-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstrtp-0.10.so.0
+	libgstriff-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstriff-0.10.so.0
+	libgstreamer-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstreamer-0.10.so.0
+	libgstpbutils-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstpbutils-0.10.so.0
+	libgstnetbuffer-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstnetbuffer-0.10.so.0
+	libgstnet-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstnet-0.10.so.0
+	libgstinterfaces-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstinterfaces-0.10.so.0
+	libgstfft-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstfft-0.10.so.0
+	libgstdataprotocol-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstdataprotocol-0.10.so.0
+	libgstcontroller-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstcontroller-0.10.so.0
+	libgstcdda-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstcdda-0.10.so.0
+	libgstbase-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstbase-0.10.so.0
+	libgstaudio-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstaudio-0.10.so.0
+	libgstapp-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstapp-0.10.so.0
+	libgssrpc.so.4 (libc6,x86-64) => /lib64/libgssrpc.so.4
+	libgssrpc.so (libc6,x86-64) => /usr/lib64/libgssrpc.so
+	libgssglue.so.1 (libc6,x86-64) => /lib64/libgssglue.so.1
+	libgssapi_krb5.so.2 (libc6,x86-64) => /lib64/libgssapi_krb5.so.2
+	libgssapi_krb5.so (libc6,x86-64) => /usr/lib64/libgssapi_krb5.so
+	libgsf-1.so.114 (libc6,x86-64) => /usr/lib64/libgsf-1.so.114
+	libgs.so.8 (libc6,x86-64) => /usr/lib64/libgs.so.8
+	libgs.so (libc6,x86-64) => /usr/lib64/libgs.so
+	libgraph.so.4 (libc6,x86-64) => /usr/lib64/libgraph.so.4
+	libgp11.so.0 (libc6,x86-64) => /usr/lib64/libgp11.so.0
+	libgpm.so.2 (libc6,x86-64) => /usr/lib64/libgpm.so.2
+	libgpgme.so.11 (libc6,x86-64) => /usr/lib64/libgpgme.so.11
+	libgpgme-pthread.so.11 (libc6,x86-64) => /usr/lib64/libgpgme-pthread.so.11
+	libgpgme-pth.so.11 (libc6,x86-64) => /usr/lib64/libgpgme-pth.so.11
+	libgpg-error.so.0 (libc6,x86-64) => /lib64/libgpg-error.so.0
+	libgpg-error.so (libc6,x86-64) => /usr/lib64/libgpg-error.so
+	libgomp.so.1 (libc6,x86-64) => /usr/lib64/libgomp.so.1
+	libgobject-2.0.so.0 (libc6,x86-64) => /lib64/libgobject-2.0.so.0
+	libgobject-2.0.so (libc6,x86-64) => /usr/lib64/libgobject-2.0.so
+	libgnutlsxx.so.26 (libc6,x86-64) => /usr/lib64/libgnutlsxx.so.26
+	libgnutls.so.26 (libc6,x86-64) => /usr/lib64/libgnutls.so.26
+	libgnutls-extra.so.26 (libc6,x86-64) => /usr/lib64/libgnutls-extra.so.26
+	libgnomevfs-2.so.0 (libc6,x86-64) => /usr/lib64/libgnomevfs-2.so.0
+	libgnomeui-2.so.0 (libc6,x86-64) => /usr/lib64/libgnomeui-2.so.0
+	libgnomecanvas-2.so.0 (libc6,x86-64) => /usr/lib64/libgnomecanvas-2.so.0
+	libgnome-2.so.0 (libc6,x86-64) => /usr/lib64/libgnome-2.so.0
+	libgnome-keyring.so.0 (libc6,x86-64) => /usr/lib64/libgnome-keyring.so.0
+	libgnome-desktop-2.so.11 (libc6,x86-64) => /usr/lib64/libgnome-desktop-2.so.11
+	libgmpxx.so.4 (libc6,x86-64) => /usr/lib64/libgmpxx.so.4
+	libgmpxx.so (libc6,x86-64) => /usr/lib64/libgmpxx.so
+	libgmp.so.3 (libc6,x86-64) => /usr/lib64/libgmp.so.3
+	libgmp.so (libc6,x86-64) => /usr/lib64/libgmp.so
+	libgmodule-2.0.so.0 (libc6,x86-64) => /lib64/libgmodule-2.0.so.0
+	libgmodule-2.0.so (libc6,x86-64) => /usr/lib64/libgmodule-2.0.so
+	libgmodule-1.2.so.0 (libc6,x86-64) => /usr/lib64/libgmodule-1.2.so.0
+	libglut.so.3 (libc6,x86-64) => /usr/lib64/libglut.so.3
+	libglut.so (libc6,x86-64) => /usr/lib64/libglut.so
+	libglib-2.0.so.0 (libc6,x86-64) => /lib64/libglib-2.0.so.0
+	libglib-2.0.so (libc6,x86-64) => /usr/lib64/libglib-2.0.so
+	libglib-1.2.so.0 (libc6,x86-64) => /usr/lib64/libglib-1.2.so.0
+	libglapi.so.0 (libc6,x86-64) => /usr/lib64/libglapi.so.0
+	libglapi.so.0 (libc6) => /usr/lib/libglapi.so.0
+	libglapi.so (libc6,x86-64) => /usr/lib64/libglapi.so
+	libglapi.so (libc6) => /usr/lib/libglapi.so
+	libglade-2.0.so.0 (libc6,x86-64) => /usr/lib64/libglade-2.0.so.0
+	libgio-2.0.so.0 (libc6,x86-64) => /lib64/libgio-2.0.so.0
+	libgio-2.0.so (libc6,x86-64) => /usr/lib64/libgio-2.0.so
+	libgif.so.4 (libc6,x86-64) => /usr/lib64/libgif.so.4
+	libgif.so (libc6,x86-64) => /usr/lib64/libgif.so
+	libgfortran.so.3 (libc6,x86-64) => /usr/lib64/libgfortran.so.3
+	libgfortran.so.1 (libc6,x86-64) => /usr/lib64/libgfortran.so.1
+	libgettextsrc-0.17.so (libc6,x86-64) => /usr/lib64/libgettextsrc-0.17.so
+	libgettextlib-0.17.so (libc6,x86-64) => /usr/lib64/libgettextlib-0.17.so
+	libgeotiff.so.1.2 (libc6,x86-64) => /usr/lib64/libgeotiff.so.1.2
+	libgensec.so.0 (libc6,x86-64) => /usr/lib64/libgensec.so.0
+	libgdu.so.0 (libc6,x86-64) => /usr/lib64/libgdu.so.0
+	libgdk_pixbuf_xlib-2.0.so.0 (libc6,x86-64) => /usr/lib64/libgdk_pixbuf_xlib-2.0.so.0
+	libgdk_pixbuf_xlib-2.0.so (libc6,x86-64) => /usr/lib64/libgdk_pixbuf_xlib-2.0.so
+	libgdk_pixbuf-2.0.so.0 (libc6,x86-64) => /usr/lib64/libgdk_pixbuf-2.0.so.0
+	libgdk_pixbuf-2.0.so (libc6,x86-64) => /usr/lib64/libgdk_pixbuf-2.0.so
+	libgdk-1.2.so.0 (libc6,x86-64) => /usr/lib64/libgdk-1.2.so.0
+	libgdk-x11-2.0.so.0 (libc6,x86-64) => /usr/lib64/libgdk-x11-2.0.so.0
+	libgdk-x11-2.0.so (libc6,x86-64) => /usr/lib64/libgdk-x11-2.0.so
+	libgdbm.so.2 (libc6,x86-64) => /usr/lib64/libgdbm.so.2
+	libgdbm.so (libc6,x86-64) => /usr/lib64/libgdbm.so
+	libgd.so.2 (libc6,x86-64) => /usr/lib64/libgd.so.2
+	libgd.so (libc6,x86-64) => /usr/lib64/libgd.so
+	libgcrypt.so.11 (libc6,x86-64) => /lib64/libgcrypt.so.11
+	libgcrypt.so (libc6,x86-64) => /usr/lib64/libgcrypt.so
+	libgcr.so.0 (libc6,x86-64) => /usr/lib64/libgcr.so.0
+	libgconf-2.so.4 (libc6,x86-64) => /usr/lib64/libgconf-2.so.4
+	libgcc_s.so.1 (libc6,x86-64) => /lib64/libgcc_s.so.1
+	libgcc_s.so.1 (libc6) => /lib/libgcc_s.so.1
+	libgbm.so.1 (libc6,x86-64) => /usr/lib64/libgbm.so.1
+	libganglia.so.0 (libc6,x86-64) => /usr/lib64/libganglia.so.0
+	libganglia-3.6.0.so.0 (libc6,x86-64) => /usr/lib64/libganglia-3.6.0.so.0
+	libgamin-1.so.0 (libc6,x86-64) => /usr/lib64/libgamin-1.so.0
+	libgailutil.so.18 (libc6,x86-64) => /usr/lib64/libgailutil.so.18
+	libgailutil.so (libc6,x86-64) => /usr/lib64/libgailutil.so
+	libfreetype.so.6 (libc6,x86-64) => /usr/lib64/libfreetype.so.6
+	libfreetype.so.6 (libc6) => /usr/lib/libfreetype.so.6
+	libfreetype.so (libc6,x86-64) => /usr/lib64/libfreetype.so
+	libfreeipmi.so.13 (libc6,x86-64) => /usr/lib64/libfreeipmi.so.13
+	libfreebl3.so (libc6,x86-64) => /lib64/libfreebl3.so
+	libfreebl3.so (libc6,x86-64) => /usr/lib64/libfreebl3.so
+	libfreebl3.so (libc6) => /lib/libfreebl3.so
+	libfreebl3.so (libc6) => /usr/lib/libfreebl3.so
+	libfreeblpriv3.so (libc6,x86-64) => /lib64/libfreeblpriv3.so
+	libfreeblpriv3.so (libc6,x86-64) => /usr/lib64/libfreeblpriv3.so
+	libfreeblpriv3.so (libc6) => /lib/libfreeblpriv3.so
+	libfreeblpriv3.so (libc6) => /usr/lib/libfreeblpriv3.so
+	libformw.so.5 (libc6,x86-64) => /usr/lib64/libformw.so.5
+	libformw.so.5 (libc6) => /usr/lib/libformw.so.5
+	libformw.so (libc6,x86-64) => /usr/lib64/libformw.so
+	libformw.so (libc6) => /usr/lib/libformw.so
+	libform.so.5 (libc6,x86-64) => /usr/lib64/libform.so.5
+	libform.so.5 (libc6) => /usr/lib/libform.so.5
+	libform.so (libc6,x86-64) => /usr/lib64/libform.so
+	libform.so (libc6) => /usr/lib/libform.so
+	libfontenc.so.1 (libc6,x86-64) => /usr/lib64/libfontenc.so.1
+	libfontconfig.so.1 (libc6,x86-64) => /usr/lib64/libfontconfig.so.1
+	libfontconfig.so.1 (libc6) => /usr/lib/libfontconfig.so.1
+	libfontconfig.so (libc6,x86-64) => /usr/lib64/libfontconfig.so
+	libfltk_images.so.1.1 (libc6,x86-64) => /usr/lib64/libfltk_images.so.1.1
+	libfltk_gl.so.1.1 (libc6,x86-64) => /usr/lib64/libfltk_gl.so.1.1
+	libfltk_forms.so.1.1 (libc6,x86-64) => /usr/lib64/libfltk_forms.so.1.1
+	libfltk.so.1.1 (libc6,x86-64) => /usr/lib64/libfltk.so.1.1
+	libfipscheck.so.1 (libc6,x86-64) => /lib64/libfipscheck.so.1
+	libffi.so.5 (libc6,x86-64) => /usr/lib64/libffi.so.5
+	libffi.so (libc6,x86-64) => /usr/lib64/libffi.so
+	libfca.so.0 (libc6,x86-64) => /opt/mellanox/fca/lib/libfca.so.0
+	libfca.so (libc6,x86-64) => /opt/mellanox/fca/lib/libfca.so
+	libfam.so.0 (libc6,x86-64) => /usr/lib64/libfam.so.0
+	libe2p.so.2 (libc6,x86-64) => /lib64/libe2p.so.2
+	libe2p.so (libc6,x86-64) => /usr/lib64/libe2p.so
+	libext2fs.so.2 (libc6,x86-64) => /lib64/libext2fs.so.2
+	libext2fs.so (libc6,x86-64) => /usr/lib64/libext2fs.so
+	libexslt.so.0 (libc6,x86-64) => /usr/lib64/libexslt.so.0
+	libexslt.so (libc6,x86-64) => /usr/lib64/libexslt.so
+	libexpect5.44.1.15.so (libc6,x86-64) => /usr/lib64/libexpect5.44.1.15.so
+	libexpect.so (libc6,x86-64) => /usr/lib64/libexpect.so
+	libexpat.so.1 (libc6,x86-64) => /lib64/libexpat.so.1
+	libexpat.so.1 (libc6) => /lib/libexpat.so.1
+	libexpat.so (libc6,x86-64) => /usr/lib64/libexpat.so
+	libexif.so.12 (libc6,x86-64) => /usr/lib64/libexif.so.12
+	libexempi.so.3 (libc6,x86-64) => /usr/lib64/libexempi.so.3
+	libevview.so.1 (libc6,x86-64) => /usr/lib64/libevview.so.1
+	libevent_extra-1.4.so.2 (libc6,x86-64) => /usr/lib64/libevent_extra-1.4.so.2
+	libevent_core-1.4.so.2 (libc6,x86-64) => /usr/lib64/libevent_core-1.4.so.2
+	libevent-1.4.so.2 (libc6,x86-64) => /usr/lib64/libevent-1.4.so.2
+	libevdocument.so.1 (libc6,x86-64) => /usr/lib64/libevdocument.so.1
+	libevdev.so.2 (libc6,x86-64) => /usr/lib64/libevdev.so.2
+	libepoxy.so.0 (libc6,x86-64) => /usr/lib64/libepoxy.so.0
+	libelf.so.1 (libc6,x86-64) => /usr/lib64/libelf.so.1
+	libelf.so.1 (libc6) => /usr/lib/libelf.so.1
+	libeggdbus-1.so.0 (libc6,x86-64) => /usr/lib64/libeggdbus-1.so.0
+	libedit.so.0 (libc6,x86-64) => /usr/lib64/libedit.so.0
+	libecpg_compat.so.3 (libc6,x86-64) => /usr/lib64/libecpg_compat.so.3
+	libecpg_compat.so (libc6,x86-64) => /usr/lib64/libecpg_compat.so
+	libecpg.so.6 (libc6,x86-64) => /usr/lib64/libecpg.so.6
+	libecpg.so (libc6,x86-64) => /usr/lib64/libecpg.so
+	libdw.so.1 (libc6,x86-64) => /usr/lib64/libdw.so.1
+	libdump_pr.so.1 (libc6,x86-64) => /usr/lib64/libdump_pr.so.1
+	libdump_pr.so (libc6,x86-64) => /usr/lib64/libdump_pr.so
+	libdrm_radeon.so.1 (libc6,x86-64) => /usr/lib64/libdrm_radeon.so.1
+	libdrm_radeon.so.1 (libc6) => /usr/lib/libdrm_radeon.so.1
+	libdrm_radeon.so (libc6,x86-64) => /usr/lib64/libdrm_radeon.so
+	libdrm_nouveau2.so.2 (libc6,x86-64) => /usr/lib64/libdrm_nouveau2.so.2
+	libdrm_nouveau2.so.2 (libc6) => /usr/lib/libdrm_nouveau2.so.2
+	libdrm_nouveau2.so (libc6,x86-64) => /usr/lib64/libdrm_nouveau2.so
+	libdrm_nouveau.so.1 (libc6,x86-64) => /usr/lib64/libdrm_nouveau.so.1
+	libdrm_nouveau.so.1 (libc6) => /usr/lib/libdrm_nouveau.so.1
+	libdrm_nouveau.so (libc6,x86-64) => /usr/lib64/libdrm_nouveau.so
+	libdrm_intel.so.1 (libc6,x86-64) => /usr/lib64/libdrm_intel.so.1
+	libdrm_intel.so.1 (libc6) => /usr/lib/libdrm_intel.so.1
+	libdrm_intel.so (libc6,x86-64) => /usr/lib64/libdrm_intel.so
+	libdrm_amdgpu.so.1 (libc6,x86-64) => /usr/lib64/libdrm_amdgpu.so.1
+	libdrm_amdgpu.so.1 (libc6) => /usr/lib/libdrm_amdgpu.so.1
+	libdrm_amdgpu.so (libc6,x86-64) => /usr/lib64/libdrm_amdgpu.so
+	libdrm.so.2 (libc6,x86-64) => /usr/lib64/libdrm.so.2
+	libdrm.so.2 (libc6) => /usr/lib/libdrm.so.2
+	libdrm.so (libc6,x86-64) => /usr/lib64/libdrm.so
+	libdns.so.81 (libc6,x86-64) => /usr/lib64/libdns.so.81
+	libdmx.so.1 (libc6,x86-64) => /usr/lib64/libdmx.so.1
+	libdl.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libdl.so.2
+	libdl.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libdl.so.2
+	libdl.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libdl.so
+	libdl.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libdl.so
+	libdhash.so.1 (libc6,x86-64) => /usr/lib64/libdhash.so.1
+	libdevmapper.so.1.02 (libc6,x86-64) => /lib64/libdevmapper.so.1.02
+	libdevmapper-event.so.1.02 (libc6,x86-64) => /lib64/libdevmapper-event.so.1.02
+	libdevmapper-event-lvm2thin.so (libc6,x86-64) => /lib64/libdevmapper-event-lvm2thin.so
+	libdevmapper-event-lvm2snapshot.so (libc6,x86-64) => /lib64/libdevmapper-event-lvm2snapshot.so
+	libdevmapper-event-lvm2raid.so (libc6,x86-64) => /lib64/libdevmapper-event-lvm2raid.so
+	libdevmapper-event-lvm2mirror.so (libc6,x86-64) => /lib64/libdevmapper-event-lvm2mirror.so
+	libdevmapper-event-lvm2.so.2.02 (libc6,x86-64) => /lib64/libdevmapper-event-lvm2.so.2.02
+	libdcerpc.so.0 (libc6,x86-64) => /usr/lib64/libdcerpc.so.0
+	libdcerpc-samr.so.0 (libc6,x86-64) => /usr/lib64/libdcerpc-samr.so.0
+	libdcerpc-binding.so.0 (libc6,x86-64) => /usr/lib64/libdcerpc-binding.so.0
+	libdcerpc-atsvc.so.0 (libc6,x86-64) => /usr/lib64/libdcerpc-atsvc.so.0
+	libdbus-1.so.3 (libc6,x86-64) => /lib64/libdbus-1.so.3
+	libdbus-glib-1.so.2 (libc6,x86-64) => /usr/lib64/libdbus-glib-1.so.2
+	libdb_cxx-4.7.so (libc6,x86-64) => /usr/lib64/libdb_cxx-4.7.so
+	libdb-4.7.so (libc6,x86-64) => /lib64/libdb-4.7.so
+	libdb-4.7.so (libc6,x86-64) => /usr/lib64/libdb-4.7.so
+	libdat2.so.2 (libc6,x86-64) => /usr/lib64/libdat2.so.2
+	libdat2.so (libc6,x86-64) => /usr/lib64/libdat2.so
+	libdaploucm.so.2 (libc6,x86-64) => /usr/lib64/libdaploucm.so.2
+	libdaploucm.so (libc6,x86-64) => /usr/lib64/libdaploucm.so
+	libdaploscm.so.2 (libc6,x86-64) => /usr/lib64/libdaploscm.so.2
+	libdaploscm.so (libc6,x86-64) => /usr/lib64/libdaploscm.so
+	libdaplofa.so.2 (libc6,x86-64) => /usr/lib64/libdaplofa.so.2
+	libdaplofa.so (libc6,x86-64) => /usr/lib64/libdaplofa.so
+	libdaemon.so.0 (libc6,x86-64) => /usr/lib64/libdaemon.so.0
+	libcxgb4-rdmav2.so (libc6,x86-64) => /usr/lib64/libcxgb4-rdmav2.so
+	libcxgb3-rdmav2.so (libc6,x86-64) => /usr/lib64/libcxgb3-rdmav2.so
+	libcurl.so.4 (libc6,x86-64) => /usr/lib64/libcurl.so.4
+	libcurl.so (libc6,x86-64) => /usr/lib64/libcurl.so
+	libcupsppdc.so.1 (libc6,x86-64) => /usr/lib64/libcupsppdc.so.1
+	libcupsmime.so.1 (libc6,x86-64) => /usr/lib64/libcupsmime.so.1
+	libcupsimage.so.2 (libc6,x86-64) => /usr/lib64/libcupsimage.so.2
+	libcupsdriver.so.1 (libc6,x86-64) => /usr/lib64/libcupsdriver.so.1
+	libcupscgi.so.1 (libc6,x86-64) => /usr/lib64/libcupscgi.so.1
+	libcups.so.2 (libc6,x86-64) => /usr/lib64/libcups.so.2
+	libcuda.so.1 (libc6,x86-64) => /usr/lib64/libcuda.so.1
+	libcuda.so (libc6,x86-64) => /usr/lib64/libcuda.so
+	libcryptsetup.so.1 (libc6,x86-64) => /lib64/libcryptsetup.so.1
+	libcrypto.so.10 (libc6,x86-64) => /usr/lib64/libcrypto.so.10
+	libcrypto.so (libc6,x86-64) => /usr/lib64/libcrypto.so
+	libcrypt.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libcrypt.so.1
+	libcrypt.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libcrypt.so.1
+	libcrypt.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libcrypt.so
+	libcrypt.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libcrypt.so
+	libcroco-0.6.so.3 (libc6,x86-64) => /usr/lib64/libcroco-0.6.so.3
+	libcrack.so.2 (libc6,x86-64) => /usr/lib64/libcrack.so.2
+	libcpupower.so.0 (libc6,x86-64) => /usr/lib64/libcpupower.so.0
+	libcppunit-1.12.so.1 (libc6,x86-64) => /usr/lib64/libcppunit-1.12.so.1
+	libconfuse.so.0 (libc6,x86-64) => /usr/lib64/libconfuse.so.0
+	libconfuse.so (libc6,x86-64) => /usr/lib64/libconfuse.so
+	libcom_err.so.2 (libc6,x86-64) => /lib64/libcom_err.so.2
+	libcom_err.so (libc6,x86-64) => /usr/lib64/libcom_err.so
+	libcollection.so.4 (libc6,x86-64) => /usr/lib64/libcollection.so.4
+	libcmdparser-1.0.0.so (libc6,x86-64) => /usr/lib64/libcmdparser-1.0.0.so
+	libcloog.so.0 (libc6,x86-64) => /usr/lib64/libcloog.so.0
+	libck-connector.so.0 (libc6,x86-64) => /usr/lib64/libck-connector.so.0
+	libcidn.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libcidn.so.1
+	libcidn.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libcidn.so.1
+	libcidn.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libcidn.so
+	libcidn.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libcidn.so
+	libcgroup.so.1 (libc6,x86-64) => /lib64/libcgroup.so.1
+	libcgroup.so (libc6,x86-64) => /usr/lib64/libcgroup.so
+	libcgraph.so.4 (libc6,x86-64) => /usr/lib64/libcgraph.so.4
+	libcdt.so.4 (libc6,x86-64) => /usr/lib64/libcdt.so.4
+	libcdio_paranoia.so.0 (libc6,x86-64) => /usr/lib64/libcdio_paranoia.so.0
+	libcdio_cdda.so.0 (libc6,x86-64) => /usr/lib64/libcdio_cdda.so.0
+	libcdio.so.10 (libc6,x86-64) => /usr/lib64/libcdio.so.10
+	libcdio++.so.0 (libc6,x86-64) => /usr/lib64/libcdio++.so.0
+	libcdda_paranoia.so.0 (libc6,x86-64) => /usr/lib64/libcdda_paranoia.so.0
+	libcdda_paranoia.so (libc6,x86-64) => /usr/lib64/libcdda_paranoia.so
+	libcdda_interface.so.0 (libc6,x86-64) => /usr/lib64/libcdda_interface.so.0
+	libcdda_interface.so (libc6,x86-64) => /usr/lib64/libcdda_interface.so
+	libccmgr.so.1 (libc6,x86-64) => /usr/lib64/libccmgr.so.1
+	libccmgr.so (libc6,x86-64) => /usr/lib64/libccmgr.so
+	libcares.so.2 (libc6,x86-64) => /usr/lib64/libcares.so.2
+	libcap.so.2 (libc6,x86-64) => /lib64/libcap.so.2
+	libcap-ng.so.0 (libc6,x86-64) => /lib64/libcap-ng.so.0
+	libcairo.so.2 (libc6,x86-64) => /usr/lib64/libcairo.so.2
+	libcairo.so (libc6,x86-64) => /usr/lib64/libcairo.so
+	libc.so.6 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libc.so.6
+	libc.so.6 (libc6, hwcap: 0x0028000000000000, OS ABI: Linux 2.6.18) => /lib/i686/nosegneg/libc.so.6
+	libc.so.6 (libc6, OS ABI: Linux 2.6.18) => /lib/libc.so.6
+	libbz2.so.1 (libc6,x86-64) => /lib64/libbz2.so.1
+	libbz2.so (libc6,x86-64) => /usr/lib64/libbz2.so
+	libbtparser.so.2 (libc6,x86-64) => /usr/lib64/libbtparser.so.2
+	libboost_wserialization.so.5 (libc6,x86-64) => /usr/lib64/libboost_wserialization.so.5
+	libboost_wserialization.so (libc6,x86-64) => /usr/lib64/libboost_wserialization.so
+	libboost_wserialization-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_wserialization-mt.so.5
+	libboost_wserialization-mt.so (libc6,x86-64) => /usr/lib64/libboost_wserialization-mt.so
+	libboost_wave-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_wave-mt.so.5
+	libboost_wave-mt.so (libc6,x86-64) => /usr/lib64/libboost_wave-mt.so
+	libboost_unit_test_framework.so.5 (libc6,x86-64) => /usr/lib64/libboost_unit_test_framework.so.5
+	libboost_unit_test_framework.so (libc6,x86-64) => /usr/lib64/libboost_unit_test_framework.so
+	libboost_unit_test_framework-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_unit_test_framework-mt.so.5
+	libboost_unit_test_framework-mt.so (libc6,x86-64) => /usr/lib64/libboost_unit_test_framework-mt.so
+	libboost_thread-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_thread-mt.so.5
+	libboost_thread-mt.so (libc6,x86-64) => /usr/lib64/libboost_thread-mt.so
+	libboost_system.so.5 (libc6,x86-64) => /usr/lib64/libboost_system.so.5
+	libboost_system.so (libc6,x86-64) => /usr/lib64/libboost_system.so
+	libboost_system-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_system-mt.so.5
+	libboost_system-mt.so (libc6,x86-64) => /usr/lib64/libboost_system-mt.so
+	libboost_signals.so.5 (libc6,x86-64) => /usr/lib64/libboost_signals.so.5
+	libboost_signals.so (libc6,x86-64) => /usr/lib64/libboost_signals.so
+	libboost_signals-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_signals-mt.so.5
+	libboost_signals-mt.so (libc6,x86-64) => /usr/lib64/libboost_signals-mt.so
+	libboost_serialization.so.5 (libc6,x86-64) => /usr/lib64/libboost_serialization.so.5
+	libboost_serialization.so (libc6,x86-64) => /usr/lib64/libboost_serialization.so
+	libboost_serialization-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_serialization-mt.so.5
+	libboost_serialization-mt.so (libc6,x86-64) => /usr/lib64/libboost_serialization-mt.so
+	libboost_regex.so.5 (libc6,x86-64) => /usr/lib64/libboost_regex.so.5
+	libboost_regex.so (libc6,x86-64) => /usr/lib64/libboost_regex.so
+	libboost_regex-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_regex-mt.so.5
+	libboost_regex-mt.so (libc6,x86-64) => /usr/lib64/libboost_regex-mt.so
+	libboost_python.so.5 (libc6,x86-64) => /usr/lib64/libboost_python.so.5
+	libboost_python.so (libc6,x86-64) => /usr/lib64/libboost_python.so
+	libboost_python-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_python-mt.so.5
+	libboost_python-mt.so (libc6,x86-64) => /usr/lib64/libboost_python-mt.so
+	libboost_program_options.so.5 (libc6,x86-64) => /usr/lib64/libboost_program_options.so.5
+	libboost_program_options.so (libc6,x86-64) => /usr/lib64/libboost_program_options.so
+	libboost_program_options-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_program_options-mt.so.5
+	libboost_program_options-mt.so (libc6,x86-64) => /usr/lib64/libboost_program_options-mt.so
+	libboost_prg_exec_monitor.so.5 (libc6,x86-64) => /usr/lib64/libboost_prg_exec_monitor.so.5
+	libboost_prg_exec_monitor.so (libc6,x86-64) => /usr/lib64/libboost_prg_exec_monitor.so
+	libboost_prg_exec_monitor-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_prg_exec_monitor-mt.so.5
+	libboost_prg_exec_monitor-mt.so (libc6,x86-64) => /usr/lib64/libboost_prg_exec_monitor-mt.so
+	libboost_math_tr1l.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1l.so.5
+	libboost_math_tr1l.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1l.so
+	libboost_math_tr1l-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1l-mt.so.5
+	libboost_math_tr1l-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1l-mt.so
+	libboost_math_tr1f.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1f.so.5
+	libboost_math_tr1f.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1f.so
+	libboost_math_tr1f-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1f-mt.so.5
+	libboost_math_tr1f-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1f-mt.so
+	libboost_math_tr1.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1.so.5
+	libboost_math_tr1.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1.so
+	libboost_math_tr1-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1-mt.so.5
+	libboost_math_tr1-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1-mt.so
+	libboost_math_c99l.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99l.so.5
+	libboost_math_c99l.so (libc6,x86-64) => /usr/lib64/libboost_math_c99l.so
+	libboost_math_c99l-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99l-mt.so.5
+	libboost_math_c99l-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_c99l-mt.so
+	libboost_math_c99f.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99f.so.5
+	libboost_math_c99f.so (libc6,x86-64) => /usr/lib64/libboost_math_c99f.so
+	libboost_math_c99f-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99f-mt.so.5
+	libboost_math_c99f-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_c99f-mt.so
+	libboost_math_c99.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99.so.5
+	libboost_math_c99.so (libc6,x86-64) => /usr/lib64/libboost_math_c99.so
+	libboost_math_c99-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99-mt.so.5
+	libboost_math_c99-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_c99-mt.so
+	libboost_iostreams.so.5 (libc6,x86-64) => /usr/lib64/libboost_iostreams.so.5
+	libboost_iostreams.so (libc6,x86-64) => /usr/lib64/libboost_iostreams.so
+	libboost_iostreams-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_iostreams-mt.so.5
+	libboost_iostreams-mt.so (libc6,x86-64) => /usr/lib64/libboost_iostreams-mt.so
+	libboost_graph.so.5 (libc6,x86-64) => /usr/lib64/libboost_graph.so.5
+	libboost_graph.so (libc6,x86-64) => /usr/lib64/libboost_graph.so
+	libboost_graph-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_graph-mt.so.5
+	libboost_graph-mt.so (libc6,x86-64) => /usr/lib64/libboost_graph-mt.so
+	libboost_filesystem.so.5 (libc6,x86-64) => /usr/lib64/libboost_filesystem.so.5
+	libboost_filesystem.so (libc6,x86-64) => /usr/lib64/libboost_filesystem.so
+	libboost_filesystem-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_filesystem-mt.so.5
+	libboost_filesystem-mt.so (libc6,x86-64) => /usr/lib64/libboost_filesystem-mt.so
+	libboost_date_time.so.5 (libc6,x86-64) => /usr/lib64/libboost_date_time.so.5
+	libboost_date_time.so (libc6,x86-64) => /usr/lib64/libboost_date_time.so
+	libboost_date_time-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_date_time-mt.so.5
+	libboost_date_time-mt.so (libc6,x86-64) => /usr/lib64/libboost_date_time-mt.so
+	libbonoboui-2.so.0 (libc6,x86-64) => /usr/lib64/libbonoboui-2.so.0
+	libbonobo-2.so.0 (libc6,x86-64) => /usr/lib64/libbonobo-2.so.0
+	libbonobo-activation.so.4 (libc6,x86-64) => /usr/lib64/libbonobo-activation.so.4
+	libblkid.so.1 (libc6,x86-64) => /lib64/libblkid.so.1
+	libbiosconfig_expat.so.0 (libc6,x86-64) => /usr/lib64/libbiosconfig_expat.so.0
+	libbiosconfig_expat.so (libc6,x86-64) => /usr/lib64/libbiosconfig_expat.so
+	libbind9.so.80 (libc6,x86-64) => /usr/lib64/libbind9.so.80
+	libbfd-2.20.51.0.2-5.44.el6.so (libc6,x86-64) => /usr/lib64/libbfd-2.20.51.0.2-5.44.el6.so
+	libbasicobjects.so.0 (libc6,x86-64) => /usr/lib64/libbasicobjects.so.0
+	liba2ps.so.1 (libc6,x86-64) => /usr/lib64/liba2ps.so.1
+	libavahi-glib.so.1 (libc6,x86-64) => /usr/lib64/libavahi-glib.so.1
+	libavahi-core.so.6 (libc6,x86-64) => /usr/lib64/libavahi-core.so.6
+	libavahi-common.so.3 (libc6,x86-64) => /usr/lib64/libavahi-common.so.3
+	libavahi-client.so.3 (libc6,x86-64) => /usr/lib64/libavahi-client.so.3
+	libauparse.so.0 (libc6,x86-64) => /lib64/libauparse.so.0
+	libaudit.so.1 (libc6,x86-64) => /lib64/libaudit.so.1
+	libattr.so.1 (libc6,x86-64) => /lib64/libattr.so.1
+	libattr.so (libc6,x86-64) => /lib64/libattr.so
+	libattr.so (libc6,x86-64) => /usr/lib64/libattr.so
+	libatk-1.0.so.0 (libc6,x86-64) => /usr/lib64/libatk-1.0.so.0
+	libatk-1.0.so (libc6,x86-64) => /usr/lib64/libatk-1.0.so
+	libatasmart.so.4 (libc6,x86-64) => /usr/lib64/libatasmart.so.4
+	libasound.so.2 (libc6,x86-64) => /lib64/libasound.so.2
+	libasm.so.1 (libc6,x86-64) => /usr/lib64/libasm.so.1
+	libart_lgpl_2.so.2 (libc6,x86-64) => /usr/lib64/libart_lgpl_2.so.2
+	libart_lgpl_2.so (libc6,x86-64) => /usr/lib64/libart_lgpl_2.so
+	libarmgr.so.1 (libc6,x86-64) => /usr/lib64/libarmgr.so.1
+	libarmgr.so (libc6,x86-64) => /usr/lib64/libarmgr.so
+	libaprutil-1.so.0 (libc6,x86-64) => /usr/lib64/libaprutil-1.so.0
+	libaprutil-1.so (libc6,x86-64) => /usr/lib64/libaprutil-1.so
+	libapr-1.so.0 (libc6,x86-64) => /usr/lib64/libapr-1.so.0
+	libapr-1.so (libc6,x86-64) => /usr/lib64/libapr-1.so
+	libanl.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libanl.so.1
+	libanl.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libanl.so.1
+	libanl.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libanl.so
+	libanl.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libanl.so
+	libaio.so.1.0.0 (libc6,x86-64) => /lib64/libaio.so.1.0.0
+	libaio.so.1 (libc6,x86-64) => /lib64/libaio.so.1
+	libaio.so (libc6,x86-64) => /usr/lib64/libaio.so
+	libacl.so.1 (libc6,x86-64) => /lib64/libacl.so.1
+	libacl.so (libc6,x86-64) => /lib64/libacl.so
+	libacl.so (libc6,x86-64) => /usr/lib64/libacl.so
+	libX11.so.6 (libc6,x86-64) => /usr/lib64/libX11.so.6
+	libX11.so.6 (libc6) => /usr/lib/libX11.so.6
+	libX11.so (libc6,x86-64) => /usr/lib64/libX11.so
+	libX11-xcb.so.1 (libc6,x86-64) => /usr/lib64/libX11-xcb.so.1
+	libX11-xcb.so.1 (libc6) => /usr/lib/libX11-xcb.so.1
+	libX11-xcb.so (libc6,x86-64) => /usr/lib64/libX11-xcb.so
+	libXxf86vm.so.1 (libc6,x86-64) => /usr/lib64/libXxf86vm.so.1
+	libXxf86vm.so.1 (libc6) => /usr/lib/libXxf86vm.so.1
+	libXxf86vm.so (libc6,x86-64) => /usr/lib64/libXxf86vm.so
+	libXxf86misc.so.1 (libc6,x86-64) => /usr/lib64/libXxf86misc.so.1
+	libXxf86dga.so.1 (libc6,x86-64) => /usr/lib64/libXxf86dga.so.1
+	libXv.so.1 (libc6,x86-64) => /usr/lib64/libXv.so.1
+	libXv.so (libc6,x86-64) => /usr/lib64/libXv.so
+	libXtst.so.6 (libc6,x86-64) => /usr/lib64/libXtst.so.6
+	libXtst.so.6 (libc6) => /usr/lib/libXtst.so.6
+	libXtst.so (libc6,x86-64) => /usr/lib64/libXtst.so
+	libXt.so.6 (libc6,x86-64) => /usr/lib64/libXt.so.6
+	libXt.so.6 (libc6) => /usr/lib/libXt.so.6
+	libXt.so (libc6,x86-64) => /usr/lib64/libXt.so
+	libXt.so (libc6) => /usr/lib/libXt.so
+	libXss.so.1 (libc6,x86-64) => /usr/lib64/libXss.so.1
+	libXrender.so.1 (libc6,x86-64) => /usr/lib64/libXrender.so.1
+	libXrender.so.1 (libc6) => /usr/lib/libXrender.so.1
+	libXrender.so (libc6,x86-64) => /usr/lib64/libXrender.so
+	libXrandr.so.2 (libc6,x86-64) => /usr/lib64/libXrandr.so.2
+	libXrandr.so (libc6,x86-64) => /usr/lib64/libXrandr.so
+	libXpm.so.4 (libc6,x86-64) => /usr/lib64/libXpm.so.4
+	libXpm.so.4 (libc6) => /usr/lib/libXpm.so.4
+	libXpm.so (libc6,x86-64) => /usr/lib64/libXpm.so
+	libXp.so.6 (libc6,x86-64) => /usr/lib64/libXp.so.6
+	libXp.so.6 (libc6) => /usr/lib/libXp.so.6
+	libXp.so (libc6,x86-64) => /usr/lib64/libXp.so
+	libXmuu.so.1 (libc6,x86-64) => /usr/lib64/libXmuu.so.1
+	libXmuu.so.1 (libc6) => /usr/lib/libXmuu.so.1
+	libXmuu.so (libc6,x86-64) => /usr/lib64/libXmuu.so
+	libXmu.so.6 (libc6,x86-64) => /usr/lib64/libXmu.so.6
+	libXmu.so.6 (libc6) => /usr/lib/libXmu.so.6
+	libXmu.so (libc6,x86-64) => /usr/lib64/libXmu.so
+	libXm.so.4 (libc6,x86-64) => /usr/lib64/libXm.so.4
+	libXm.so.4 (libc6) => /usr/lib/libXm.so.4
+	libXm.so.3 (libc6,x86-64) => /usr/lib64/libXm.so.3
+	libXm.so (libc6,x86-64) => /usr/lib64/libXm.so
+	libXm.so (libc6) => /usr/lib/libXm.so
+	libXinerama.so.1 (libc6,x86-64) => /usr/lib64/libXinerama.so.1
+	libXinerama.so (libc6,x86-64) => /usr/lib64/libXinerama.so
+	libXi.so.6 (libc6,x86-64) => /usr/lib64/libXi.so.6
+	libXi.so.6 (libc6) => /usr/lib/libXi.so.6
+	libXi.so (libc6,x86-64) => /usr/lib64/libXi.so
+	libXft.so.2 (libc6,x86-64) => /usr/lib64/libXft.so.2
+	libXft.so.2 (libc6) => /usr/lib/libXft.so.2
+	libXft.so (libc6,x86-64) => /usr/lib64/libXft.so
+	libXfont.so.1 (libc6,x86-64) => /usr/lib64/libXfont.so.1
+	libXfixes.so.3 (libc6,x86-64) => /usr/lib64/libXfixes.so.3
+	libXfixes.so.3 (libc6) => /usr/lib/libXfixes.so.3
+	libXfixes.so (libc6,x86-64) => /usr/lib64/libXfixes.so
+	libXext.so.6 (libc6,x86-64) => /usr/lib64/libXext.so.6
+	libXext.so.6 (libc6) => /usr/lib/libXext.so.6
+	libXext.so (libc6,x86-64) => /usr/lib64/libXext.so
+	libXdmcp.so.6 (libc6,x86-64) => /usr/lib64/libXdmcp.so.6
+	libXdmcp.so (libc6,x86-64) => /usr/lib64/libXdmcp.so
+	libXdamage.so.1 (libc6,x86-64) => /usr/lib64/libXdamage.so.1
+	libXdamage.so.1 (libc6) => /usr/lib/libXdamage.so.1
+	libXdamage.so (libc6,x86-64) => /usr/lib64/libXdamage.so
+	libXcursor.so.1 (libc6,x86-64) => /usr/lib64/libXcursor.so.1
+	libXcursor.so (libc6,x86-64) => /usr/lib64/libXcursor.so
+	libXcomposite.so.1 (libc6,x86-64) => /usr/lib64/libXcomposite.so.1
+	libXcomposite.so (libc6,x86-64) => /usr/lib64/libXcomposite.so
+	libXaw3d.so.7 (libc6,x86-64) => /usr/lib64/libXaw3d.so.7
+	libXaw.so.7 (libc6,x86-64) => /usr/lib64/libXaw.so.7
+	libXaw.so (libc6,x86-64) => /usr/lib64/libXaw.so
+	libXau.so.6 (libc6,x86-64) => /usr/lib64/libXau.so.6
+	libXau.so.6 (libc6) => /usr/lib/libXau.so.6
+	libXau.so (libc6,x86-64) => /usr/lib64/libXau.so
+	libUil.so.4 (libc6,x86-64) => /usr/lib64/libUil.so.4
+	libUil.so.4 (libc6) => /usr/lib/libUil.so.4
+	libUil.so.3 (libc6,x86-64) => /usr/lib64/libUil.so.3
+	libUil.so (libc6,x86-64) => /usr/lib64/libUil.so
+	libUil.so (libc6) => /usr/lib/libUil.so
+	libTix.so (libc6,x86-64) => /usr/lib64/tcl8.5/libTix.so
+	libSegFault.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libSegFault.so
+	libSegFault.so (libc6, OS ABI: Linux 2.6.18) => /lib/libSegFault.so
+	libSM.so.6 (libc6,x86-64) => /usr/lib64/libSM.so.6
+	libSM.so.6 (libc6) => /usr/lib/libSM.so.6
+	libSM.so (libc6,x86-64) => /usr/lib64/libSM.so
+	libSDL-1.2.so.0 (libc6,x86-64) => /usr/lib64/libSDL-1.2.so.0
+	libQt3Support.so.4 (libc6,x86-64) => /usr/lib64/libQt3Support.so.4
+	libQt3Support.so (libc6,x86-64) => /usr/lib64/libQt3Support.so
+	libQtXmlPatterns.so.4 (libc6,x86-64) => /usr/lib64/libQtXmlPatterns.so.4
+	libQtXmlPatterns.so (libc6,x86-64) => /usr/lib64/libQtXmlPatterns.so
+	libQtXml.so.4 (libc6,x86-64) => /usr/lib64/libQtXml.so.4
+	libQtXml.so (libc6,x86-64) => /usr/lib64/libQtXml.so
+	libQtTest.so.4 (libc6,x86-64) => /usr/lib64/libQtTest.so.4
+	libQtTest.so (libc6,x86-64) => /usr/lib64/libQtTest.so
+	libQtSvg.so.4 (libc6,x86-64) => /usr/lib64/libQtSvg.so.4
+	libQtSvg.so (libc6,x86-64) => /usr/lib64/libQtSvg.so
+	libQtSql.so.4 (libc6,x86-64) => /usr/lib64/libQtSql.so.4
+	libQtSql.so (libc6,x86-64) => /usr/lib64/libQtSql.so
+	libQtScriptTools.so.4 (libc6,x86-64) => /usr/lib64/libQtScriptTools.so.4
+	libQtScriptTools.so (libc6,x86-64) => /usr/lib64/libQtScriptTools.so
+	libQtScript.so.4 (libc6,x86-64) => /usr/lib64/libQtScript.so.4
+	libQtScript.so (libc6,x86-64) => /usr/lib64/libQtScript.so
+	libQtOpenGL.so.4 (libc6,x86-64) => /usr/lib64/libQtOpenGL.so.4
+	libQtOpenGL.so (libc6,x86-64) => /usr/lib64/libQtOpenGL.so
+	libQtNetwork.so.4 (libc6,x86-64) => /usr/lib64/libQtNetwork.so.4
+	libQtNetwork.so (libc6,x86-64) => /usr/lib64/libQtNetwork.so
+	libQtMultimedia.so.4 (libc6,x86-64) => /usr/lib64/libQtMultimedia.so.4
+	libQtMultimedia.so (libc6,x86-64) => /usr/lib64/libQtMultimedia.so
+	libQtHelp.so.4 (libc6,x86-64) => /usr/lib64/libQtHelp.so.4
+	libQtHelp.so (libc6,x86-64) => /usr/lib64/libQtHelp.so
+	libQtGui.so.4 (libc6,x86-64) => /usr/lib64/libQtGui.so.4
+	libQtGui.so (libc6,x86-64) => /usr/lib64/libQtGui.so
+	libQtDesignerComponents.so.4 (libc6,x86-64) => /usr/lib64/libQtDesignerComponents.so.4
+	libQtDesignerComponents.so (libc6,x86-64) => /usr/lib64/libQtDesignerComponents.so
+	libQtDesigner.so.4 (libc6,x86-64) => /usr/lib64/libQtDesigner.so.4
+	libQtDesigner.so (libc6,x86-64) => /usr/lib64/libQtDesigner.so
+	libQtDBus.so.4 (libc6,x86-64) => /usr/lib64/libQtDBus.so.4
+	libQtDBus.so (libc6,x86-64) => /usr/lib64/libQtDBus.so
+	libQtCore.so.4 (libc6,x86-64) => /usr/lib64/libQtCore.so.4
+	libQtCore.so (libc6,x86-64) => /usr/lib64/libQtCore.so
+	libQtCLucene.so.4 (libc6,x86-64) => /usr/lib64/libQtCLucene.so.4
+	libQtCLucene.so (libc6,x86-64) => /usr/lib64/libQtCLucene.so
+	libQtAssistantClient.so.4 (libc6,x86-64) => /usr/lib64/libQtAssistantClient.so.4
+	libQtAssistantClient.so (libc6,x86-64) => /usr/lib64/libQtAssistantClient.so
+	libOpenIPMIutils.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMIutils.so.0
+	libOpenIPMIui.so.1 (libc6,x86-64) => /usr/lib64/libOpenIPMIui.so.1
+	libOpenIPMIpthread.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMIpthread.so.0
+	libOpenIPMIposix.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMIposix.so.0
+	libOpenIPMIglib.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMIglib.so.0
+	libOpenIPMIcmdlang.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMIcmdlang.so.0
+	libOpenIPMI.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMI.so.0
+	libOpenCL.so.1 (libc6,x86-64) => /usr/lib64/libOpenCL.so.1
+	libOpenCL.so (libc6,x86-64) => /usr/lib64/libOpenCL.so
+	libOSMesa32.so.6 (libc6,x86-64) => /usr/lib64/libOSMesa32.so.6
+	libOSMesa32.so (libc6,x86-64) => /usr/lib64/libOSMesa32.so
+	libOSMesa16.so.6 (libc6,x86-64) => /usr/lib64/libOSMesa16.so.6
+	libOSMesa16.so (libc6,x86-64) => /usr/lib64/libOSMesa16.so
+	libOSMesa.so.6 (libc6,x86-64) => /usr/lib64/libOSMesa.so.6
+	libOSMesa.so (libc6,x86-64) => /usr/lib64/libOSMesa.so
+	libORBitCosNaming-2.so.0 (libc6,x86-64) => /usr/lib64/libORBitCosNaming-2.so.0
+	libORBit-2.so.0 (libc6,x86-64) => /usr/lib64/libORBit-2.so.0
+	libORBit-imodule-2.so.0 (libc6,x86-64) => /usr/lib64/libORBit-imodule-2.so.0
+	libMrm.so.4 (libc6,x86-64) => /usr/lib64/libMrm.so.4
+	libMrm.so.4 (libc6) => /usr/lib/libMrm.so.4
+	libMrm.so.3 (libc6,x86-64) => /usr/lib64/libMrm.so.3
+	libMrm.so (libc6,x86-64) => /usr/lib64/libMrm.so
+	libMrm.so (libc6) => /usr/lib/libMrm.so
+	libMagickWand.so.5 (libc6,x86-64) => /usr/lib64/libMagickWand.so.5
+	libMagickWand.so (libc6,x86-64) => /usr/lib64/libMagickWand.so
+	libMagickCore.so.5 (libc6,x86-64) => /usr/lib64/libMagickCore.so.5
+	libMagickCore.so (libc6,x86-64) => /usr/lib64/libMagickCore.so
+	libMagick++.so.5 (libc6,x86-64) => /usr/lib64/libMagick++.so.5
+	libMagick++.so (libc6,x86-64) => /usr/lib64/libMagick++.so
+	libLLVM-3.6-mesa.so (libc6,x86-64) => /usr/lib64/libLLVM-3.6-mesa.so
+	libLLVM-3.6-mesa.so (libc6) => /usr/lib/libLLVM-3.6-mesa.so
+	libImlib2.so.1 (libc6,x86-64) => /usr/lib64/libImlib2.so.1
+	libImath.so.6 (libc6,x86-64) => /usr/lib64/libImath.so.6
+	libIlmThread.so.6 (libc6,x86-64) => /usr/lib64/libIlmThread.so.6
+	libIlmImf.so.6 (libc6,x86-64) => /usr/lib64/libIlmImf.so.6
+	libIex.so.6 (libc6,x86-64) => /usr/lib64/libIex.so.6
+	libIPMIlanserv.so.0 (libc6,x86-64) => /usr/lib64/libIPMIlanserv.so.0
+	libIDL-2.so.0 (libc6,x86-64) => /usr/lib64/libIDL-2.so.0
+	libIDL-2.so (libc6,x86-64) => /usr/lib64/libIDL-2.so
+	libICE.so.6 (libc6,x86-64) => /usr/lib64/libICE.so.6
+	libICE.so.6 (libc6) => /usr/lib/libICE.so.6
+	libICE.so (libc6,x86-64) => /usr/lib64/libICE.so
+	libHalf.so.6 (libc6,x86-64) => /usr/lib64/libHalf.so.6
+	libGLU.so.1 (libc6,x86-64) => /usr/lib64/libGLU.so.1
+	libGLU.so.1 (libc6) => /usr/lib/libGLU.so.1
+	libGLU.so (libc6,x86-64) => /usr/lib64/libGLU.so
+	libGLESv2.so.2 (libc6,x86-64) => /usr/lib64/libGLESv2.so.2
+	libGLESv2.so (libc6,x86-64) => /usr/lib64/libGLESv2.so
+	libGLESv1_CM.so.1 (libc6,x86-64) => /usr/lib64/libGLESv1_CM.so.1
+	libGLESv1_CM.so (libc6,x86-64) => /usr/lib64/libGLESv1_CM.so
+	libGL.so.1 (libc6,x86-64) => /usr/lib64/libGL.so.1
+	libGL.so (libc6,x86-64) => /usr/lib64/libGL.so
+	libEGL.so.1 (libc6,x86-64) => /usr/lib64/libEGL.so.1
+	libEGL.so (libc6,x86-64) => /usr/lib64/libEGL.so
+	libBrokenLocale.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libBrokenLocale.so.1
+	libBrokenLocale.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libBrokenLocale.so.1
+	libBrokenLocale.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libBrokenLocale.so
+	libBrokenLocale.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libBrokenLocale.so
+	ld-linux.so.2 (ELF) => /lib/ld-linux.so.2
+	ld-linux-x86-64.so.2 (libc6,x86-64) => /lib64/ld-linux-x86-64.so.2
+
+---------------
+df
+---------------
+Filesystem               1K-blocks          Used     Available Use% Mounted on
+10.9.103.1@o2ib3:10.9.103.2@o2ib3:/imapps
+                      135286266880    1277023408  132653637056   1% /plush/dugong
+10.9.103.1@o2ib3:10.9.103.2@o2ib3:/imapps
+                      135286266880    1277023408  132653637056   1% /opt
+/dev/ram                     10240          2052          8188  21% /ram
+none                      16487376           180      16487196   1% /dev
+none                      16493568            12      16493556   1% /dev/shm
+none                        102400             8        102392   1% /tmp
+/dev/sda3                460903324       1134304     436349792   1% /jobfs/local
+10.9.103.3@o2ib3:10.9.103.4@o2ib3:/homsys
+                      228379092480   26897999172  199192454036  12% /home
+10.9.103.3@o2ib3:10.9.103.4@o2ib3:/homsys
+                      228379092480   26897999172  199192454036  12% /system
+10.9.103.1@o2ib3:10.9.103.2@o2ib3:/imapps
+                      135286266880    1277023408  132653637056   1% /apps
+10.9.103.5@o2ib3:10.9.103.6@o2ib3:/short
+                     8256412275200 4337697602172 3514848915992  56% /projects
+10.9.103.5@o2ib3:10.9.103.6@o2ib3:/short
+                     8256412275200 4337697602172 3514848915992  56% /short
+10.12.0.11@o2ib4:10.12.0.12@o2ib4:/gdata1
+                     8119865446200 6494760832008 1218795458008  85% /g/data1
+10.13.0.13@o2ib5:10.13.0.14@o2ib5:/gdata2
+                     7356150051840 6294789502408  693430374092  91% /g/data2
+10.13.1.10@o2ib6:10.13.1.11@o2ib6:/gdata3
+                     7862421329280 6185376961344 1283774154472  83% /g/data3
+none                      16493568            12      16493556   1% /dev/shm
+none                        102400             8        102392   1% /tmp
+
+--------------------------------------------------
+-----------------SYSTEM SPECS END-----------------
+--------------------------------------------------
+2016-10-13T20:42:07 main.cpp 114: INFO: Own PID is '26820'
+---ORDER_FILE BEGIN---
+version = 2
+id = LS8-20160926
+Input:
+	satNum = 'Landsat8'
+	sensor = 'OLI_TIRS'
+	productType = 'MD'
+	linkInput = 'TRUE'
+	cleanBefore = 'TRUE'
+	cleanAfter = 'TRUE'
+	inputPath = /g/data/v10/repackaged/rawdata/0/2016/09/LS8_OLI-TIRS_STD-MDF_P00_LC81140740812016270LGN00_114_074-081_20160926T021444Z20160926T031053_1/product
+	workingFolder = /jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm
+	standardScene:
+	period:
+	floatingScene:
+
+
+Process Control:
+	Use max processing time = 'TRUE'
+		Max Processing Time:
+			Hours: 4
+			Minutes: 0
+			Seconds: 0
+
+Downloader Outputs:
+
+L0Ra Processing:
+	CPF:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>DIRECTORY: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile'
+	Output Path:
+		 = 'Extended mentadata = (FALSE) = '
+	Parameters:
+		May fallback on sensor: TRUE
+
+	Mrc:
+		Generate Mrc = FALSE
+		Orbit Number = -1
+
+
+L0Rp Processing:
+	Max Concurrent Scenes = 15
+	CPF:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>DIRECTORY: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile'
+	Output Path:
+		 = 'Extended mentadata = (FALSE) = '
+
+L1 Processing:
+	Max Concurrent Scenes = 15
+	Output Path:
+		 = 'Extended mentadata = (FALSE) = /jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/scenes'
+	EPH:
+	RLUT:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>DIRECTORY: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT'
+	BPF OLI:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>DIRECTORY: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09'
+	BPF TIRS:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>DIRECTORY: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09'
+	Estimated TIRS SSM position:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>FILE: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt'
+	L1T Processing:
+		DEM:
+			Path: '/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li'
+			Format: 'srtm90'
+		GCP:
+			Path: '/g/data/v10/eoancillarydata/GCP/Phase2_GCP'
+			Format: 'chips_30'
+		Parameters:
+			Minimum Required Gcps: '10'
+
+	Parameters:
+		LatitudeOfFirstStdParallel
+			L1G = 0.000000000000000
+			L1GT = 0.000000000000000
+			L1T = 0.000000000000000
+		LongitudeOfCentralMeridian
+			L1G = 0.000000000000000
+			L1GT = 0.000000000000000
+			L1T = 0.000000000000000
+		FalseEastingNorthingUnits
+			L1G = METERS
+			L1GT = METERS
+			L1T = METERS
+		FalseEasting
+			L1G = 0.000000000000000
+			L1GT = 0.000000000000000
+			L1T = 0.000000000000000
+		FalseNorthing
+			L1G = 0.000000000000000
+			L1GT = 0.000000000000000
+			L1T = 0.000000000000000
+		MaxScanGap
+			L1G = 2
+			L1GT = 2
+			L1T = 2
+		Resampler
+			L1G = CC
+			L1GT = CC
+			L1T = CC
+		Fallback Resampler
+			L1G = CC
+			L1GT = CC
+			L1T = CC
+		Hemisphere
+			L1G = S
+			L1GT = S
+			L1T = S
+		ScenePadding
+			L1G = 1.000000000000000
+			L1GT = 1.000000000000000
+			L1T = 1.000000000000000
+		PixelOrigin
+			L1G = UL
+			L1GT = UL
+			L1T = UL
+		Fallbacks
+			L1G = FALSE
+			L1GT = TRUE
+			L1R = FALSE
+		Orientation
+			L1G = NUP
+			L1GT = NUP
+			L1T = NUP
+		PixelSizesPan
+			L1G = 12.50000
+			L1GT = 12.50000
+			L1T = 12.50000
+		PixelSizesRef
+			L1G = 25.00000
+			L1GT = 25.00000
+			L1T = 25.00000
+		PixelSizesThm
+			L1G = 25.00000
+			L1GT = 25.00000
+			L1T = 25.00000
+		Datum
+			L1G = GDA_94
+			L1GT = GDA_94
+			L1T = GDA_94
+		Spheroid
+			L1G = GRS_80
+			L1GT = GRS_80
+			L1T = GRS_80
+		Projection
+			L1G = UTM
+			L1GT = UTM
+			L1T = UTM
+		Product Type = 'L1T'
+		Output format = 'GEOTIFF'
+
+
+---ORDER_FILE END---
+2016-10-13T20:42:07 Processor.cpp 149: INFO: Time out schedule to trigger at '2016-10-14 00:42:07'
+2016-10-13T20:42:07 Processor.cpp 112: INFO: Cleaning path '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm'
+2016-10-13T20:42:07 GenerateProcessChainLandsat.cpp 732: INFO: Creating log folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs'
+2016-10-13T20:42:07 GenerateProcessChainLandsat.cpp 191: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/MD'
+2016-10-13T20:42:07 GenerateProcessChainLandsat.cpp 66: INFO: Will link '/g/data/v10/repackaged/rawdata/0/2016/09/LS8_OLI-TIRS_STD-MDF_P00_LC81140740812016270LGN00_114_074-081_20160926T021444Z20160926T031053_1/product' to '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/MD'
+2016-10-13T20:42:07 GenerateProcessChainMdRcc2L0Ra.cpp 94: INFO: Creating L0Ra folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA'
+2016-10-13T20:42:07 AncDatabasePopulator.cpp 243: INFO: Locating all 'EPH' ancillary files
+2016-10-13T20:42:07 AncDatabasePopulator.cpp 243: INFO: Locating all 'CPF' ancillary files
+2016-10-13T20:42:38 AncDatabasePopulator.cpp 243: INFO: Locating all 'BPF' ancillary files
+2016-10-13T20:44:44 ProductMetadata.cpp 151: WARN: Path '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160914102104_20160914111455.01' is not a Landsat product
+2016-10-13T20:45:34 AncDatabasePopulator.cpp 243: INFO: Locating all 'RLUT' ancillary files
+2016-10-13T20:45:38 ul_Hdf5Reader.cpp 534: ERROR: Failed to open HDF 5 file '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20130211_20241231v03.h5'
+2016-10-13T20:45:38 ul_Hdf5Reader.cpp 563: ERROR: Failure returned from StartUpCall()
+2016-10-13T20:45:38 ProductMetadataSensor.cpp 555: ERROR: Failure returned from CHdf5Reader::Parse()
+2016-10-13T20:45:38 ProductMetadataSensor.cpp 610: ERROR: Failed to read all ancillary metadata
+2016-10-13T20:45:38 ProductMetadata.cpp 140: ERROR: Failed to populate all ancillary metadata
+2016-10-13T20:45:38 ul_Hdf5Reader.cpp 534: ERROR: Failed to open HDF 5 file '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20130211_20241231v04.h5'
+2016-10-13T20:45:38 ul_Hdf5Reader.cpp 563: ERROR: Failure returned from StartUpCall()
+2016-10-13T20:45:38 ProductMetadataSensor.cpp 555: ERROR: Failure returned from CHdf5Reader::Parse()
+2016-10-13T20:45:38 ProductMetadataSensor.cpp 610: ERROR: Failed to read all ancillary metadata
+2016-10-13T20:45:38 ProductMetadata.cpp 140: ERROR: Failed to populate all ancillary metadata
+2016-10-13T20:45:38 ul_Hdf5Reader.cpp 534: ERROR: Failed to open HDF 5 file '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20130211_20241231v01.h5'
+2016-10-13T20:45:38 ul_Hdf5Reader.cpp 563: ERROR: Failure returned from StartUpCall()
+2016-10-13T20:45:38 ProductMetadataSensor.cpp 555: ERROR: Failure returned from CHdf5Reader::Parse()
+2016-10-13T20:45:38 ProductMetadataSensor.cpp 610: ERROR: Failed to read all ancillary metadata
+2016-10-13T20:45:38 ProductMetadata.cpp 140: ERROR: Failed to populate all ancillary metadata
+2016-10-13T20:45:38 ul_Hdf5Reader.cpp 534: ERROR: Failed to open HDF 5 file '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20130211_20241231v02.h5'
+2016-10-13T20:45:38 ul_Hdf5Reader.cpp 563: ERROR: Failure returned from StartUpCall()
+2016-10-13T20:45:38 ProductMetadataSensor.cpp 555: ERROR: Failure returned from CHdf5Reader::Parse()
+2016-10-13T20:45:38 ProductMetadataSensor.cpp 610: ERROR: Failed to read all ancillary metadata
+2016-10-13T20:45:38 ProductMetadata.cpp 140: ERROR: Failed to populate all ancillary metadata
+2016-10-13T20:45:38 AncDatabasePopulator.cpp 243: INFO: Locating all 'SSM' ancillary files
+2016-10-13T20:45:41 ProcessingStep.cpp 413: INFO: Starting processing step 'INGEST: MD -> L0Ra'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_INGEST_PROCESS_0 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA_WO" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/MD" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "OLI_TIRS" "TRUE" "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs" 2>&1'
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_INGEST_PROCESS_0 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA_WO" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/MD" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "OLI_TIRS" "TRUE" "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs" 2>&1' output =
+--------------------------------------------------
+-------------DPAS INGEST PROCESS------------------
+--------------------------------------------------
+Processing (ADC) ..... DONE
+Processing (LG) ..... DONE
+Processing (SFC) ..... DONE
+Processing (MG) ..... DONE
+
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_073_073')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_075_075')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_076_076')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_077_077')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_074_074')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_078_078')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_079_079')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_080_080')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_081_081')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_082_082')'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 41: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_075_075'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_077_077'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_074_074'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_079_079'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_081_081'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_073_073'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_076_076'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_078_078'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_080_080'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_082_082'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_1 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_075_075" "" "114" "75" "75" "2016:270:02:15:00.0510005" "2016:270:02:15:31.8210005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_075_075" "LC81140740812016270LGN00" "LC81140752016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_2 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_077_077" "" "114" "77" "77" "2016:270:02:15:47.9310005" "2016:270:02:16:19.7010005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_077_077" "LC81140740812016270LGN00" "LC81140772016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_3 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_074_074" "" "114" "74" "74" "2016:270:02:14:36.1130005" "2016:270:02:15:07.8830005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_074_074" "LC81140740812016270LGN00" "LC81140742016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_4 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_079_079" "" "114" "79" "79" "2016:270:02:16:35.8270005" "2016:270:02:17:07.5970005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_079_079" "LC81140740812016270LGN00" "LC81140792016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_5 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_081_081" "" "114" "81" "81" "2016:270:02:17:23.7190005" "2016:270:02:17:55.4890005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_081_081" "LC81140740812016270LGN00" "LC81140812016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_6 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_073_073" "" "114" "73" "73" "2016:270:02:14:34.5290005" "2016:270:02:14:42.1920005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_073_073" "LC81140740812016270LGN00" "LC81140732016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_7 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_076_076" "" "114" "76" "76" "2016:270:02:15:23.9930005" "2016:270:02:15:55.7630005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_076_076" "LC81140740812016270LGN00" "LC81140762016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_8 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_078_078" "" "114" "78" "78" "2016:270:02:16:11.8770005" "2016:270:02:16:43.6470005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_078_078" "LC81140740812016270LGN00" "LC81140782016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_9 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_080_080" "" "114" "80" "80" "2016:270:02:16:59.7730005" "2016:270:02:17:31.5430005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_080_080" "LC81140740812016270LGN00" "LC81140802016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_10 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_082_082" "" "114" "82" "82" "2016:270:02:17:49.4230005" "2016:270:02:17:57.0180005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_082_082" "LC81140740812016270LGN00" "LC81140822016270LGN00" 2>&1'
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_6 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_073_073" "" "114" "73" "73" "2016:270:02:14:34.5290005" "2016:270:02:14:42.1920005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_073_073" "LC81140740812016270LGN00" "LC81140732016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_10 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_082_082" "" "114" "82" "82" "2016:270:02:17:49.4230005" "2016:270:02:17:57.0180005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_082_082" "LC81140740812016270LGN00" "LC81140822016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_2 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_077_077" "" "114" "77" "77" "2016:270:02:15:47.9310005" "2016:270:02:16:19.7010005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_077_077" "LC81140740812016270LGN00" "LC81140772016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_7 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_076_076" "" "114" "76" "76" "2016:270:02:15:23.9930005" "2016:270:02:15:55.7630005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_076_076" "LC81140740812016270LGN00" "LC81140762016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_3 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_074_074" "" "114" "74" "74" "2016:270:02:14:36.1130005" "2016:270:02:15:07.8830005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_074_074" "LC81140740812016270LGN00" "LC81140742016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_8 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_078_078" "" "114" "78" "78" "2016:270:02:16:11.8770005" "2016:270:02:16:43.6470005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_078_078" "LC81140740812016270LGN00" "LC81140782016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_1 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_075_075" "" "114" "75" "75" "2016:270:02:15:00.0510005" "2016:270:02:15:31.8210005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_075_075" "LC81140740812016270LGN00" "LC81140752016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_5 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_081_081" "" "114" "81" "81" "2016:270:02:17:23.7190005" "2016:270:02:17:55.4890005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_081_081" "LC81140740812016270LGN00" "LC81140812016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_4 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_079_079" "" "114" "79" "79" "2016:270:02:16:35.8270005" "2016:270:02:17:07.5970005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_079_079" "LC81140740812016270LGN00" "LC81140792016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_9 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_080_080" "" "114" "80" "80" "2016:270:02:16:59.7730005" "2016:270:02:17:31.5430005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_080_080" "LC81140740812016270LGN00" "LC81140802016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_082_082')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_076_076')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_081_081')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_074_074')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_075_075')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_077_077')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_079_079')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_073_073')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_078_078')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_080_080')'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 71: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 82: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_080_080'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_080_080'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_074_074'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_074_074'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_073_073'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_081_081'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_073_073'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_077_077'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_081_081'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_077_077'
+<--------L1 Order ODL-------->
+<--START--(114_080_080)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_080_080"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 80
+  WRS_PATH = 114
+  WRS_START_ROW = 80
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_080_080)--END-->
+<--------L1 Order ODL-------->
+<--START--(114_074_074)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_074_074"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 74
+  WRS_PATH = 114
+  WRS_START_ROW = 74
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_074_074)--END-->
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_079_079'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_082_082'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_075_075'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_079_079'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_075_075'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_082_082'
+<--------L1 Order ODL-------->
+<--START--(114_073_073)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_073_073"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 73
+  WRS_PATH = 114
+  WRS_START_ROW = 73
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_073_073)--END-->
+<--------L1 Order ODL-------->
+<--START--(114_081_081)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_081_081"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -49
+  WRS_END_ROW = 81
+  WRS_PATH = 114
+  WRS_START_ROW = 81
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_081_081)--END-->
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_11 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_080_080" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_080_080" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_080_080" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_080_080" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_080_080/114_080_080.odl" 2>&1'
+<--------L1 Order ODL-------->
+<--START--(114_077_077)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_077_077"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 77
+  WRS_PATH = 114
+  WRS_START_ROW = 77
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_077_077)--END-->
+<--------L1 Order ODL-------->
+<--START--(114_079_079)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_079_079"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 79
+  WRS_PATH = 114
+  WRS_START_ROW = 79
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_079_079)--END-->
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_12 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_074_074" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_074_074" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_074_074" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_074_074" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_074_074/114_074_074.odl" 2>&1'
+<--------L1 Order ODL-------->
+<--START--(114_082_082)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_082_082"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -49
+  WRS_END_ROW = 82
+  WRS_PATH = 114
+  WRS_START_ROW = 82
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_082_082)--END-->
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_076_076'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_078_078'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_076_076'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_078_078'
+<--------L1 Order ODL-------->
+<--START--(114_075_075)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_075_075"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 75
+  WRS_PATH = 114
+  WRS_START_ROW = 75
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_075_075)--END-->
+<--------L1 Order ODL-------->
+<--START--(114_076_076)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_076_076"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 76
+  WRS_PATH = 114
+  WRS_START_ROW = 76
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_076_076)--END-->
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_13 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_075_075" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_075_075" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_075_075" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_075_075" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_075_075/114_075_075.odl" 2>&1'
+<--------L1 Order ODL-------->
+<--START--(114_078_078)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_078_078"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 78
+  WRS_PATH = 114
+  WRS_START_ROW = 78
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_078_078)--END-->
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_14 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_081_081" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_081_081" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_081_081" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_081_081" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_081_081/114_081_081.odl" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_15 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_077_077" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_077_077" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_077_077" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_077_077" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_077_077/114_077_077.odl" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_16 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_079_079" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_079_079" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_079_079" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_079_079" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_079_079/114_079_079.odl" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_17 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_082_082" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_082_082" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_082_082" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_082_082" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_082_082/114_082_082.odl" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_18 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_073_073" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_073_073" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_073_073" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_073_073" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_073_073/114_073_073.odl" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_19 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_076_076" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_076_076" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_076_076" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_076_076" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_076_076/114_076_076.odl" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_20 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_078_078" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_078_078" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_078_078" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_078_078" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_078_078/114_078_078.odl" 2>&1'
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_18 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_073_073" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_073_073" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_073_073" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_073_073" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_073_073/114_073_073.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... FAILED
+Failure returned from CallIt()
+Failure returned from ExecRunLpgs() for L1T
+Processing a 'L1GT' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_17 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_082_082" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_082_082" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_082_082" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_082_082" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_082_082/114_082_082.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... FAILED
+Failure returned from CallIt()
+Failure returned from ExecRunLpgs() for L1T
+Processing a 'L1GT' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_16 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_079_079" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_079_079" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_079_079" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_079_079" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_079_079/114_079_079.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_12 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_074_074" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_074_074" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_074_074" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_074_074" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_074_074/114_074_074.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_20 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_078_078" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_078_078" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_078_078" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_078_078" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_078_078/114_078_078.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_15 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_077_077" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_077_077" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_077_077" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_077_077" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_077_077/114_077_077.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_11 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_080_080" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_080_080" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_080_080" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_080_080" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_080_080/114_080_080.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_19 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_076_076" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_076_076" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_076_076" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_076_076" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_076_076/114_076_076.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_14 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_081_081" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_081_081" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_081_081" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_081_081" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_081_081/114_081_081.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_13 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_075_075" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_075_075" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_075_075" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_075_075" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_075_075/114_075_075.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+2016-10-13T21:11:10 Processor.cpp 112: INFO: Cleaning path '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm'
+Output XML = 
+<LandsatProcessingResult status="success">
+	<Message>Processing was successful</Message>
+	<LandsatProcessingRequest id="LS8-20160926" version="2">
+		<Input format="MD" satellite="LANDSAT8" sensor="OLI_TIRS">
+			<WorkingFolder cleanBefore="TRUE" cleanAfter="TRUE">/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm</WorkingFolder>
+			<InputPath linkInput="TRUE">/g/data/v10/repackaged/rawdata/0/2016/09/LS8_OLI-TIRS_STD-MDF_P00_LC81140740812016270LGN00_114_074-081_20160926T021444Z20160926T031053_1/product</InputPath>
+		</Input>
+	</LandsatProcessingRequest>
+	<Version>4.1.4110</Version>
+	<HostName>r2353</HostName>
+	<StartTime>2016-10-13T20:42:06</StartTime>
+	<StopTime>2016-10-13T21:11:11</StopTime>
+	<TotalTime>00:29:05</TotalTime>
+	<L0RaProcessing status="succeeded"/>
+	<L0RpProcessing maxConcurrentScenes="15" fail="0" busy="0" queued="0" success="10" canceled="0" timedout="0">
+		<Succeeded sceneType="partial">114_073_073</Succeeded>
+		<Succeeded sceneType="full">114_074_074</Succeeded>
+		<Succeeded sceneType="full">114_075_075</Succeeded>
+		<Succeeded sceneType="full">114_076_076</Succeeded>
+		<Succeeded sceneType="full">114_077_077</Succeeded>
+		<Succeeded sceneType="full">114_078_078</Succeeded>
+		<Succeeded sceneType="full">114_079_079</Succeeded>
+		<Succeeded sceneType="full">114_080_080</Succeeded>
+		<Succeeded sceneType="full">114_081_081</Succeeded>
+		<Succeeded sceneType="partial">114_082_082</Succeeded>
+	</L0RpProcessing>
+	<L1Processing maxConcurrentScenes="15" fail="0" busy="0" queued="0" success="10" canceled="0" timedout="0" L1R="0" L1G="0" L1Gt="2" L1T="8">
+		<Succeeded sceneType="full" level="L1T">114_076_076</Succeeded>
+		<Succeeded sceneType="partial" level="L1GT">114_082_082</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_074_074</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_081_081</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_075_075</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_077_077</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_079_079</Succeeded>
+		<Succeeded sceneType="partial" level="L1GT">114_073_073</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_078_078</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_080_080</Succeeded>
+	</L1Processing>
+</LandsatProcessingResult>
+

--- a/integration_tests/data/dupe/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926_2/additional/20160926_20140804_B6_gverify.log
+++ b/integration_tests/data/dupe/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926_2/additional/20160926_20140804_B6_gverify.log
@@ -1,0 +1,190 @@
+2016-12-20T13:39:27 main.cpp 34: INFO: Arguments
+gridSize = '26'
+resampleType  = 'BI'
+nullValue = '0.000000000000000'
+chipGenType = 'FIXED_LOCATION'
+fixedChipLocationFile = '/g/data/v10/eoancillarydata/GCP/Fix_QA_points/114/080/points.txt
+correlationThreshold = '0.750000000000000'
+referenceImage = 
+'	pathToImage = '/g/data/v10/eoancillarydata/GCP/GQA_v3/wrs2/114/080/LC81140802014216LGN00_B6.TIF'
+	proj4Str = '''
+inputImage = 
+'	pathToImage = '/g/data/v10/reprocess/ls8/level1/2016/09/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926/product/LC81140802016270LGN00_B6.TIF'
+	proj4Str = '''
+logPath = '/g/data/v10/reprocess/gqa/ls8/2016/09/output/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926.gqa-work'
+outputPath = '/g/data/v10/reprocess/gqa/ls8/2016/09/output/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926.gqa-work'
+threadCount = '4'
+usePhaseCorrelation = 'FALSE'
+workingDirectory = '/g/data/v10/reprocess/gqa/ls8/2016/09/output/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926.gqa-work'
+chipSize = '31'
+amountOfPyramids = '5'
+
+
+2016-12-20T13:39:31 ul_Reproject.cpp 133: INFO: Projecting 100%   
+2016-12-20T13:39:34 ul_Reproject.cpp 173: INFO: Generate translation map 100%   
+2016-12-20T13:39:34 ul_Resampler.h 476: INFO: Resample map is of type 'double'
+2016-12-20T13:39:35 ul_Resampler.h 97: INFO: Resampler is bilinear
+2016-12-20T13:39:39 ul_Resampler.h 326: INFO: Resampling 100%     
+2016-12-20T13:39:43 ul_ImageOverlap.cpp 356: INFO: Save new overlapped image to '/g/data/v10/reprocess/gqa/ls8/2016/09/output/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926.gqa-work/MinMaxBox/Input/warpedInput_LC81140802016270LGN00_B6.TIF'
+2016-12-20T13:39:47 ul_ImageOverlap.cpp 356: INFO: Save new overlapped image to '/g/data/v10/reprocess/gqa/ls8/2016/09/output/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926.gqa-work/MinMaxBox/Reference/LC81140802014216LGN00_B6.TIF'
+2016-12-20T13:39:52 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T13:39:58 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T13:40:06 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T13:40:11 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T13:40:20 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T13:40:26 ul_PaddImage.cpp 144: INFO: Processing 100%     
+2016-12-20T13:40:29 ul_TiledGaussianPyramidTiePointGenerator.cpp 534: INFO: <<----------------------------------------------------------->>
+2016-12-20T13:40:29 ul_TiledGaussianPyramidTiePointGenerator.cpp 535: INFO:  <----TILE LOOP (1/2)----------------->
+2016-12-20T13:40:29 ul_TiledGaussianPyramidTiePointGenerator.cpp 536: INFO: <<----------------------------------------------------------->>
+2016-12-20T13:40:29 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '2' of '5' for image 'Input_1_1'
+2016-12-20T13:40:31 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '3' of '5' for image 'Input_1_1'
+2016-12-20T13:40:32 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '4' of '5' for image 'Input_1_1'
+2016-12-20T13:40:32 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '5' of '5' for image 'Input_1_1'
+2016-12-20T13:40:32 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '2' of '5' for image 'Reference_1_1'
+2016-12-20T13:40:34 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '3' of '5' for image 'Reference_1_1'
+2016-12-20T13:40:35 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '4' of '5' for image 'Reference_1_1'
+2016-12-20T13:40:35 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '5' of '5' for image 'Reference_1_1'
+2016-12-20T13:40:35 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (1/5)----------------->>
+2016-12-20T13:40:35 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:40:35 ul_FixedLocationChips.cpp 171: INFO: Generated '217' chips
+2016-12-20T13:40:35 ul_TiePointGenerator.cpp 166: INFO: Correlating '217' chips of size '31x31' on a search window of size '52x52' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:40:35 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:40:36 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:40:36 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:40:36 ul_TiePointGenerator.cpp 285: INFO: Obtained '217' chips
+2016-12-20T13:40:36 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T13:40:36 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '1/5' is 'x = 0.003366440787691 y = -0.005289874290138' pixels
+2016-12-20T13:40:36 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (2/5)----------------->>
+2016-12-20T13:40:37 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:40:37 ul_FixedLocationChips.cpp 171: INFO: Generated '291' chips
+2016-12-20T13:40:37 ul_TiePointGenerator.cpp 166: INFO: Correlating '291' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:40:37 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:40:37 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:40:37 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:40:37 ul_TiePointGenerator.cpp 285: INFO: Obtained '291' chips
+2016-12-20T13:40:37 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T13:40:37 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '2/5' is 'x = 0.003728280223307 y = -0.008053842805880' pixels
+2016-12-20T13:40:37 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (3/5)----------------->>
+2016-12-20T13:40:37 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:40:37 ul_FixedLocationChips.cpp 171: INFO: Generated '306' chips
+2016-12-20T13:40:37 ul_TiePointGenerator.cpp 166: INFO: Correlating '306' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:40:37 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:40:38 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:40:38 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:40:38 ul_TiePointGenerator.cpp 285: INFO: Obtained '306' chips
+2016-12-20T13:40:38 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T13:40:38 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '3/5' is 'x = 0.005203393754169 y = -0.013317783287777' pixels
+2016-12-20T13:40:38 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (4/5)----------------->>
+2016-12-20T13:40:38 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:40:38 ul_FixedLocationChips.cpp 171: INFO: Generated '320' chips
+2016-12-20T13:40:38 ul_TiePointGenerator.cpp 166: INFO: Correlating '320' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:40:39 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:40:39 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:40:39 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:40:39 ul_TiePointGenerator.cpp 285: INFO: Obtained '320' chips
+2016-12-20T13:40:39 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T13:40:39 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '4/5' is 'x = 0.019862204535735 y = -0.016763880840031' pixels
+2016-12-20T13:40:39 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (5/5)----------------->>
+2016-12-20T13:40:40 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:40:40 ul_FixedLocationChips.cpp 171: INFO: Generated '328' chips
+2016-12-20T13:40:40 ul_TiePointGenerator.cpp 166: INFO: Correlating '328' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:40:42 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:40:43 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:40:43 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:40:43 ul_TiePointGenerator.cpp 285: INFO: Obtained '328' chips
+2016-12-20T13:40:44 ul_GcpHullRejection.cpp 264: INFO: Hull trim size is '31'
+2016-12-20T13:40:47 ul_ConvKernelToImage.h 178: INFO: 100%   
+2016-12-20T13:40:47 ul_ConvKernelToImage.h 178: INFO: 100%   
+2016-12-20T13:40:47 ul_ConvexHull.cpp 142: INFO: Sorting '591363' data points
+2016-12-20T13:40:47 ul_ConvexHull.cpp 142: INFO: Sorting '827935' data points
+2016-12-20T13:40:47 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T13:40:47 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T13:40:48 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T13:40:48 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T13:40:52 ul_GcpOutlierTestingHullGenThread.cpp 235: INFO: TrimHullArea 100%     
+2016-12-20T13:40:54 ul_GcpOutlierTestingHullGenThread.cpp 235: INFO: TrimHullArea 100%     
+2016-12-20T13:40:55 ul_GcpHullRejection.cpp 155: INFO: RejectGcps 100%     
+2016-12-20T13:40:55 ul_GcpHullRejection.cpp 275: INFO: Rejected a total of '3' GCP on the outer hull edges
+2016-12-20T13:40:55 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 205: INFO: Average shift in pixels are 'x = 0.023339647400945 y = 0.009610903329615'
+2016-12-20T13:40:55 ul_TiledGaussianPyramidTiePointGenerator.cpp 534: INFO: <<----------------------------------------------------------->>
+2016-12-20T13:40:55 ul_TiledGaussianPyramidTiePointGenerator.cpp 535: INFO:  <----TILE LOOP (2/2)----------------->
+2016-12-20T13:40:55 ul_TiledGaussianPyramidTiePointGenerator.cpp 536: INFO: <<----------------------------------------------------------->>
+2016-12-20T13:40:55 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '2' of '5' for image 'Input_2_1'
+2016-12-20T13:40:57 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '3' of '5' for image 'Input_2_1'
+2016-12-20T13:40:59 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '4' of '5' for image 'Input_2_1'
+2016-12-20T13:40:59 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '5' of '5' for image 'Input_2_1'
+2016-12-20T13:40:59 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '2' of '5' for image 'Reference_2_1'
+2016-12-20T13:41:02 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '3' of '5' for image 'Reference_2_1'
+2016-12-20T13:41:03 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '4' of '5' for image 'Reference_2_1'
+2016-12-20T13:41:03 ul_GaussianPyramidTiePointGenerator.cpp 90: INFO: Generating pyramid level '5' of '5' for image 'Reference_2_1'
+2016-12-20T13:41:03 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (1/5)----------------->>
+2016-12-20T13:41:03 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:41:03 ul_FixedLocationChips.cpp 171: INFO: Generated '42' chips
+2016-12-20T13:41:03 ul_TiePointGenerator.cpp 166: INFO: Correlating '42' chips of size '31x31' on a search window of size '52x52' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:41:03 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:41:03 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:41:03 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:41:03 ul_TiePointGenerator.cpp 285: INFO: Obtained '42' chips
+2016-12-20T13:41:03 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T13:41:03 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '1/5' is 'x = 0.014122703481782 y = 0.004447877661212' pixels
+2016-12-20T13:41:03 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (2/5)----------------->>
+2016-12-20T13:41:03 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:41:03 ul_FixedLocationChips.cpp 171: INFO: Generated '63' chips
+2016-12-20T13:41:03 ul_TiePointGenerator.cpp 166: INFO: Correlating '63' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:41:03 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:41:04 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:41:04 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:41:04 ul_TiePointGenerator.cpp 285: INFO: Obtained '63' chips
+2016-12-20T13:41:04 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T13:41:04 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '2/5' is 'x = 0.021426878564258 y = 0.006762774123531' pixels
+2016-12-20T13:41:04 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (3/5)----------------->>
+2016-12-20T13:41:04 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:41:04 ul_FixedLocationChips.cpp 171: INFO: Generated '76' chips
+2016-12-20T13:41:04 ul_TiePointGenerator.cpp 166: INFO: Correlating '76' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:41:04 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:41:04 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:41:04 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:41:04 ul_TiePointGenerator.cpp 285: INFO: Obtained '76' chips
+2016-12-20T13:41:04 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T13:41:04 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '3/5' is 'x = -0.005474825420835 y = 0.005154264941812' pixels
+2016-12-20T13:41:04 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (4/5)----------------->>
+2016-12-20T13:41:04 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:41:04 ul_FixedLocationChips.cpp 171: INFO: Generated '88' chips
+2016-12-20T13:41:04 ul_TiePointGenerator.cpp 166: INFO: Correlating '88' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:41:04 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:41:05 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:41:05 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:41:05 ul_TiePointGenerator.cpp 285: INFO: Obtained '88' chips
+2016-12-20T13:41:05 ul_TiePointGeneratorHullReject.cpp 29: INFO: Not going to reject GCPs based on the image outer hulls
+2016-12-20T13:41:05 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 186: INFO: Average shift for pyramid scene '4/5' is 'x = 0.007857799540432 y = 0.000398980073270' pixels
+2016-12-20T13:41:05 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 127: INFO: <<----PYRAMID LOOP (5/5)----------------->>
+2016-12-20T13:41:05 ul_FixedLocationChips.cpp 170: INFO: Processing 100%      
+2016-12-20T13:41:05 ul_FixedLocationChips.cpp 171: INFO: Generated '95' chips
+2016-12-20T13:41:05 ul_TiePointGenerator.cpp 166: INFO: Correlating '95' chips of size '31x31' on a search window of size '46x46' using a 'CCOEFF_NORM' correlator
+2016-12-20T13:41:07 ul_CorrelationHandler.cpp 174: INFO: Starting chip correlation
+2016-12-20T13:41:08 ul_TiePointGenerator.cpp 195: INFO: Removing duplicate GCPs
+2016-12-20T13:41:08 ul_TiePointGenerator.cpp 219: INFO: Removed '0' duplicate GCPs
+2016-12-20T13:41:08 ul_TiePointGenerator.cpp 285: INFO: Obtained '95' chips
+2016-12-20T13:41:09 ul_GcpHullRejection.cpp 264: INFO: Hull trim size is '31'
+2016-12-20T13:41:12 ul_ConvKernelToImage.h 178: INFO: 100%   
+2016-12-20T13:41:12 ul_ConvKernelToImage.h 178: INFO: 100%   
+2016-12-20T13:41:12 ul_ConvexHull.cpp 142: INFO: Sorting '526054' data points
+2016-12-20T13:41:12 ul_ConvexHull.cpp 142: INFO: Sorting '1083116' data points
+2016-12-20T13:41:13 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T13:41:13 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T13:41:13 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T13:41:13 ul_ConvexHull.cpp 119: INFO: CConvexHull 100%      
+2016-12-20T13:41:18 ul_GcpOutlierTestingHullGenThread.cpp 235: INFO: TrimHullArea 100%     
+2016-12-20T13:41:19 ul_GcpOutlierTestingHullGenThread.cpp 235: INFO: TrimHullArea 100%     
+2016-12-20T13:41:20 ul_GcpHullRejection.cpp 155: INFO: RejectGcps 100%     
+2016-12-20T13:41:20 ul_GcpHullRejection.cpp 275: INFO: Rejected a total of '1' GCP on the outer hull edges
+2016-12-20T13:41:20 ul_GaussianPyramidTiePointGeneratorProcessingLoop.cpp 205: INFO: Average shift in pixels are 'x = 0.010796772761923 y = -0.001197990804326'
+2016-12-20T13:41:20 ul_TiledGaussianPyramidTiePointGenerator.cpp 457: INFO: Removing duplicate GCPs
+2016-12-20T13:41:20 ul_TiledGaussianPyramidTiePointGenerator.cpp 481: INFO: Removed '7' duplicate GCPs
+2016-12-20T13:41:32 GenerateResults.cpp 57: INFO: Residual X = 0.112185873154427 Y = 0.135500685890115
+2016-12-20T13:41:32 GenerateResults.cpp 81: INFO: Residual histogram
+	Green 257
+	Teal 8
+	Blue 0
+	Yellow 0
+	Red 1

--- a/integration_tests/data/dupe/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926_2/additional/LPGS.log
+++ b/integration_tests/data/dupe/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926_2/additional/LPGS.log
@@ -1,0 +1,936 @@
+Thu Oct 13 20:53:29 AEDT 2016
+ 
+DMS Setup Work Order (DSW)
+ 
+2016-10-13 20:53:29  setup_work_order    28174 setup_work_order.c        91  INFO Initiated
+2016-10-13 20:53:29  setup_work_order    28174 read_l0r_metadata.c       91  INFO Reading L0R metadata from l0r_symlink/LC81140802016270LGN00
+2016-10-13 20:53:29  setup_work_order    28174 setup_work_order.c       554  INFO Successful completion
+ 
+setup_work_order execution completed with status of 0
+ 
+Thu Oct 13 20:53:29 AEDT 2016
+Thu Oct 13 20:53:31 AEDT 2016
+ 
+DMS Retrieve Elevation (DRE)
+ 
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s28_e112_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s28_e112_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s28e112
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s28_e113_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s28_e113_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s28e113
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s28_e114_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s28_e114_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s28e114
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s28_e115_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s28_e115_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s28e115
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s29_e112_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s29_e112_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s29e112
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s29_e113_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s29_e113_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s29e113
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s29_e114_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s29_e114_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s29e114
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s29_e115_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s29_e115_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s29e115
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s30_e112_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s30_e112_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s30e112
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s30_e113_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s30_e113_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s30e113
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s30_e114_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s30_e114_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s30e114
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s30_e115_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s30_e115_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s30e115
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s31_e112_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s31_e112_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s31e112
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s31_e113_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s31_e113_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s31e113
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s31_e114_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s31_e114_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s31e114
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      41  INFO Gls tile name v2: s31_e115_3arc_v2
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c      74  INFO Gls tile name v1: s31_e115_3arc_v1
+2016-10-13 20:53:31  retrieve_elevation    28288 make_gls_tile_name.c     107  INFO Gls tile name v0: s31e115
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           180  INFO Mosaicing GLS DEM tiles...
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:31  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           206  INFO Falling back to v1 DEM tiles
+2016-10-13 20:53:32  retrieve_elevation    28288 get_gls_data.c           221  INFO Falling back to v0 DEM tiles
+2016-10-13 20:53:41  retrieve_elevation    28288 retrieve_elevation.c     416  INFO DEM data retrieval successfully completed.
+ 
+retrieve_elevation execution completed with status of 0
+ 
+Thu Oct 13 20:53:41 AEDT 2016
+Thu Oct 13 20:53:42 AEDT 2016
+ 
+DMS Ground Control (DGC)
+ 
+2016-10-13T09:53:43 LoadChips.cpp 766: INFO: Found chips at '/g/data/v10/eoancillarydata/GCP/Phase2_GCP/114/080/GCPLib'
+2016-10-13T09:53:50 SaveChips.cpp 385: INFO: Saving tile as version '2'
+ 
+lpgs-chip-loader execution completed with status of 0
+ 
+Thu Oct 13 20:53:50 AEDT 2016
+Thu Oct 13 20:53:51 AEDT 2016
+ 
+Ancillary Data Preprocessor (ADP)
+ 
+2016-10-13 20:53:51  ancillary_data_preprocessor    28499 ancillary_data_preprocessor.c     100  INFO Initiated
+2016-10-13 20:53:51  ancillary_data_preprocessor    28499 ias_ancillary_smooth_ephemeris.c     172  INFO L0R ephemeris record count = 226
+2016-10-13 20:53:51  ancillary_data_preprocessor    28499 ias_ancillary_identify_quaternion_outliers.c     268  INFO Number of attitude quaternion points 11300
+2016-10-13 20:53:51  ancillary_data_preprocessor    28499 ias_ancillary_convert_imu_to_acs.c     350  INFO Bounds on IMU time 528128129.895857, 528128355.875101
+2016-10-13 20:53:51  ancillary_data_preprocessor    28499 ias_ancillary_extract_valid_imu_data_window.c      60  INFO Ephemeris times --- start 528128130.900064, end 528128355.900064 -> center 528128243.400064
+2016-10-13 20:53:51  ancillary_data_preprocessor    28499 ancillary_data_preprocessor.c     232  INFO Successful completion
+ 
+ancillary_data_preprocessor execution completed with status of 0
+ 
+Thu Oct 13 20:53:51 AEDT 2016
+Thu Oct 13 20:53:53 AEDT 2016
+ 
+Create Line of Sight Model Initialization (L8INIT)
+ 
+2016-10-13 20:53:53  create_los_model    28549 read_parameters.c        302  INFO Overriding the estimated TIRS SSM position file with '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt'
+2016-10-13 20:53:53  create_los_model    28549 create_los_model.c        76  INFO Create LOS Model started
+2016-10-13 20:53:54  create_los_model    28549 ias_sensor_set_ssm_from_l0r.c     180  WARN MCE mode 0 in use, not mode 4 as expected
+2016-10-13 20:53:54  create_los_model    28549 ias_sensor_set_ssm_from_l0r.c     193  WARN Operating in MCE mode 0 without valid SSM encoder data!
+2016-10-13 20:53:54  create_los_model    28549 ias_sensor_check_ssm_encoder_data.c     313  WARN No valid SSM angles found; using nominal value
+2016-10-13 20:53:54  create_los_model    28549 ias_sensor_set_ssm_from_l0r.c     778  INFO Using estimated SSM encoder data from /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt to replace missing mirror telemetry
+2016-10-13 20:53:54  create_los_model    28549 create_los_model.c       271  INFO Create LOS Model finished
+ 
+create_los_model execution completed with status of 0
+ 
+Thu Oct 13 20:53:54 AEDT 2016
+Thu Oct 13 20:53:56 AEDT 2016
+ 
+Create Level 1R (L8RPS)
+ 
+2016-10-13 20:53:56  create_l1r    28623 rps_main.c                71  INFO Initiated create_l1r
+2016-10-13 20:53:59  create_l1r    28623 process_scas.c            46  INFO Processing band 1
+2016-10-13 20:54:26  create_l1r    28623 process_scas.c            46  INFO Processing band 2
+2016-10-13 20:54:34  create_l1r    28623 process_scas.c            46  INFO Processing band 3
+2016-10-13 20:54:45  create_l1r    28623 process_scas.c            46  INFO Processing band 4
+2016-10-13 20:54:56  create_l1r    28623 process_scas.c            46  INFO Processing band 5
+2016-10-13 20:55:07  create_l1r    28623 process_scas.c            46  INFO Processing band 6
+2016-10-13 20:55:19  create_l1r    28623 process_scas.c            46  INFO Processing band 7
+2016-10-13 20:55:29  create_l1r    28623 process_scas.c            46  INFO Processing band 8
+2016-10-13 20:56:33  create_l1r    28623 process_scas.c            46  INFO Processing band 9
+2016-10-13 20:56:50  create_l1r    28623 process_scas.c            46  INFO Processing band 10
+2016-10-13 20:56:52  create_l1r    28623 process_scas.c            46  INFO Processing band 11
+2016-10-13 20:56:54  create_l1r    28623 api/api_striping_characterization.c     329  INFO Overall striping metric not calculated due to report and database storage flags being false
+2016-10-13 20:56:54  create_l1r    28623 rps_main.c               261  INFO Successful completion
+ 
+create_l1r execution completed with status of 0
+ 
+Thu Oct 13 20:56:54 AEDT 2016
+Thu Oct 13 20:56:56 AEDT 2016
+ 
+Create Systematic Grid (L8GRID_SYS)
+ 
+2016-10-13 20:56:56  create_grid    29141 get_parms_and_initialize_grid.c    1228  INFO Pixel origin will be 'UL'
+2016-10-13 20:56:56  create_grid    29141 create_grid.c            173  INFO Initiate Create Grid...
+2016-10-13 20:56:56  create_grid    29141 create_grid.c            284  INFO Elevation range   -40.00   419.00
+2016-10-13 20:56:56  create_grid    29141 pad_corners.c             58  INFO Scene padding size is 30.000000
+2016-10-13 20:56:56  create_grid    29141 build_grid.c             259  INFO Processing band number 6
+2016-10-13 20:56:59  create_grid    29141 build_grid.c              93  INFO Writing grid band number 6
+2016-10-13 20:56:59  create_grid    29141 create_grid.c            869  INFO Writing output grid file headers
+2016-10-13 20:56:59  create_grid    29141 create_grid.c            929  INFO Successful completion
+ 
+create_grid execution completed with status of 0
+ 
+Thu Oct 13 20:56:59 AEDT 2016
+Thu Oct 13 20:57:00 AEDT 2016
+ 
+Make the Geometric Terrain Grid (GRID_TERRAIN)
+ 
+2016-10-13 20:57:00  Makegeomgrid    29193 make_geom_grid.c         100  INFO Initiated
+2016-10-13 20:57:00  Makegeomgrid    29193 make_geom_grid.c         189  INFO Using band number 6 from the TARGET_FRAME_FILE
+2016-10-13 20:57:00  Makegeomgrid    29193 make_geom_grid.c         607  INFO Successful Completion
+ 
+makegeomgrid execution completed with status of 0
+ 
+Thu Oct 13 20:57:00 AEDT 2016
+Thu Oct 13 20:57:03 AEDT 2016
+ 
+Geometric Terrain Resample (RESAMPLE_TERRAIN)
+ 
+2016-10-13 20:57:03  Geomresample    29227 geomresample.c            93  INFO Geometric Resample Initiated
+2016-10-13 20:57:03  Geomresample    29227 geomresample.c           112  INFO Reading Grid
+2016-10-13 20:57:03  Geomresample    29227 geomresample.c           219  INFO Resampling band 1
+2016-10-13 20:57:03  Geomresample    29227 scanman.c                250  INFO resampling lines 0 through 800
+2016-10-13 20:57:03  Geomresample    29227 scanman.c                250  INFO resampling lines 650 through 1450
+2016-10-13 20:57:03  Geomresample    29227 scanman.c                250  INFO resampling lines 1300 through 2100
+2016-10-13 20:57:03  Geomresample    29227 scanman.c                250  INFO resampling lines 1950 through 2750
+2016-10-13 20:57:03  Geomresample    29227 scanman.c                250  INFO resampling lines 2600 through 3400
+2016-10-13 20:57:04  Geomresample    29227 scanman.c                250  INFO resampling lines 3250 through 4050
+2016-10-13 20:57:04  Geomresample    29227 scanman.c                250  INFO resampling lines 3900 through 4700
+2016-10-13 20:57:04  Geomresample    29227 scanman.c                250  INFO resampling lines 4550 through 5350
+2016-10-13 20:57:04  Geomresample    29227 scanman.c                250  INFO resampling lines 5200 through 6000
+2016-10-13 20:57:04  Geomresample    29227 scanman.c                250  INFO resampling lines 5850 through 6650
+2016-10-13 20:57:05  Geomresample    29227 scanman.c                250  INFO resampling lines 6500 through 7300
+2016-10-13 20:57:05  Geomresample    29227 scanman.c                250  INFO resampling lines 7150 through 7950
+2016-10-13 20:57:05  Geomresample    29227 scanman.c                250  INFO resampling lines 7800 through 8600
+2016-10-13 20:57:05  Geomresample    29227 scanman.c                250  INFO resampling lines 8450 through 9250
+2016-10-13 20:57:06  Geomresample    29227 scanman.c                250  INFO resampling lines 9100 through 9900
+2016-10-13 20:57:06  Geomresample    29227 scanman.c                250  INFO resampling lines 9750 through 10550
+2016-10-13 20:57:06  Geomresample    29227 scanman.c                250  INFO resampling lines 10400 through 11200
+2016-10-13 20:57:06  Geomresample    29227 scanman.c                250  INFO resampling lines 11050 through 11850
+2016-10-13 20:57:06  Geomresample    29227 scanman.c                250  INFO resampling lines 11700 through 12500
+2016-10-13 20:57:06  Geomresample    29227 scanman.c                250  INFO resampling lines 12350 through 13093
+2016-10-13 20:57:06  Geomresample    29227 geomresample.c           330  INFO Geometric Resample Successful Completion
+ 
+geomresample execution completed with status of 0
+ 
+Thu Oct 13 20:57:06 AEDT 2016
+Thu Oct 13 20:57:08 AEDT 2016
+ 
+Systematic L8 Resample (L8RESAMPLE_SYS)
+ 
+2016-10-13 20:57:08  Resample    29290 resample.c               115  INFO Initiated
+2016-10-13 20:57:10  Resample    29290 process_band.c            80  INFO Resampling band number 6
+2016-10-13 20:57:37  Resample    29290 resample.c               789  INFO Successful Completion
+ 
+resample execution completed with status of 0
+ 
+Thu Oct 13 20:57:37 AEDT 2016
+Thu Oct 13 20:57:39 AEDT 2016
+ 
+L8 GCP Correlation for Precision (L8PRECISION_GCP)
+ 
+2016-10-13 20:57:39  gcpcorrelate    29481 GCPcorrelate.c            84  INFO Initiated
+2016-10-13 20:57:39  gcpcorrelate    29481 GCPcorrelate.c            87  INFO Reading gcp_lib/GCPLib
+2016-10-13 20:57:39  gcpcorrelate    29481 ias_gcp_read_gcplib.c     292  INFO Reading gcp_lib/GCPLib
+2016-10-13 20:57:39  gcpcorrelate    29481 ias_gcp_read_gcplib.c     313  INFO Read 408 GCPs
+2016-10-13 20:57:39  gcpcorrelate    29481 ias_gcp_read_gcplib.c     135  INFO Pixel alignment will be 'UL', hemisphere is 'S', datum = 'GDA_94'
+2016-10-13 20:57:39  gcpcorrelate    29481 GCPcorrelate.c           116  INFO Read 408 GCPs
+2016-10-13 20:57:39  gcpcorrelate    29481 process_gcp.c            236  INFO Processing 1 SCA(s) in image sys_l1g.h5
+2016-10-13 20:57:39  gcpcorrelate    29481 process_gcp.c            375  INFO Using image chips from gcp_lib
+2016-10-13 20:57:39  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 0 to SCA 0
+2016-10-13 20:57:39  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 40 to SCA 0
+2016-10-13 20:57:39  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 80 to SCA 0
+2016-10-13 20:57:39  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 120 to SCA 0
+2016-10-13 20:57:39  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 160 to SCA 0
+2016-10-13 20:57:40  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 200 to SCA 0
+2016-10-13 20:57:40  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 240 to SCA 0
+2016-10-13 20:57:40  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 280 to SCA 0
+2016-10-13 20:57:40  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 320 to SCA 0
+2016-10-13 20:57:40  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 360 to SCA 0
+2016-10-13 20:57:41  gcpcorrelate    29481 process_gcp.c            430  INFO Correlating GCP # 400 to SCA 0
+2016-10-13 20:57:41  gcpcorrelate    29481 process_gcp.c            694  INFO Points inside image 408, Number used 408, Last used 0
+2016-10-13 20:57:41  gcpcorrelate    29481 process_gcp.c            759  INFO 318 of 408 points correlated
+2016-10-13 20:57:41  gcpcorrelate    29481 GCPcorrelate.c           151  INFO Successful completion
+ 
+gcpcorrelate execution completed with status of 0
+ 
+Thu Oct 13 20:57:41 AEDT 2016
+Thu Oct 13 20:57:42 AEDT 2016
+ 
+L8 Precision Correction (L8PRECISION_SOLVE)
+ 
+2016-10-13 20:57:42  correct_los_model    29494 correct_los_model.c      116  INFO Initiated correct_los_model
+2016-10-13 20:57:43  correct_los_model    29494 correct_los_model.c      298  INFO Finished getting satellite time and position
+2016-10-13 20:57:44  correct_los_model    29494 correct_los_model.c      369  INFO Finished calculating the precision corrections
+2016-10-13 20:57:44  correct_los_model    29494 correct_los_model.c      402  INFO Pre-fit RMS residuals:   X =  11.154 meters  Y =   8.346 meters
+2016-10-13 20:57:44  correct_los_model    29494 correct_los_model.c      405  INFO Post-fit RMS residuals:  X =   4.256 meters  Y =   4.797 meters
+2016-10-13 20:57:44  correct_los_model    29494 correct_los_model.c      409  INFO GCP Outlier Percentage:  11.01 percent
+2016-10-13 20:57:45  correct_los_model    29494 correct_los_model.c      544  INFO Successful completion
+ 
+correct_los_model exection completed with status of 0
+ 
+Thu Oct 13 20:57:45 AEDT 2016
+Thu Oct 13 20:57:47 AEDT 2016
+ 
+Geodetic Accuracy Characterization (GEODETIC)
+ 
+2016-10-13 20:57:47  geodetic    29518 geodetic_char.c           89  INFO Geodetic Accuracy Assessment initiated
+2016-10-13 20:57:47  geodetic    29518 geodetic_char.c          235  INFO Successful Completion
+ 
+geodetic execution completed with status of 0
+ 
+Thu Oct 13 20:57:47 AEDT 2016
+Thu Oct 13 20:57:49 AEDT 2016
+ 
+Create Grid for Precision (L8GRID_PREC)
+ 
+2016-10-13 20:57:49  create_grid    29543 get_parms_and_initialize_grid.c    1228  INFO Pixel origin will be 'UL'
+2016-10-13 20:57:49  create_grid    29543 create_grid.c            173  INFO Initiate Create Grid...
+2016-10-13 20:57:49  create_grid    29543 create_grid.c            284  INFO Elevation range   -40.00   419.00
+2016-10-13 20:57:49  create_grid    29543 pad_corners.c             58  INFO Scene padding size is 25.000000
+2016-10-13 20:57:49  create_grid    29543 get_frame_minbox.c       189  INFO 123825.000000 351750.000000 6687925.000000 6918600.000000
+
+2016-10-13 20:57:49  create_grid    29543 build_grid.c             259  INFO Processing band number 1
+2016-10-13 20:57:52  create_grid    29543 build_grid.c             259  INFO Processing band number 2
+2016-10-13 20:57:53  create_grid    29543 build_grid.c              93  INFO Writing grid band number 1
+2016-10-13 20:57:55  create_grid    29543 build_grid.c             259  INFO Processing band number 3
+2016-10-13 20:57:56  create_grid    29543 build_grid.c              93  INFO Writing grid band number 2
+2016-10-13 20:57:58  create_grid    29543 build_grid.c             259  INFO Processing band number 4
+2016-10-13 20:57:59  create_grid    29543 build_grid.c              93  INFO Writing grid band number 3
+2016-10-13 20:58:02  create_grid    29543 build_grid.c             259  INFO Processing band number 5
+2016-10-13 20:58:02  create_grid    29543 build_grid.c              93  INFO Writing grid band number 4
+2016-10-13 20:58:05  create_grid    29543 build_grid.c             259  INFO Processing band number 6
+2016-10-13 20:58:06  create_grid    29543 build_grid.c              93  INFO Writing grid band number 5
+2016-10-13 20:58:08  create_grid    29543 build_grid.c             259  INFO Processing band number 7
+2016-10-13 20:58:09  create_grid    29543 build_grid.c              93  INFO Writing grid band number 6
+2016-10-13 20:58:12  create_grid    29543 build_grid.c             259  INFO Processing band number 8
+2016-10-13 20:58:13  create_grid    29543 build_grid.c              93  INFO Writing grid band number 7
+2016-10-13 20:58:15  create_grid    29543 build_grid.c             259  INFO Processing band number 9
+2016-10-13 20:58:16  create_grid    29543 build_grid.c              93  INFO Writing grid band number 8
+2016-10-13 20:58:18  create_grid    29543 build_grid.c             259  INFO Processing band number 10
+2016-10-13 20:58:19  create_grid    29543 build_grid.c             259  INFO Processing band number 11
+2016-10-13 20:58:19  create_grid    29543 build_grid.c              93  INFO Writing grid band number 9
+2016-10-13 20:58:22  create_grid    29543 build_grid.c              93  INFO Writing grid band number 10
+2016-10-13 20:58:25  create_grid    29543 build_grid.c              93  INFO Writing grid band number 11
+2016-10-13 20:58:25  create_grid    29543 create_grid.c            869  INFO Writing output grid file headers
+2016-10-13 20:58:25  create_grid    29543 create_grid.c            929  INFO Successful completion
+ 
+create_grid execution completed with status of 0
+ 
+Thu Oct 13 20:58:25 AEDT 2016
+Thu Oct 13 20:58:27 AEDT 2016
+ 
+Grid Terrain Second Pass (GRID_TERRAIN_PASS2)
+ 
+2016-10-13 20:58:27  Makegeomgrid    29746 make_geom_grid.c         100  INFO Initiated
+2016-10-13 20:58:27  Makegeomgrid    29746 make_geom_grid.c         189  INFO Using band number 6 from the TARGET_FRAME_FILE
+2016-10-13 20:58:27  Makegeomgrid    29746 make_geom_grid.c         607  INFO Successful Completion
+ 
+makegeomgrid execution completed with status of 0
+ 
+Thu Oct 13 20:58:27 AEDT 2016
+Thu Oct 13 20:58:29 AEDT 2016
+ 
+Resample Terrain Second Pass (RESAMPLE_TERRAIN_PASS2)
+ 
+2016-10-13 20:58:29  Geomresample    29762 geomresample.c            93  INFO Geometric Resample Initiated
+2016-10-13 20:58:29  Geomresample    29762 geomresample.c           112  INFO Reading Grid
+2016-10-13 20:58:29  Geomresample    29762 geomresample.c           219  INFO Resampling band 1
+2016-10-13 20:58:29  Geomresample    29762 scanman.c                250  INFO resampling lines 0 through 800
+2016-10-13 20:58:30  Geomresample    29762 scanman.c                250  INFO resampling lines 650 through 1450
+2016-10-13 20:58:30  Geomresample    29762 scanman.c                250  INFO resampling lines 1300 through 2100
+2016-10-13 20:58:30  Geomresample    29762 scanman.c                250  INFO resampling lines 1950 through 2750
+2016-10-13 20:58:30  Geomresample    29762 scanman.c                250  INFO resampling lines 2600 through 3400
+2016-10-13 20:58:30  Geomresample    29762 scanman.c                250  INFO resampling lines 3250 through 4050
+2016-10-13 20:58:30  Geomresample    29762 scanman.c                250  INFO resampling lines 3900 through 4700
+2016-10-13 20:58:31  Geomresample    29762 scanman.c                250  INFO resampling lines 4550 through 5350
+2016-10-13 20:58:31  Geomresample    29762 scanman.c                250  INFO resampling lines 5200 through 6000
+2016-10-13 20:58:31  Geomresample    29762 scanman.c                250  INFO resampling lines 5850 through 6650
+2016-10-13 20:58:31  Geomresample    29762 scanman.c                250  INFO resampling lines 6500 through 7300
+2016-10-13 20:58:32  Geomresample    29762 scanman.c                250  INFO resampling lines 7150 through 7950
+2016-10-13 20:58:32  Geomresample    29762 scanman.c                250  INFO resampling lines 7800 through 8600
+2016-10-13 20:58:32  Geomresample    29762 scanman.c                250  INFO resampling lines 8450 through 9250
+2016-10-13 20:58:33  Geomresample    29762 scanman.c                250  INFO resampling lines 9100 through 9900
+2016-10-13 20:58:33  Geomresample    29762 scanman.c                250  INFO resampling lines 9750 through 10550
+2016-10-13 20:58:33  Geomresample    29762 scanman.c                250  INFO resampling lines 10400 through 11200
+2016-10-13 20:58:33  Geomresample    29762 scanman.c                250  INFO resampling lines 11050 through 11850
+2016-10-13 20:58:33  Geomresample    29762 scanman.c                250  INFO resampling lines 11700 through 12500
+2016-10-13 20:58:34  Geomresample    29762 scanman.c                250  INFO resampling lines 12350 through 13093
+2016-10-13 20:58:34  Geomresample    29762 geomresample.c           330  INFO Geometric Resample Successful Completion
+ 
+geomresample execution completed with status of 0
+ 
+Thu Oct 13 20:58:34 AEDT 2016
+Thu Oct 13 20:58:35 AEDT 2016
+ 
+L8 Resample Precision (L8RESAMPLE_PREC)
+ 
+2016-10-13 20:58:35  Resample    29793 resample.c               115  INFO Initiated
+2016-10-13 20:58:36  Resample    29793 process_band.c            80  INFO Resampling band number 1
+2016-10-13 20:59:14  Resample    29793 process_band.c            80  INFO Resampling band number 2
+2016-10-13 20:59:56  Resample    29793 process_band.c            80  INFO Resampling band number 3
+2016-10-13 21:00:33  Resample    29793 process_band.c            80  INFO Resampling band number 4
+2016-10-13 21:01:13  Resample    29793 process_band.c            80  INFO Resampling band number 5
+2016-10-13 21:01:52  Resample    29793 process_band.c            80  INFO Resampling band number 6
+2016-10-13 21:02:30  Resample    29793 process_band.c            80  INFO Resampling band number 7
+2016-10-13 21:03:03  Resample    29793 process_band.c            80  INFO Resampling band number 8
+2016-10-13 21:05:36  Resample    29793 process_band.c            80  INFO Resampling band number 9
+2016-10-13 21:06:07  Resample    29793 process_band.c            80  INFO Resampling band number 10
+2016-10-13 21:06:40  Resample    29793 process_band.c            80  INFO Resampling band number 11
+2016-10-13 21:07:10  Resample    29793 resample.c               789  INFO Successful Completion
+ 
+resample execution completed with status of 0
+ 
+Thu Oct 13 21:07:10 AEDT 2016
+Thu Oct 13 21:07:12 AEDT 2016
+ 
+L8 GCP Correlation for Precision Second Pass (L8PRECISION_GCP_PASS2)
+ 
+2016-10-13 21:07:12  gcpcorrelate    30362 GCPcorrelate.c            84  INFO Initiated
+2016-10-13 21:07:12  gcpcorrelate    30362 GCPcorrelate.c            87  INFO Reading gcp_lib/GCPLib
+2016-10-13 21:07:12  gcpcorrelate    30362 ias_gcp_read_gcplib.c     292  INFO Reading gcp_lib/GCPLib
+2016-10-13 21:07:12  gcpcorrelate    30362 ias_gcp_read_gcplib.c     313  INFO Read 408 GCPs
+2016-10-13 21:07:12  gcpcorrelate    30362 ias_gcp_read_gcplib.c     135  INFO Pixel alignment will be 'UL', hemisphere is 'S', datum = 'GDA_94'
+2016-10-13 21:07:12  gcpcorrelate    30362 GCPcorrelate.c           116  INFO Read 408 GCPs
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            236  INFO Processing 1 SCA(s) in image l1t.h5
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            375  INFO Using image chips from gcp_lib
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 0 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800156 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800374 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800184 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800061 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800142 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800367 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800305 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800194 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800116 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800379 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800252 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800370 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800361 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800113 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800090 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800060 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800327 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800259 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800198 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800378 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800042 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800393 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800025 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800328 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800261 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800039 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800139 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800188 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800024 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800056 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800206 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800064 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800217 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800164 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800015 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800363 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800218 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800291 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800301 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800020 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 40 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800284 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800197 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800294 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800234 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800272 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800009 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800154 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800346 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800058 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800038 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800109 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800005 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800223 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800114 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800099 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800022 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800317 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800120 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800176 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800250 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800322 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800130 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800246 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800028 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800092 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800210 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800170 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800135 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800107 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800225 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800310 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800131 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800079 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800260 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800040 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800181 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800100 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800345 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800076 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800125 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 80 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800012 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800175 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800354 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800282 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800018 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800240 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800088 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800280 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800073 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800117 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800318 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800375 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800033 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800239 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800035 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800150 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800059 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800147 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800074 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800362 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800377 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800172 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800032 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800249 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800288 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800395 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800245 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800192 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800258 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800050 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800075 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800340 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800004 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800148 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800081 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800247 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800315 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800337 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800266 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800052 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 120 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800201 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800065 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800224 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800145 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800338 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800086 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800205 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800163 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800271 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800091 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800066 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800041 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800263 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800143 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800069 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800037 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800297 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800119 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800264 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800230 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800231 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800151 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800110 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800391 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800278 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800190 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800355 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800002 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800057 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800146 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800168 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800098 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800084 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800102 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800221 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800166 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800289 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800352 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800237 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800296 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 160 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800128 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800277 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800106 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800394 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800101 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800017 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800406 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800158 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800254 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800108 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800169 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800211 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800085 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800356 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800177 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800202 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800093 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800126 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800123 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800178 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800314 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800072 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800173 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800381 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800220 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800403 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800311 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800319 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800010 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800019 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800400 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800236 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800044 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800062 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800384 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800267 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800304 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800273 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800321 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800227 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 200 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800121 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800144 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800115 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800386 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800342 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800171 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800083 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800161 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800251 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800281 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800071 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800390 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800193 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800335 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800348 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800136 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800360 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800174 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800298 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800213 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800129 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800183 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800134 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800215 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800388 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800330 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800292 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800248 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800182 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800396 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800089 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800299 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800212 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800034 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800257 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800207 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800047 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800255 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800339 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800419 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 240 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800068 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800343 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800222 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800167 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800372 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800195 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800233 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800313 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800031 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800235 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800006 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800373 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800189 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800295 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800208 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800138 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800080 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800347 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800104 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800358 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800268 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800132 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800013 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800199 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800269 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800275 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800325 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800127 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800229 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800357 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800320 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800293 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800232 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800054 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800111 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800279 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800265 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800341 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800287 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800118 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 280 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800124 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800141 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800187 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800368 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800228 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800001 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800140 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800155 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800014 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800308 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800196 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800369 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800326 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800112 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800048 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800276 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800316 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800046 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800380 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800094 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800003 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800398 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800149 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800331 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800152 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800336 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800133 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800055 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800097 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800021 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800185 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800385 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800165 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800027 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800290 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800137 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800366 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800179 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800191 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800051 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 320 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800382 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800200 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800333 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800204 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800365 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800371 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800043 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800383 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800323 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800226 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800306 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800351 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800392 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800359 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800334 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800399 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800159 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800045 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800096 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800303 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800387 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800067 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800008 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800016 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800186 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800030 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800162 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800241 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800350 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800302 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800283 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800397 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800103 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800153 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800312 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800349 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800082 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800011 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800216 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800332 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 360 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800244 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800242 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800344 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800087 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800353 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800389 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800270 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800324 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800238 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800243 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800023 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800364 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800274 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800105 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800077 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800253 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800286 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800285 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800122 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800029 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800307 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800063 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800219 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800095 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800007 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800157 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800300 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800070 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800214 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800078 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800180 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800053 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800036 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800376 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800407 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800026 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800049 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800405 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800309 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800160 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            430  INFO Correlating GCP # 400 to SCA 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800404 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800203 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800262 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800402 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800209 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800418 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800416 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            476  WARN Skipping GCP 1140800329 pixel size (30.000000, 30.000000) does not match image pixel size (25.000000, 25.000000)
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            694  INFO Points inside image 0, Number used 0, Last used 0
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            755  WARN No points correlated successfully
+2016-10-13 21:07:12  gcpcorrelate    30362 process_gcp.c            759  INFO 0 of 408 points correlated
+2016-10-13 21:07:12  gcpcorrelate    30362 GCPcorrelate.c           151  INFO Successful completion
+ 
+gcpcorrelate execution completed with status of 0
+ 
+Thu Oct 13 21:07:12 AEDT 2016
+Thu Oct 13 21:07:14 AEDT 2016
+ 
+Geometric Accuracy Characterization (GEOMETRIC)
+ 
+2016-10-13 21:07:14  geometric    30375 geometric_char.c         104  INFO Geometric Accuracy Assessment Characterization initiated
+2016-10-13 21:07:14  geometric    30375 geometric_char.c         143  WARN Number of correlated validation GCPs read 0 is below the minimum threshold 20, so geometric results should not be used
+ 
+geometric execution completed with status of 0
+ 
+Thu Oct 13 21:07:14 AEDT 2016
+Thu Oct 13 21:07:17 AEDT 2016
+ 
+Terrain Occlusion (TERRAIN_OCCLUSION)
+ 
+2016-10-13 21:07:17  terrain_occlusion    30387 terrain_occlusion.c       86  INFO Initiate ...
+2016-10-13 21:07:20  terrain_occlusion    30387 terrain_occlusion.c      269  INFO Elevation range on unresampled DEM: -40 to 419
+
+2016-10-13 21:07:20  terrain_occlusion    30387 occlusion_threading.c     348  INFO Starting terrain occlusion with 4 threads
+2016-10-13 21:07:20  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 0
+2016-10-13 21:07:22  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 1
+2016-10-13 21:07:23  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 2
+2016-10-13 21:07:25  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 3
+2016-10-13 21:07:26  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 4
+2016-10-13 21:07:27  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 5
+2016-10-13 21:07:29  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 6
+2016-10-13 21:07:30  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 7
+2016-10-13 21:07:31  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 8
+2016-10-13 21:07:32  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 9
+2016-10-13 21:07:33  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 10
+2016-10-13 21:07:34  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 11
+2016-10-13 21:07:35  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 12
+2016-10-13 21:07:36  terrain_occlusion    30387 occlusion_threading.c     144  INFO Starting SCA 13
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 0: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 1: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 2: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 3: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 4: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 5: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 6: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 7: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 8: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 9: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 10: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 11: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 12: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     377  INFO Occluded pixels in SCA 13: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 occlusion_threading.c     381  INFO Total occluded pixels: 0
+2016-10-13 21:07:38  terrain_occlusion    30387 write_l1g.c               61  INFO Writing occlusion file occlusion_mask.h5
+2016-10-13 21:07:38  terrain_occlusion    30387 terrain_occlusion.c      330  INFO Successful completion.
+ 
+terrain_occlusion execution completed with a status of 0
+ 
+Thu Oct 13 21:07:39 AEDT 2016
+Thu Oct 13 21:07:40 AEDT 2016
+ 
+Assess Cloud Cover (ASSESS_CLOUD_COVER)
+ 
+2016-10-13 21:07:40  assess_cloud_cover    30473 assess_cloud_cover.c    2061  INFO assess_cloud_cover l1t.h5
+2016-10-13 21:07:40  assess_cloud_cover    30473 ias_cpf_parse_cloud_cover_assessment.c     122  WARN Only 1 parameter read in from the CPF for Cirrus Threshold
+2016-10-13 21:07:40  assess_cloud_cover    30473 algorithm.c              359  INFO Using ACCA algorithm
+2016-10-13 21:07:40  assess_cloud_cover    30473 algorithm.c              359  INFO Using Cirrus algorithm
+2016-10-13 21:07:40  assess_cloud_cover    30473 algorithm.c              359  INFO Using See5 algorithm
+2016-10-13 21:07:44  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line    0/9228 (0%)
+2016-10-13 21:07:47  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line  922/9228 (10%)
+2016-10-13 21:07:52  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 1844/9228 (20%)
+2016-10-13 21:07:57  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 2766/9228 (30%)
+2016-10-13 21:08:04  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 3688/9228 (40%)
+2016-10-13 21:08:08  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 4610/9228 (50%)
+2016-10-13 21:08:12  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 5532/9228 (60%)
+2016-10-13 21:08:17  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 6454/9228 (70%)
+2016-10-13 21:08:22  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 7376/9228 (80%)
+2016-10-13 21:08:26  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 8298/9228 (90%)
+2016-10-13 21:08:28  assess_cloud_cover    30473 assess_cloud_cover.c    1374  INFO Processing line 9220/9228 (100%)
+2016-10-13 21:08:28  assess_cloud_cover    30473 assess_cloud_cover.c    1633  INFO Processing line 9228/9228 (100%)
+2016-10-13 21:08:28  assess_cloud_cover    30473 assess_cloud_cover.c    1971  INFO Cloud Score l1t.h5: 5.48%
+2016-10-13 21:08:28  assess_cloud_cover    30473 assess_cloud_cover.c    1972  INFO Snow/Ice Score l1t.h5: 0.16%
+2016-10-13 21:08:28  assess_cloud_cover    30473 assess_cloud_cover.c    1974  INFO Land Cloud Cover Score l1t.h5: 0.09%
+2016-10-13 21:08:28  assess_cloud_cover    30473 assess_cloud_cover.c    1975  INFO Created quality band image: quality_band.h5
+2016-10-13 21:08:28  assess_cloud_cover    30473 assess_cloud_cover.c    1976  INFO assess_cloud_cover took 48 seconds
+ 
+assess_cloud_cover execution completed with a status of 0
+ 
+Thu Oct 13 21:08:28 AEDT 2016
+Thu Oct 13 21:08:30 AEDT 2016
+ 
+DMS Format and Package (DFP)
+ 
+2016-10-13 21:08:30  format_and_package    30607 format_and_package.c     244  INFO DMS Format & Package started
+2016-10-13 21:08:30  format_and_package    30607 format_and_package.c     245  INFO Pixel origin is UL
+2016-10-13 21:08:30  format_and_package    30607 convert_band.c            92  INFO Converting band 1
+2016-10-13 21:08:31  format_and_package    30607 convert_band.c            92  INFO Converting band 2
+2016-10-13 21:08:33  format_and_package    30607 convert_band.c            92  INFO Converting band 3
+2016-10-13 21:08:35  format_and_package    30607 convert_band.c            92  INFO Converting band 4
+2016-10-13 21:08:36  format_and_package    30607 convert_band.c            92  INFO Converting band 5
+2016-10-13 21:08:37  format_and_package    30607 convert_band.c            92  INFO Converting band 6
+2016-10-13 21:08:39  format_and_package    30607 convert_band.c            92  INFO Converting band 7
+2016-10-13 21:08:40  format_and_package    30607 convert_band.c            92  INFO Converting band 8
+2016-10-13 21:08:45  format_and_package    30607 convert_band.c            92  INFO Converting band 9
+2016-10-13 21:08:47  format_and_package    30607 convert_band.c            92  INFO Converting band 10
+2016-10-13 21:08:49  format_and_package    30607 convert_band.c            92  INFO Converting band 11
+2016-10-13 21:08:51  format_and_package    30607 convert_band.c            95  INFO Converting quality band
+2016-10-13 21:08:53  format_and_package    30607 format_and_package.c     532  INFO Creating the angle coefficients file
+2016-10-13 21:08:53  format_and_package    30607 write_metadata.c        1557  INFO Creating the L1G metadata file
+2016-10-13 21:08:53  format_and_package    30607 format_and_package.c     616  INFO Successful completion of DMS Format & Package
+ 
+format_and_package execution completed with status of 0
+ 
+Thu Oct 13 21:08:53 AEDT 2016

--- a/integration_tests/data/dupe/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926_2/additional/OLI_TIRS_subsetter.log
+++ b/integration_tests/data/dupe/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926_2/additional/OLI_TIRS_subsetter.log
@@ -1,0 +1,5 @@
+CMD = '"/projects/v10/PinkMatter/LPGS4.1.4110/build/LAM/ot_subsetter" LC81140740812016270LGN00 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_080_080" --scene LC81140802016270LGN00'
+-------------------------------------------------------
+2016-10-13 20:52:15  Subsetter    27827 src/OTS/ot_subsetter.c     231  INFO scene_id LC81140802016270LGN00
+2016-10-13 20:52:15  Subsetter    27827 src/OTS/ot_subroutines.c    1730  INFO oli start: 34288
+2016-10-13 20:52:15  Subsetter    27827 src/OTS/ot_subroutines.c    1731  INFO oli stop: 41788

--- a/integration_tests/data/dupe/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926_2/additional/landsat-processor.log
+++ b/integration_tests/data/dupe/LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926_2/additional/landsat-processor.log
@@ -1,0 +1,7611 @@
+2016-10-13T20:42:06 ComServer.cpp 90: INFO: Trying to host communication server on port '15000'
+2016-10-13T20:42:06 SystemSpecLogThread.cpp 73: WARN: Failed to obtain all system logs
+--------------------------------------------------
+----------------SYSTEM SPECS BEGIN----------------
+--------------------------------------------------
+---------------
+/proc/cpuinfo
+---------------
+processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 0
+cpu cores	: 8
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 1
+cpu cores	: 8
+apicid		: 2
+initial apicid	: 2
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 2
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 2
+cpu cores	: 8
+apicid		: 4
+initial apicid	: 4
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 3
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 3
+cpu cores	: 8
+apicid		: 6
+initial apicid	: 6
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 4
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 4
+cpu cores	: 8
+apicid		: 8
+initial apicid	: 8
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 5
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 5
+cpu cores	: 8
+apicid		: 10
+initial apicid	: 10
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 6
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 6
+cpu cores	: 8
+apicid		: 12
+initial apicid	: 12
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 7
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 7
+cpu cores	: 8
+apicid		: 14
+initial apicid	: 14
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 8
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 0
+cpu cores	: 8
+apicid		: 32
+initial apicid	: 32
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 9
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 1
+cpu cores	: 8
+apicid		: 34
+initial apicid	: 34
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 10
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 2
+cpu cores	: 8
+apicid		: 36
+initial apicid	: 36
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 11
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 3
+cpu cores	: 8
+apicid		: 38
+initial apicid	: 38
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 12
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 4
+cpu cores	: 8
+apicid		: 40
+initial apicid	: 40
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 13
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 5
+cpu cores	: 8
+apicid		: 42
+initial apicid	: 42
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 14
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 6
+cpu cores	: 8
+apicid		: 44
+initial apicid	: 44
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 15
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 7
+cpu cores	: 8
+apicid		: 46
+initial apicid	: 46
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 16
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 0
+cpu cores	: 8
+apicid		: 1
+initial apicid	: 1
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 17
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 1
+cpu cores	: 8
+apicid		: 3
+initial apicid	: 3
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 18
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 2
+cpu cores	: 8
+apicid		: 5
+initial apicid	: 5
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 19
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 3
+cpu cores	: 8
+apicid		: 7
+initial apicid	: 7
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 20
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 4
+cpu cores	: 8
+apicid		: 9
+initial apicid	: 9
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 21
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 5
+cpu cores	: 8
+apicid		: 11
+initial apicid	: 11
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 22
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 6
+cpu cores	: 8
+apicid		: 13
+initial apicid	: 13
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 23
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 0
+siblings	: 16
+core id		: 7
+cpu cores	: 8
+apicid		: 15
+initial apicid	: 15
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5187.20
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 24
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 0
+cpu cores	: 8
+apicid		: 33
+initial apicid	: 33
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 25
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 1
+cpu cores	: 8
+apicid		: 35
+initial apicid	: 35
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 26
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 2
+cpu cores	: 8
+apicid		: 37
+initial apicid	: 37
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 27
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 3
+cpu cores	: 8
+apicid		: 39
+initial apicid	: 39
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 28
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 4
+cpu cores	: 8
+apicid		: 41
+initial apicid	: 41
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 29
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 5
+cpu cores	: 8
+apicid		: 43
+initial apicid	: 43
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 30
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 6
+cpu cores	: 8
+apicid		: 45
+initial apicid	: 45
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 31
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 45
+model name	: Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz
+stepping	: 7
+microcode	: 1808
+cpu MHz		: 2601.000
+cache size	: 20480 KB
+physical id	: 1
+siblings	: 16
+core id		: 7
+cpu cores	: 8
+apicid		: 47
+initial apicid	: 47
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx lahf_lm ida arat epb xsaveopt pln pts dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 5186.77
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+
+---------------
+/proc/meminfo
+---------------
+MemTotal:       32987140 kB
+MemFree:        18408804 kB
+Buffers:            1888 kB
+Cached:         10703376 kB
+SwapCached:        64384 kB
+Active:          3611468 kB
+Inactive:        7153440 kB
+Active(anon):      24972 kB
+Inactive(anon):    88320 kB
+Active(file):    3586496 kB
+Inactive(file):  7065120 kB
+Unevictable:       51816 kB
+Mlocked:               0 kB
+SwapTotal:      12000252 kB
+SwapFree:       11905224 kB
+Dirty:             11868 kB
+Writeback:             0 kB
+AnonPages:         84520 kB
+Mapped:            15632 kB
+Shmem:                40 kB
+Slab:            2977688 kB
+SReclaimable:     104508 kB
+SUnreclaim:      2873180 kB
+KernelStack:       17088 kB
+PageTables:         3728 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:    28493820 kB
+Committed_AS:     745792 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:      550096 kB
+VmallocChunk:   34340571272 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:         0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+DirectMap4k:        4096 kB
+DirectMap2M:     2084864 kB
+DirectMap1G:    31457280 kB
+
+---------------
+/proc/swaps
+---------------
+Filename				Type		Size	Used	Priority
+/dev/sda2                               partition	12000252	95028	-1
+
+---------------
+/proc/version
+---------------
+Linux version 2.6.32-642.1.1.el6.x86_64 (mockbuild@worker1.bsys.centos.org) (gcc version 4.4.7 20120313 (Red Hat 4.4.7-17) (GCC) ) #1 SMP Tue May 31 21:57:07 UTC 2016
+
+---------------
+export
+---------------
+export BASH_ENV="/home/547/lpgs/.bashrc"
+export BBCP_BASE="/apps/bbcp/15.02.03.01.1"
+export BBCP_ROOT="/apps/bbcp/15.02.03.01.1"
+export BBCP_VERSION="15.02.03.01.1"
+export BLAS="/g/data/v10/private/modules/core/lib64/libblas.so"
+export CC="gcc"
+export CONCURRENT_LPGS_SCENES="15"
+export CPATH="/g/data/v10/private/modules/core/include"
+export CSV_FILE="/g/data/v10/reprocess/work/ls8/level1/2016/log/20161013T152002/0/datasets.csv"
+export CXX="g++"
+export EDITOR="vim"
+export ENV="/home/547/lpgs/.bashrc"
+export ENVIRONMENT="BATCH"
+export FPATH="/opt/Modules/krutsh/commands"
+export GCC_BASE="/apps/gcc/5.2.0"
+export GCC_ROOT="/apps/gcc/5.2.0"
+export GCC_VERSION="5.2.0"
+export GDAL_DATA="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/gdal/share/gdal"
+export GDAL_DRIVER_PATH="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/gdal/gdalplugins"
+export GEOTIFF_CSV="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/libgeotiff/share/epsg_csv"
+export HDF5_PLUGIN_PATH="/g/data/v10/private/modules/core/hdf5-plugins/lib/plugin"
+export HISTSIZE="1000"
+export HOME="/home/547/lpgs"
+export HOST="r2353"
+export HOSTNAME="r2353"
+export HPCLPGS_HOME="/projects/v10/NEMO/hpc-lpgs"
+export IASBIN="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/bin"
+export IASDEM="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/GEOID"
+export IASSYS="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/share/sys"
+export IASYS="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/share/sys"
+export IAS_BIN="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/bin"
+export IAS_BIN2="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS2/bin"
+export IAS_DATA_DIR2="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS2/share"
+export IAS_SERVICES="DUMMY"
+export IAS_SYS_DIR2="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS2"
+export INFOPATH="/g/data/v10/private/modules/core/share/info"
+export INPUTRC="/etc/inputrc"
+export JPLDE421="/projects/v10/PinkMatter/LPGS4.1.4110/build/COTS64/novas3.1/data/lnxp1900p2053.421"
+export LANDSAT_INSTALL_DIR="/projects/v10/PinkMatter/LPGS4.1.4110"
+export LANG="C.UTF-8"
+export LAPACK="/g/data/v10/private/modules/core/lib64/liblapack.so"
+export LC_ALL="en_AU.utf8"
+export LD_LIBRARY_PATH="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/COTS64/unixodbc/lib64:/projects/v10/PinkMatter/LPGS4.1.4110/build/LACS/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/LAM/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/DPAS/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/tiff/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/libgeotiff/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/openjpeg/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/OpenThreads/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/allegro/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/proj4/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/geos/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/gdal/lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/fann/lib"
+export LD_RUN_PATH="/apps/gcc/5.2.0/lib64"
+export LEAP_SECONDS_FILE="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/LeapSeconds/leap_seconds.odl"
+export LEVEL1_MODE="LPGS"
+export LIBRARY_PATH="/g/data/v10/private/modules/core/lib64:/g/data/v10/private/modules/core/lib:/apps/gcc/5.2.0/lib64"
+export LOADEDMODULES="pbs:bbcp/15.02.03.01.1:gcc/5.2.0:core/1.0:eodatasets/0.8:gaip/4.2.2:galpgs-py2-env/1.3.7"
+export LOGNAME="lpgs"
+export LOG_PATH="/g/data/v10/reprocess/work/ls8/level1/2016/log/20161013T152002/0"
+export LPGS_NOTIFY_EMAIL="Earth.Observation@ga.gov.au"
+export LPGS_SYS_DIR2="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS2"
+export LPS_TABLE_PATH="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPS/tables"
+export LP_MAX_PORT="15025"
+export LP_MIN_PORT="15000"
+export LUIGI_WORKERS="12"
+export MACHTYPE="x86_64"
+export MAIL="/var/spool/mail/lpgs"
+export MANPATH="/g/data/v10/private/modules/core/share/man:/apps/gcc/5.2.0/share/man:/opt/pbs/default/man:/usr/share/man:/opt/man:/opt/Modules/default/man"
+export MODULEPATH="/g/data/v10/private/modules/modulefiles:/projects/u46/opt/modules/modulefiles:/projects/u46/opt/modules/modulefiles:/apps/.mf:/opt/Modules/modulefiles:/apps/Modules/modulefiles:"
+export MODULESHOME="/opt/Modules/3.2.6"
+export MODULE_VERSION="3.2.6"
+export MODULE_VERSION_STACK="3.2.6"
+export NCPUS="16"
+export NF_MODULES_LOADED="YES"
+export OLDPWD
+export OMP_NUM_THREADS="1"
+export OPSBIN="/projects/v10/PinkMatter/LPGS4.1.4110/build/LPGS/bin"
+export OSSIM_BIN="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/bin"
+export OSSIM_INC="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/include"
+export OSSIM_LIB="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/lib"
+export OSSIM_PREFS_FILE="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/ossim_preferences"
+export PATH="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/libgeotiff/bin:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/tiff/bin:/projects/v10/PinkMatter/LPGS4.1.4110/build/landsat_Pinkmatter:/g/data/v10/private/modules/galpgs-py2-env/1.3.7/bin:/g/data/v10/private/modules/gaip/4.2.2/ga-neo-landsat-processor/workflow:/g/data/v10/private/modules/eodatasets/0.8/bin:/g/data/v10/private/modules/core/bin:/apps/gcc/5.2.0/wrapper:/apps/gcc/5.2.0/bin:/projects/v10/NEMO/hpc-lpgs/bin:/home/547/lpgs/bin:/home/547/lpgs/local/bin:/apps/bbcp/15.02.03.01.1/bin:/opt/bin:/bin:/usr/bin:/opt/pbs/default/bin:/projects/v10/PinkMatter/LPGS4.1.4110/build/LAM/perl5lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/ossim/bin:/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA/gdal/bin"
+export PBS_ENVIRONMENT="PBS_BATCH"
+export PBS_JOBCOOKIE="000000003DFF07AD00000000697E2079"
+export PBS_JOBDIR="/home/547/lpgs"
+export PBS_JOBFS="/jobfs/local/9456756.r-man2"
+export PBS_JOBID="9456756.r-man2"
+export PBS_JOBNAME="ls8-2016-lvl1-0"
+export PBS_MOMPORT="15003"
+export PBS_NCI_FS_GDATA1="1"
+export PBS_NCI_FS_GDATA2="1"
+export PBS_NCI_FS_GDATA3="1"
+export PBS_NCI_HT="0"
+export PBS_NCI_JOBFS_GLOBAL="966367641600b"
+export PBS_NCI_WD="1"
+export PBS_NCPUS="32"
+export PBS_NGPUS="0"
+export PBS_NODENUM="1"
+export PBS_O_HOME="/home/547/lpgs"
+export PBS_O_HOST="raijin1"
+export PBS_O_LANG="C.UTF-8"
+export PBS_O_LOGNAME="lpgs"
+export PBS_O_MAIL="/var/spool/mail/lpgs"
+export PBS_O_PATH="/g/data/v10/private/modules/galpgs-py2-env/1.3.7/bin:/g/data/v10/private/modules/gaip/4.2.2/ga-neo-landsat-processor/workflow:/g/data/v10/private/modules/eodatasets/0.8/bin:/g/data/v10/private/modules/core/bin:/apps/gcc/5.2.0/wrapper:/apps/gcc/5.2.0/bin:/projects/v10/NEMO/hpc-lpgs/bin:/home/547/lpgs/bin:/home/547/lpgs/local/bin:/apps/bbcp/15.02.03.01.1/bin:/opt/bin:/bin:/usr/bin:/opt/pbs/default/bin"
+export PBS_O_QUEUE="normal"
+export PBS_O_SHELL="/bin/bash"
+export PBS_O_SYSTEM="Linux"
+export PBS_O_WORKDIR="/g/data/v10/projects/gaip-scripts"
+export PBS_QUEUE="normal-def"
+export PBS_TASKNUM="04000001"
+export PBS_VMEM="68719476736"
+export PERL5LIB="/projects/v10/PinkMatter/LPGS4.1.4110/build/landsat_Pinkmatter/perl5lib:/projects/v10/PinkMatter/LPGS4.1.4110/build/perl/lib/5.10.0/x86_64-linux-thread-multi:/projects/v10/PinkMatter/LPGS4.1.4110/build/COTS/lib/perl:/projects/v10/PinkMatter/LPGS4.1.4110/build/perl/lib"
+export PINKMATTER_LPGS_HOME="/projects/v10/PinkMatter/LPGS3616"
+export PKG_CONFIG_PATH="/g/data/v10/private/modules/core/lib64/pkgconfig:/g/data/v10/private/modules/core/lib/pkgconfig"
+export PROCESSING_CENTER="GA"
+export PROCESSING_SYSTEM="LPGS_LDCM"
+export PROJECT="v10"
+export PROJ_LIB="/g/data/v10/private/modules/core/lib/python2.7/site-packages/rasterio/proj_data"
+export PWD="/short/global_jobfs/9456756.r-man2/r2353/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work"
+export PYTHONPATH="/g/data/v10/private/modules/galpgs-py2-env/1.3.7/lib/python2.7/site-packages:/g/data/v10/private/modules/gaip/4.2.2/ga-neo-landsat-processor:/g/data/v10/private/modules/eodatasets/0.8/lib/python2.7/site-packages:/g/data/v10/private/modules/core/lib/python2.7/site-packages:/projects/v10/NEMO/hpc-lpgs/python:"
+export SHLVL="3"
+export STATUS_PATH="/g/data/v10/reprocess/work/ls8/level1/2016/status"
+export TCLLIBPATH="/apps/modext/default/lib/tcl"
+export TMPDIR="/jobfs/local/9456756.r-man2"
+export TMSS_HOME="/projects/v10/PinkMatter/LPGS4.1.4110/build/LAM/TMSS"
+export ULTRA_INSTALL_DIR="/projects/v10/PinkMatter/LPGS4.1.4110/build/ULTRA"
+export USER="lpgs"
+export _="/projects/v10/PinkMatter/LPGS4.1.4110/build/landsat_Pinkmatter/landsat_processor"
+export _LMFILES_="/opt/Modules/modulefiles/pbs:/apps/Modules/modulefiles/bbcp/15.02.03.01.1:/apps/Modules/modulefiles/gcc/5.2.0:/g/data/v10/private/modules/modulefiles/core/1.0:/g/data/v10/private/modules/modulefiles/eodatasets/0.8:/g/data/v10/private/modules/modulefiles/gaip/4.2.2:/g/data/v10/private/modules/modulefiles/galpgs-py2-env/1.3.7"
+export galpgs_module_path="/g/data/v10/private/modules/modulefiles"
+export needed_modules="gaip/4.2.2 galpgs-py2-env/1.3.7"
+
+---------------
+/sbin/ldconfig -p
+---------------
+1246 libs found in cache `/etc/ld.so.cache'
+	libz.so.1 (libc6,x86-64) => /lib64/libz.so.1
+	libz.so.1 (libc6) => /lib/libz.so.1
+	libz.so (libc6,x86-64) => /usr/lib64/libz.so
+	libxtables.so.4 (libc6,x86-64) => /lib64/libxtables.so.4
+	libxslt.so.1 (libc6,x86-64) => /usr/lib64/libxslt.so.1
+	libxslt.so (libc6,x86-64) => /usr/lib64/libxslt.so
+	libxshmfence.so.1 (libc6,x86-64) => /usr/lib64/libxshmfence.so.1
+	libxml2.so.2 (libc6,x86-64) => /usr/lib64/libxml2.so.2
+	libxml2.so (libc6,x86-64) => /usr/lib64/libxml2.so
+	libxmlsec1.so.1 (libc6,x86-64) => /usr/lib64/libxmlsec1.so.1
+	libxmlsec1.so (libc6,x86-64) => /usr/lib64/libxmlsec1.so
+	libxmlsec1-openssl.so.1 (libc6,x86-64) => /usr/lib64/libxmlsec1-openssl.so.1
+	libxmlsec1-openssl.so (libc6,x86-64) => /usr/lib64/libxmlsec1-openssl.so
+	libxmlrpc_util.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_util.so.3
+	libxmlrpc_server_cgi.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_server_cgi.so.3
+	libxmlrpc_server_abyss.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_server_abyss.so.3
+	libxmlrpc_server.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_server.so.3
+	libxmlrpc_client.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_client.so.3
+	libxmlrpc_abyss.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc_abyss.so.3
+	libxmlrpc.so.3 (libc6,x86-64) => /usr/lib64/libxmlrpc.so.3
+	libxkbfile.so.1 (libc6,x86-64) => /usr/lib64/libxkbfile.so.1
+	libxerces-c-3.0.so (libc6,x86-64) => /usr/lib64/libxerces-c-3.0.so
+	libxdot.so.4 (libc6,x86-64) => /usr/lib64/libxdot.so.4
+	libxcb.so.1 (libc6,x86-64) => /usr/lib64/libxcb.so.1
+	libxcb.so.1 (libc6) => /usr/lib/libxcb.so.1
+	libxcb.so (libc6,x86-64) => /usr/lib64/libxcb.so
+	libxcb-xvmc.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xvmc.so.0
+	libxcb-xvmc.so.0 (libc6) => /usr/lib/libxcb-xvmc.so.0
+	libxcb-xvmc.so (libc6,x86-64) => /usr/lib64/libxcb-xvmc.so
+	libxcb-xv.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xv.so.0
+	libxcb-xv.so.0 (libc6) => /usr/lib/libxcb-xv.so.0
+	libxcb-xv.so (libc6,x86-64) => /usr/lib64/libxcb-xv.so
+	libxcb-xtest.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xtest.so.0
+	libxcb-xtest.so.0 (libc6) => /usr/lib/libxcb-xtest.so.0
+	libxcb-xtest.so (libc6,x86-64) => /usr/lib64/libxcb-xtest.so
+	libxcb-xselinux.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xselinux.so.0
+	libxcb-xselinux.so.0 (libc6) => /usr/lib/libxcb-xselinux.so.0
+	libxcb-xselinux.so (libc6,x86-64) => /usr/lib64/libxcb-xselinux.so
+	libxcb-xkb.so.1 (libc6,x86-64) => /usr/lib64/libxcb-xkb.so.1
+	libxcb-xkb.so.1 (libc6) => /usr/lib/libxcb-xkb.so.1
+	libxcb-xkb.so (libc6,x86-64) => /usr/lib64/libxcb-xkb.so
+	libxcb-xinerama.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xinerama.so.0
+	libxcb-xinerama.so.0 (libc6) => /usr/lib/libxcb-xinerama.so.0
+	libxcb-xinerama.so (libc6,x86-64) => /usr/lib64/libxcb-xinerama.so
+	libxcb-xf86dri.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xf86dri.so.0
+	libxcb-xf86dri.so.0 (libc6) => /usr/lib/libxcb-xf86dri.so.0
+	libxcb-xf86dri.so (libc6,x86-64) => /usr/lib64/libxcb-xf86dri.so
+	libxcb-xfixes.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xfixes.so.0
+	libxcb-xfixes.so.0 (libc6) => /usr/lib/libxcb-xfixes.so.0
+	libxcb-xfixes.so (libc6,x86-64) => /usr/lib64/libxcb-xfixes.so
+	libxcb-xevie.so.0 (libc6,x86-64) => /usr/lib64/libxcb-xevie.so.0
+	libxcb-xevie.so.0 (libc6) => /usr/lib/libxcb-xevie.so.0
+	libxcb-xevie.so (libc6,x86-64) => /usr/lib64/libxcb-xevie.so
+	libxcb-util.so.1 (libc6,x86-64) => /usr/lib64/libxcb-util.so.1
+	libxcb-sync.so.1 (libc6,x86-64) => /usr/lib64/libxcb-sync.so.1
+	libxcb-sync.so.1 (libc6) => /usr/lib/libxcb-sync.so.1
+	libxcb-sync.so (libc6,x86-64) => /usr/lib64/libxcb-sync.so
+	libxcb-shm.so.0 (libc6,x86-64) => /usr/lib64/libxcb-shm.so.0
+	libxcb-shm.so.0 (libc6) => /usr/lib/libxcb-shm.so.0
+	libxcb-shm.so (libc6,x86-64) => /usr/lib64/libxcb-shm.so
+	libxcb-shape.so.0 (libc6,x86-64) => /usr/lib64/libxcb-shape.so.0
+	libxcb-shape.so.0 (libc6) => /usr/lib/libxcb-shape.so.0
+	libxcb-shape.so (libc6,x86-64) => /usr/lib64/libxcb-shape.so
+	libxcb-screensaver.so.0 (libc6,x86-64) => /usr/lib64/libxcb-screensaver.so.0
+	libxcb-screensaver.so.0 (libc6) => /usr/lib/libxcb-screensaver.so.0
+	libxcb-screensaver.so (libc6,x86-64) => /usr/lib64/libxcb-screensaver.so
+	libxcb-res.so.0 (libc6,x86-64) => /usr/lib64/libxcb-res.so.0
+	libxcb-res.so.0 (libc6) => /usr/lib/libxcb-res.so.0
+	libxcb-res.so (libc6,x86-64) => /usr/lib64/libxcb-res.so
+	libxcb-reply.so.1 (libc6,x86-64) => /usr/lib64/libxcb-reply.so.1
+	libxcb-render.so.0 (libc6,x86-64) => /usr/lib64/libxcb-render.so.0
+	libxcb-render.so.0 (libc6) => /usr/lib/libxcb-render.so.0
+	libxcb-render.so (libc6,x86-64) => /usr/lib64/libxcb-render.so
+	libxcb-record.so.0 (libc6,x86-64) => /usr/lib64/libxcb-record.so.0
+	libxcb-record.so.0 (libc6) => /usr/lib/libxcb-record.so.0
+	libxcb-record.so (libc6,x86-64) => /usr/lib64/libxcb-record.so
+	libxcb-randr.so.0 (libc6,x86-64) => /usr/lib64/libxcb-randr.so.0
+	libxcb-randr.so.0 (libc6) => /usr/lib/libxcb-randr.so.0
+	libxcb-randr.so (libc6,x86-64) => /usr/lib64/libxcb-randr.so
+	libxcb-property.so.1 (libc6,x86-64) => /usr/lib64/libxcb-property.so.1
+	libxcb-present.so.0 (libc6,x86-64) => /usr/lib64/libxcb-present.so.0
+	libxcb-present.so.0 (libc6) => /usr/lib/libxcb-present.so.0
+	libxcb-present.so (libc6,x86-64) => /usr/lib64/libxcb-present.so
+	libxcb-keysyms.so.1 (libc6,x86-64) => /usr/lib64/libxcb-keysyms.so.1
+	libxcb-icccm.so.1 (libc6,x86-64) => /usr/lib64/libxcb-icccm.so.1
+	libxcb-glx.so.0 (libc6,x86-64) => /usr/lib64/libxcb-glx.so.0
+	libxcb-glx.so.0 (libc6) => /usr/lib/libxcb-glx.so.0
+	libxcb-glx.so (libc6,x86-64) => /usr/lib64/libxcb-glx.so
+	libxcb-event.so.1 (libc6,x86-64) => /usr/lib64/libxcb-event.so.1
+	libxcb-dri3.so.0 (libc6,x86-64) => /usr/lib64/libxcb-dri3.so.0
+	libxcb-dri3.so.0 (libc6) => /usr/lib/libxcb-dri3.so.0
+	libxcb-dri3.so (libc6,x86-64) => /usr/lib64/libxcb-dri3.so
+	libxcb-dri2.so.0 (libc6,x86-64) => /usr/lib64/libxcb-dri2.so.0
+	libxcb-dri2.so.0 (libc6) => /usr/lib/libxcb-dri2.so.0
+	libxcb-dri2.so (libc6,x86-64) => /usr/lib64/libxcb-dri2.so
+	libxcb-dpms.so.0 (libc6,x86-64) => /usr/lib64/libxcb-dpms.so.0
+	libxcb-dpms.so.0 (libc6) => /usr/lib/libxcb-dpms.so.0
+	libxcb-dpms.so (libc6,x86-64) => /usr/lib64/libxcb-dpms.so
+	libxcb-damage.so.0 (libc6,x86-64) => /usr/lib64/libxcb-damage.so.0
+	libxcb-damage.so.0 (libc6) => /usr/lib/libxcb-damage.so.0
+	libxcb-damage.so (libc6,x86-64) => /usr/lib64/libxcb-damage.so
+	libxcb-composite.so.0 (libc6,x86-64) => /usr/lib64/libxcb-composite.so.0
+	libxcb-composite.so.0 (libc6) => /usr/lib/libxcb-composite.so.0
+	libxcb-composite.so (libc6,x86-64) => /usr/lib64/libxcb-composite.so
+	libxcb-aux.so.0 (libc6,x86-64) => /usr/lib64/libxcb-aux.so.0
+	libxcb-atom.so.1 (libc6,x86-64) => /usr/lib64/libxcb-atom.so.1
+	libwx_gtk2u_xrc-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_xrc-2.8.so.0
+	libwx_gtk2u_xrc-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_xrc-2.8.so
+	libwx_gtk2u_svg-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_svg-2.8.so.0
+	libwx_gtk2u_svg-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_svg-2.8.so
+	libwx_gtk2u_stc-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_stc-2.8.so.0
+	libwx_gtk2u_stc-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_stc-2.8.so
+	libwx_gtk2u_richtext-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_richtext-2.8.so.0
+	libwx_gtk2u_richtext-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_richtext-2.8.so
+	libwx_gtk2u_qa-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_qa-2.8.so.0
+	libwx_gtk2u_qa-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_qa-2.8.so
+	libwx_gtk2u_ogl-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_ogl-2.8.so.0
+	libwx_gtk2u_ogl-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_ogl-2.8.so
+	libwx_gtk2u_media-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_media-2.8.so.0
+	libwx_gtk2u_media-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_media-2.8.so
+	libwx_gtk2u_html-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_html-2.8.so.0
+	libwx_gtk2u_html-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_html-2.8.so
+	libwx_gtk2u_gl-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gl-2.8.so.0
+	libwx_gtk2u_gl-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gl-2.8.so
+	libwx_gtk2u_gizmos_xrc-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gizmos_xrc-2.8.so.0
+	libwx_gtk2u_gizmos_xrc-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gizmos_xrc-2.8.so
+	libwx_gtk2u_gizmos-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gizmos-2.8.so.0
+	libwx_gtk2u_gizmos-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_gizmos-2.8.so
+	libwx_gtk2u_core-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_core-2.8.so.0
+	libwx_gtk2u_core-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_core-2.8.so
+	libwx_gtk2u_aui-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_aui-2.8.so.0
+	libwx_gtk2u_aui-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_aui-2.8.so
+	libwx_gtk2u_adv-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_gtk2u_adv-2.8.so.0
+	libwx_gtk2u_adv-2.8.so (libc6,x86-64) => /usr/lib64/libwx_gtk2u_adv-2.8.so
+	libwx_baseu_xml-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_baseu_xml-2.8.so.0
+	libwx_baseu_xml-2.8.so (libc6,x86-64) => /usr/lib64/libwx_baseu_xml-2.8.so
+	libwx_baseu_net-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_baseu_net-2.8.so.0
+	libwx_baseu_net-2.8.so (libc6,x86-64) => /usr/lib64/libwx_baseu_net-2.8.so
+	libwx_baseu-2.8.so.0 (libc6,x86-64) => /usr/lib64/libwx_baseu-2.8.so.0
+	libwx_baseu-2.8.so (libc6,x86-64) => /usr/lib64/libwx_baseu-2.8.so
+	libwrap.so.0 (libc6,x86-64) => /lib64/libwrap.so.0
+	libwmflite-0.2.so.7 (libc6,x86-64) => /usr/lib64/libwmflite-0.2.so.7
+	libwmf-0.2.so.7 (libc6,x86-64) => /usr/lib64/libwmf-0.2.so.7
+	libvsl.so (libc6,x86-64) => /usr/lib/fio/libvsl.so
+	libvorbisfile.so.3 (libc6,x86-64) => /usr/lib64/libvorbisfile.so.3
+	libvorbisenc.so.2 (libc6,x86-64) => /usr/lib64/libvorbisenc.so.2
+	libvorbis.so.0 (libc6,x86-64) => /usr/lib64/libvorbis.so.0
+	libvma.so.6 (libc6,x86-64) => /usr/lib64/libvma.so.6
+	libvma.so (libc6,x86-64) => /usr/lib64/libvma.so
+	libvisual-0.4.so.0 (libc6,x86-64) => /usr/lib64/libvisual-0.4.so.0
+	libverto.so.0 (libc6,x86-64) => /usr/lib64/libverto.so.0
+	libverto.so (libc6,x86-64) => /usr/lib64/libverto.so
+	libverto-k5ev.so.0 (libc6,x86-64) => /usr/lib64/libverto-k5ev.so.0
+	libverto-k5ev.so (libc6,x86-64) => /usr/lib64/libverto-k5ev.so
+	libvdpau_trace.so (libc6,x86-64) => /usr/lib64/libvdpau_trace.so
+	libvdpau_nvidia.so (libc6,x86-64, OS ABI: Linux 2.3.99) => /usr/lib64/libvdpau_nvidia.so
+	libvdpau.so.1 (libc6,x86-64) => /usr/lib64/libvdpau.so.1
+	libvdpau.so (libc6,x86-64) => /usr/lib64/libvdpau.so
+	libuuid.so.1 (libc6,x86-64) => /lib64/libuuid.so.1
+	libuuid.so.1 (libc6) => /lib/libuuid.so.1
+	libuuid.so (libc6,x86-64) => /usr/lib64/libuuid.so
+	libutil.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libutil.so.1
+	libutil.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libutil.so.1
+	libutil.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libutil.so
+	libutil.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libutil.so
+	libutempter.so.0 (libc6,x86-64) => /usr/lib64/libutempter.so.0
+	libustr-1.0.so.1 (libc6,x86-64) => /usr/lib64/libustr-1.0.so.1
+	libuser.so.1 (libc6,x86-64) => /usr/lib64/libuser.so.1
+	libusbpp-0.1.so.4 (libc6,x86-64) => /usr/lib64/libusbpp-0.1.so.4
+	libusb-1.0.so.0 (libc6,x86-64) => /usr/lib64/libusb-1.0.so.0
+	libusb-0.1.so.4 (libc6,x86-64) => /usr/lib64/libusb-0.1.so.4
+	libunistring.so.0 (libc6,x86-64) => /usr/lib64/libunistring.so.0
+	libunique-1.0.so.0 (libc6,x86-64) => /usr/lib64/libunique-1.0.so.0
+	libungif.so.4 (libc6,x86-64) => /usr/lib64/libungif.so.4
+	libungif.so (libc6,x86-64) => /usr/lib64/libungif.so
+	libudf.so.0 (libc6,x86-64) => /usr/lib64/libudf.so.0
+	libudev.so.0 (libc6,x86-64) => /lib64/libudev.so.0
+	libt1x.so.5 (libc6,x86-64) => /usr/lib64/libt1x.so.5
+	libt1.so.5 (libc6,x86-64) => /usr/lib64/libt1.so.5
+	libturbojpeg.so (libc6,x86-64) => /usr/lib64/libturbojpeg.so
+	libtt-1.0.0.so (libc6,x86-64) => /usr/lib64/libtt-1.0.0.so
+	libtk8.5.so (libc6,x86-64) => /usr/lib64/libtk8.5.so
+	libtirpc.so.1 (libc6,x86-64) => /lib64/libtirpc.so.1
+	libtinfo.so.5 (libc6,x86-64) => /lib64/libtinfo.so.5
+	libtinfo.so.5 (libc6) => /lib/libtinfo.so.5
+	libtinfo.so (libc6,x86-64) => /usr/lib64/libtinfo.so
+	libtinfo.so (libc6) => /usr/lib/libtinfo.so
+	libtiffxx.so.3 (libc6,x86-64) => /usr/lib64/libtiffxx.so.3
+	libtiffxx.so.3 (libc6) => /usr/lib/libtiffxx.so.3
+	libtiffxx.so (libc6,x86-64) => /usr/lib64/libtiffxx.so
+	libtiff.so.3 (libc6,x86-64) => /usr/lib64/libtiff.so.3
+	libtiff.so.3 (libc6) => /usr/lib/libtiff.so.3
+	libtiff.so (libc6,x86-64) => /usr/lib64/libtiff.so
+	libtic.so.5 (libc6,x86-64) => /usr/lib64/libtic.so.5
+	libtic.so.5 (libc6) => /usr/lib/libtic.so.5
+	libtic.so (libc6,x86-64) => /usr/lib64/libtic.so
+	libtic.so (libc6) => /usr/lib/libtic.so
+	libthread_db.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libthread_db.so.1
+	libthread_db.so.1 (libc6, hwcap: 0x0028000000000000, OS ABI: Linux 2.6.18) => /lib/i686/nosegneg/libthread_db.so.1
+	libthread_db.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libthread_db.so.1
+	libthread_db.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libthread_db.so
+	libthread_db.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libthread_db.so
+	libtheoraenc.so.1 (libc6,x86-64) => /usr/lib64/libtheoraenc.so.1
+	libtheoradec.so.1 (libc6,x86-64) => /usr/lib64/libtheoradec.so.1
+	libtheora.so.0 (libc6,x86-64) => /usr/lib64/libtheora.so.0
+	libthai.so.0 (libc6,x86-64) => /usr/lib64/libthai.so.0
+	libtevent.so.0 (libc6,x86-64) => /usr/lib64/libtevent.so.0
+	libtevent-util.so.0 (libc6,x86-64) => /usr/lib64/libtevent-util.so.0
+	libtdb.so.1 (libc6,x86-64) => /usr/lib64/libtdb.so.1
+	libtcl8.5.so (libc6,x86-64) => /usr/lib64/libtcl8.5.so
+	libtclx8.4.so (libc6,x86-64) => /usr/lib64/tcl8.5/tclx8.4/libtclx8.4.so
+	libtasn1.so.3 (libc6,x86-64) => /usr/lib64/libtasn1.so.3
+	libtar.so.1 (libc6,x86-64) => /usr/lib64/libtar.so.1
+	libtalloc.so.2 (libc6,x86-64) => /usr/lib64/libtalloc.so.2
+	libsysfs.so.2 (libc6,x86-64) => /usr/lib64/libsysfs.so.2
+	libsvn_wc-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_wc-1.so.0
+	libsvn_swig_py-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_swig_py-1.so.0
+	libsvn_swig_perl-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_swig_perl-1.so.0
+	libsvn_subr-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_subr-1.so.0
+	libsvn_repos-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_repos-1.so.0
+	libsvn_ra_svn-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_ra_svn-1.so.0
+	libsvn_ra_neon-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_ra_neon-1.so.0
+	libsvn_ra_local-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_ra_local-1.so.0
+	libsvn_ra-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_ra-1.so.0
+	libsvn_fs_util-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_fs_util-1.so.0
+	libsvn_fs_fs-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_fs_fs-1.so.0
+	libsvn_fs_base-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_fs_base-1.so.0
+	libsvn_fs-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_fs-1.so.0
+	libsvn_diff-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_diff-1.so.0
+	libsvn_delta-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_delta-1.so.0
+	libsvn_client-1.so.0 (libc6,x86-64) => /usr/lib64/libsvn_client-1.so.0
+	libstdc++.so.6 (libc6,x86-64) => /usr/lib64/libstdc++.so.6
+	libstdc++.so.6 (libc6) => /usr/lib/libstdc++.so.6
+	libstdc++.so.5 (libc6,x86-64) => /usr/lib64/libstdc++.so.5
+	libstdc++.so.5 (libc6) => /usr/lib/libstdc++.so.5
+	libstartup-notification-1.so.0 (libc6,x86-64) => /usr/lib64/libstartup-notification-1.so.0
+	libsss_sudo.so (libc6,x86-64) => /usr/lib64/libsss_sudo.so
+	libsss_idmap.so.0 (libc6,x86-64) => /usr/lib64/libsss_idmap.so.0
+	libssl3.so (libc6,x86-64) => /usr/lib64/libssl3.so
+	libssl.so.10 (libc6,x86-64) => /usr/lib64/libssl.so.10
+	libssl.so (libc6,x86-64) => /usr/lib64/libssl.so
+	libssh2.so.1 (libc6,x86-64) => /usr/lib64/libssh2.so.1
+	libss.so.2 (libc6,x86-64) => /lib64/libss.so.2
+	libsqlite3.so.0 (libc6,x86-64) => /usr/lib64/libsqlite3.so.0
+	libsqlite3.so (libc6,x86-64) => /usr/lib64/libsqlite3.so
+	libspectre.so.1 (libc6,x86-64) => /usr/lib64/libspectre.so.1
+	libsoup-2.4.so.1 (libc6,x86-64) => /usr/lib64/libsoup-2.4.so.1
+	libsoup-gnome-2.4.so.1 (libc6,x86-64) => /usr/lib64/libsoup-gnome-2.4.so.1
+	libsoftokn3.so (libc6,x86-64) => /usr/lib64/libsoftokn3.so
+	libsnmp.so.20 (libc6,x86-64) => /usr/lib64/libsnmp.so.20
+	libsnappy.so.1 (libc6,x86-64) => /usr/lib64/libsnappy.so.1
+	libsmime3.so (libc6,x86-64) => /usr/lib64/libsmime3.so
+	libsmbldap.so.0 (libc6,x86-64) => /usr/lib64/libsmbldap.so.0
+	libsmbconf.so.0 (libc6,x86-64) => /usr/lib64/libsmbconf.so.0
+	libsmbclient-raw.so.0 (libc6,x86-64) => /usr/lib64/libsmbclient-raw.so.0
+	libslang.so.2 (libc6,x86-64) => /usr/lib64/libslang.so.2
+	libsgutils2.so.2 (libc6,x86-64) => /usr/lib64/libsgutils2.so.2
+	libsepol.so.1 (libc6,x86-64) => /lib64/libsepol.so.1
+	libsepol.so (libc6,x86-64) => /usr/lib64/libsepol.so
+	libsensors.so.4 (libc6,x86-64) => /usr/lib64/libsensors.so.4
+	libsemanage.so.1 (libc6,x86-64) => /lib64/libsemanage.so.1
+	libselinux.so.1 (libc6,x86-64) => /lib64/libselinux.so.1
+	libselinux.so.1 (libc6) => /lib/libselinux.so.1
+	libselinux.so (libc6,x86-64) => /usr/lib64/libselinux.so
+	libsasl2.so.2 (libc6,x86-64) => /usr/lib64/libsasl2.so.2
+	libsasl2.so (libc6,x86-64) => /usr/lib64/libsasl2.so
+	libsamdb.so.0 (libc6,x86-64) => /usr/lib64/libsamdb.so.0
+	libsamba-util.so.0 (libc6,x86-64) => /usr/lib64/libsamba-util.so.0
+	libsamba-policy.so.0 (libc6,x86-64) => /usr/lib64/libsamba-policy.so.0
+	libsamba-passdb.so.0 (libc6,x86-64) => /usr/lib64/libsamba-passdb.so.0
+	libsamba-hostconfig.so.0 (libc6,x86-64) => /usr/lib64/libsamba-hostconfig.so.0
+	libsamba-credentials.so.0 (libc6,x86-64) => /usr/lib64/libsamba-credentials.so.0
+	libruby.so.1.8 (libc6,x86-64) => /usr/lib64/libruby.so.1.8
+	libruby.so (libc6,x86-64) => /usr/lib64/libruby.so
+	librt.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/librt.so.1
+	librt.so.1 (libc6, hwcap: 0x0028000000000000, OS ABI: Linux 2.6.18) => /lib/i686/nosegneg/librt.so.1
+	librt.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/librt.so.1
+	librt.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/librt.so
+	librt.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/librt.so
+	librsvg-2.so.2 (libc6,x86-64) => /usr/lib64/librsvg-2.so.2
+	librrd_th.so.4 (libc6,x86-64) => /usr/lib64/librrd_th.so.4
+	librrd_th.so (libc6,x86-64) => /usr/lib64/librrd_th.so
+	librrd.so.4 (libc6,x86-64) => /usr/lib64/librrd.so.4
+	librrd.so (libc6,x86-64) => /usr/lib64/librrd.so
+	librpmio.so.1 (libc6,x86-64) => /usr/lib64/librpmio.so.1
+	librpmbuild.so.1 (libc6,x86-64) => /usr/lib64/librpmbuild.so.1
+	librpm.so.1 (libc6,x86-64) => /usr/lib64/librpm.so.1
+	librpcsecgss.so.3 (libc6,x86-64) => /usr/lib64/librpcsecgss.so.3
+	libresolv.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libresolv.so.2
+	libresolv.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libresolv.so.2
+	libresolv.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libresolv.so
+	libresolv.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libresolv.so
+	libregistry.so.0 (libc6,x86-64) => /usr/lib64/libregistry.so.0
+	libreg.so (libc6,x86-64) => /usr/lib64/libreg.so
+	libref_array.so.1 (libc6,x86-64) => /usr/lib64/libref_array.so.1
+	libreadline.so.6 (libc6,x86-64) => /lib64/libreadline.so.6
+	libreadline.so.5 (libc6,x86-64) => /lib64/libreadline.so.5
+	libreadline.so (libc6,x86-64) => /usr/lib64/libreadline.so
+	librdmacm.so.1 (libc6,x86-64) => /usr/lib64/librdmacm.so.1
+	librdmacm.so (libc6,x86-64) => /usr/lib64/librdmacm.so
+	librarian.so.0 (libc6,x86-64) => /usr/lib64/librarian.so.0
+	libqui.so.1 (libc6,x86-64) => /usr/lib64/qt-3.3/lib/libqui.so.1
+	libqt-mt.so.3 (libc6,x86-64) => /usr/lib64/qt-3.3/lib/libqt-mt.so.3
+	libp11-kit.so.0 (libc6,x86-64) => /usr/lib64/libp11-kit.so.0
+	libpython2.6.so.1.0 (libc6,x86-64) => /usr/lib64/libpython2.6.so.1.0
+	libpython2.6.so (libc6,x86-64) => /usr/lib64/libpython2.6.so
+	libpytalloc-util.so.2 (libc6,x86-64) => /usr/lib64/libpytalloc-util.so.2
+	libpyglib-2.0-python.so.0 (libc6,x86-64) => /usr/lib64/libpyglib-2.0-python.so.0
+	libpyglib-2.0-python.so (libc6,x86-64) => /usr/lib64/libpyglib-2.0-python.so
+	libpthread.so.0 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libpthread.so.0
+	libpthread.so.0 (libc6, hwcap: 0x0028000000000000, OS ABI: Linux 2.6.18) => /lib/i686/nosegneg/libpthread.so.0
+	libpthread.so.0 (libc6, OS ABI: Linux 2.6.18) => /lib/libpthread.so.0
+	libpth.so.20 (libc6,x86-64) => /usr/lib64/libpth.so.20
+	libpsm_infinipath.so.1 (libc6,x86-64) => /usr/lib64/libpsm_infinipath.so.1
+	libpsm_infinipath.so (libc6,x86-64) => /usr/lib64/libpsm_infinipath.so
+	libproxy.so.0 (libc6,x86-64) => /usr/lib64/libproxy.so.0
+	libproj.so.0 (libc6,x86-64) => /usr/lib64/libproj.so.0
+	libproc-3.2.8.so (libc6,x86-64) => /lib64/libproc-3.2.8.so
+	libpq.so.5 (libc6,x86-64) => /usr/lib64/libpq.so.5
+	libpq.so (libc6,x86-64) => /usr/lib64/libpq.so
+	libppl_c.so.2 (libc6,x86-64) => /usr/lib64/libppl_c.so.2
+	libppl.so.7 (libc6,x86-64) => /usr/lib64/libppl.so.7
+	libpopt.so.0 (libc6,x86-64) => /lib64/libpopt.so.0
+	libpopt.so (libc6,x86-64) => /usr/lib64/libpopt.so
+	libpoppler.so.5 (libc6,x86-64) => /usr/lib64/libpoppler.so.5
+	libpoppler-glib.so.4 (libc6,x86-64) => /usr/lib64/libpoppler-glib.so.4
+	libpolkit-gobject-1.so.0 (libc6,x86-64) => /usr/lib64/libpolkit-gobject-1.so.0
+	libpolkit-backend-1.so.0 (libc6,x86-64) => /usr/lib64/libpolkit-backend-1.so.0
+	libpolkit-agent-1.so.0 (libc6,x86-64) => /usr/lib64/libpolkit-agent-1.so.0
+	libpng12.so.0 (libc6,x86-64) => /usr/lib64/libpng12.so.0
+	libpng12.so.0 (libc6) => /usr/lib/libpng12.so.0
+	libpng12.so (libc6,x86-64) => /usr/lib64/libpng12.so
+	libpng.so.3 (libc6,x86-64) => /usr/lib64/libpng.so.3
+	libpng.so.3 (libc6) => /usr/lib/libpng.so.3
+	libply.so.2 (libc6,x86-64) => /lib64/libply.so.2
+	libply-splash-core.so.2 (libc6,x86-64) => /lib64/libply-splash-core.so.2
+	libply-boot-client.so.2 (libc6,x86-64) => /usr/lib64/libply-boot-client.so.2
+	libplds4.so (libc6,x86-64) => /lib64/libplds4.so
+	libplds4.so (libc6,x86-64) => /usr/lib64/libplds4.so
+	libplc4.so (libc6,x86-64) => /lib64/libplc4.so
+	libplc4.so (libc6,x86-64) => /usr/lib64/libplc4.so
+	libpixman-1.so.0 (libc6,x86-64) => /usr/lib64/libpixman-1.so.0
+	libpixman-1.so (libc6,x86-64) => /usr/lib64/libpixman-1.so
+	libphonon.so.4 (libc6,x86-64) => /usr/lib64/libphonon.so.4
+	libphonon.so (libc6,x86-64) => /usr/lib64/libphonon.so
+	libpgtypes.so.3 (libc6,x86-64) => /usr/lib64/libpgtypes.so.3
+	libpgtypes.so (libc6,x86-64) => /usr/lib64/libpgtypes.so
+	libpcreposix.so.0 (libc6,x86-64) => /usr/lib64/libpcreposix.so.0
+	libpcreposix.so (libc6,x86-64) => /usr/lib64/libpcreposix.so
+	libpcrecpp.so.0 (libc6,x86-64) => /usr/lib64/libpcrecpp.so.0
+	libpcrecpp.so (libc6,x86-64) => /usr/lib64/libpcrecpp.so
+	libpcre.so.0 (libc6,x86-64) => /lib64/libpcre.so.0
+	libpcre.so (libc6,x86-64) => /usr/lib64/libpcre.so
+	libpcprofile.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libpcprofile.so
+	libpcprofile.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libpcprofile.so
+	libpciaccess.so.0 (libc6,x86-64) => /usr/lib64/libpciaccess.so.0
+	libpciaccess.so.0 (libc6) => /usr/lib/libpciaccess.so.0
+	libpci.so.3 (libc6,x86-64) => /lib64/libpci.so.3
+	libpci.so (libc6,x86-64) => /usr/lib64/libpci.so
+	libpcap.so.1 (libc6,x86-64) => /usr/lib64/libpcap.so.1
+	libpathplan.so.4 (libc6,x86-64) => /usr/lib64/libpathplan.so.4
+	libpath_utils.so.1 (libc6,x86-64) => /usr/lib64/libpath_utils.so.1
+	libparted-2.1.so.0 (libc6,x86-64) => /lib64/libparted-2.1.so.0
+	libpaper.so.1 (libc6,x86-64) => /usr/lib64/libpaper.so.1
+	libpangoxft-1.0.so.0 (libc6,x86-64) => /usr/lib64/libpangoxft-1.0.so.0
+	libpangoxft-1.0.so (libc6,x86-64) => /usr/lib64/libpangoxft-1.0.so
+	libpangox-1.0.so.0 (libc6,x86-64) => /usr/lib64/libpangox-1.0.so.0
+	libpangox-1.0.so (libc6,x86-64) => /usr/lib64/libpangox-1.0.so
+	libpangoft2-1.0.so.0 (libc6,x86-64) => /usr/lib64/libpangoft2-1.0.so.0
+	libpangoft2-1.0.so (libc6,x86-64) => /usr/lib64/libpangoft2-1.0.so
+	libpangocairo-1.0.so.0 (libc6,x86-64) => /usr/lib64/libpangocairo-1.0.so.0
+	libpangocairo-1.0.so (libc6,x86-64) => /usr/lib64/libpangocairo-1.0.so
+	libpango-1.0.so.0 (libc6,x86-64) => /usr/lib64/libpango-1.0.so.0
+	libpango-1.0.so (libc6,x86-64) => /usr/lib64/libpango-1.0.so
+	libpanelw.so.5 (libc6,x86-64) => /usr/lib64/libpanelw.so.5
+	libpanelw.so.5 (libc6) => /usr/lib/libpanelw.so.5
+	libpanelw.so (libc6,x86-64) => /usr/lib64/libpanelw.so
+	libpanelw.so (libc6) => /usr/lib/libpanelw.so
+	libpanel.so.5 (libc6,x86-64) => /usr/lib64/libpanel.so.5
+	libpanel.so.5 (libc6) => /usr/lib/libpanel.so.5
+	libpanel.so (libc6,x86-64) => /usr/lib64/libpanel.so
+	libpanel.so (libc6) => /usr/lib/libpanel.so
+	libpamc.so.0 (libc6,x86-64) => /lib64/libpamc.so.0
+	libpam_misc.so.0 (libc6,x86-64) => /lib64/libpam_misc.so.0
+	libpam.so.0 (libc6,x86-64) => /lib64/libpam.so.0
+	libpakchois.so.0 (libc6,x86-64) => /usr/lib64/libpakchois.so.0
+	libotf.so.0 (libc6,x86-64) => /usr/lib64/libotf.so.0
+	libostyle.so.0 (libc6,x86-64) => /usr/lib64/libostyle.so.0
+	libospgrove.so.0 (libc6,x86-64) => /usr/lib64/libospgrove.so.0
+	libosp.so.5 (libc6,x86-64) => /usr/lib64/libosp.so.5
+	libosmvendor.so.3 (libc6,x86-64) => /usr/lib64/libosmvendor.so.3
+	libosmvendor.so (libc6,x86-64) => /usr/lib64/libosmvendor.so
+	libosmcomp.so.3 (libc6,x86-64) => /usr/lib64/libosmcomp.so.3
+	libosmcomp.so (libc6,x86-64) => /usr/lib64/libosmcomp.so
+	libopensm.so.5 (libc6,x86-64) => /usr/lib64/libopensm.so.5
+	libopensm.so (libc6,x86-64) => /usr/lib64/libopensm.so
+	libopenjpeg.so.2 (libc6,x86-64) => /usr/lib64/libopenjpeg.so.2
+	libopenjpeg.so (libc6,x86-64) => /usr/lib64/libopenjpeg.so
+	libopcodes-2.20.51.0.2-5.44.el6.so (libc6,x86-64) => /usr/lib64/libopcodes-2.20.51.0.2-5.44.el6.so
+	liboil-0.3.so.0 (libc6,x86-64) => /usr/lib64/liboil-0.3.so.0
+	libogrove.so.0 (libc6,x86-64) => /usr/lib64/libogrove.so.0
+	libogg.so.0 (libc6,x86-64) => /usr/lib64/libogg.so.0
+	libnvidia-tls.so.352.79 (libc6,x86-64, hwcap: 0x8000000000000000, OS ABI: Linux 2.3.99) => /usr/lib64/tls/libnvidia-tls.so.352.79
+	libnvidia-tls.so.352.79 (libc6,x86-64, OS ABI: Linux 2.2.5) => /usr/lib64/libnvidia-tls.so.352.79
+	libnvidia-opencl.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-opencl.so.1
+	libnvidia-ml.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-ml.so.1
+	libnvidia-ml.so (libc6,x86-64) => /usr/lib64/libnvidia-ml.so
+	libnvidia-ifr.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-ifr.so.1
+	libnvidia-ifr.so (libc6,x86-64) => /usr/lib64/libnvidia-ifr.so
+	libnvidia-gtk3.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-gtk3.so.352.79
+	libnvidia-gtk2.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-gtk2.so.352.79
+	libnvidia-glsi.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-glsi.so.352.79
+	libnvidia-glcore.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-glcore.so.352.79
+	libnvidia-fbc.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-fbc.so.1
+	libnvidia-fbc.so (libc6,x86-64) => /usr/lib64/libnvidia-fbc.so
+	libnvidia-encode.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-encode.so.1
+	libnvidia-encode.so (libc6,x86-64) => /usr/lib64/libnvidia-encode.so
+	libnvidia-eglcore.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-eglcore.so.352.79
+	libnvidia-compiler.so.352.79 (libc6,x86-64) => /usr/lib64/libnvidia-compiler.so.352.79
+	libnvidia-cfg.so.1 (libc6,x86-64) => /usr/lib64/libnvidia-cfg.so.1
+	libnvidia-cfg.so (libc6,x86-64) => /usr/lib64/libnvidia-cfg.so
+	libnvcuvid.so.1 (libc6,x86-64) => /usr/lib64/libnvcuvid.so.1
+	libnvcuvid.so (libc6,x86-64) => /usr/lib64/libnvcuvid.so
+	libnuma.so.1 (libc6,x86-64) => /usr/lib64/libnuma.so.1
+	libnuma.so (libc6,x86-64) => /usr/lib64/libnuma.so
+	libnss3.so (libc6,x86-64) => /usr/lib64/libnss3.so
+	libnssutil3.so (libc6,x86-64) => /usr/lib64/libnssutil3.so
+	libnsssysinit.so (libc6,x86-64) => /usr/lib64/libnsssysinit.so
+	libnsspem.so (libc6,x86-64) => /usr/lib64/libnsspem.so
+	libnssdbm3.so (libc6,x86-64) => /usr/lib64/libnssdbm3.so
+	libnssckbi.so (libc6,x86-64) => /usr/lib64/libnssckbi.so
+	libnss_sss.so.2 (libc6,x86-64) => /lib64/libnss_sss.so.2
+	libnss_nisplus.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_nisplus.so.2
+	libnss_nisplus.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_nisplus.so.2
+	libnss_nisplus.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_nisplus.so
+	libnss_nisplus.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_nisplus.so
+	libnss_nis.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_nis.so.2
+	libnss_nis.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_nis.so.2
+	libnss_nis.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_nis.so
+	libnss_nis.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_nis.so
+	libnss_ldap.so.2 (libc6,x86-64) => /lib64/libnss_ldap.so.2
+	libnss_ldap.so (libc6,x86-64) => /usr/lib64/libnss_ldap.so
+	libnss_hesiod.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_hesiod.so.2
+	libnss_hesiod.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_hesiod.so.2
+	libnss_hesiod.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_hesiod.so
+	libnss_hesiod.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_hesiod.so
+	libnss_files.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_files.so.2
+	libnss_files.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_files.so.2
+	libnss_files.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_files.so
+	libnss_files.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_files.so
+	libnss_dns.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_dns.so.2
+	libnss_dns.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_dns.so.2
+	libnss_dns.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_dns.so
+	libnss_dns.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_dns.so
+	libnss_compat.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnss_compat.so.2
+	libnss_compat.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libnss_compat.so.2
+	libnss_compat.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnss_compat.so
+	libnss_compat.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnss_compat.so
+	libnspr4.so (libc6,x86-64) => /lib64/libnspr4.so
+	libnspr4.so (libc6,x86-64) => /usr/lib64/libnspr4.so
+	libnsl.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libnsl.so.1
+	libnsl.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libnsl.so.1
+	libnsl.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libnsl.so
+	libnsl.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libnsl.so
+	libnl.so.1 (libc6,x86-64) => /lib64/libnl.so.1
+	libnl.so (libc6,x86-64) => /usr/lib64/libnl.so
+	libnl-3.so.200 (libc6,x86-64) => /usr/lib64/libnl-3.so.200
+	libnl-route-3.so.200 (libc6,x86-64) => /usr/lib64/libnl-route-3.so.200
+	libnl-nf-3.so.200 (libc6,x86-64) => /usr/lib64/libnl-nf-3.so.200
+	libnl-genl-3.so.200 (libc6,x86-64) => /usr/lib64/libnl-genl-3.so.200
+	libnih.so.1 (libc6,x86-64) => /lib64/libnih.so.1
+	libnih-dbus.so.1 (libc6,x86-64) => /lib64/libnih-dbus.so.1
+	libnfsidmap.so.0 (libc6,x86-64) => /usr/lib64/libnfsidmap.so.0
+	libnewt.so.0.52 (libc6,x86-64) => /usr/lib64/libnewt.so.0.52
+	libnetsnmptrapd.so.20 (libc6,x86-64) => /usr/lib64/libnetsnmptrapd.so.20
+	libnetsnmpmibs.so.20 (libc6,x86-64) => /usr/lib64/libnetsnmpmibs.so.20
+	libnetsnmphelpers.so.20 (libc6,x86-64) => /usr/lib64/libnetsnmphelpers.so.20
+	libnetsnmpagent.so.20 (libc6,x86-64) => /usr/lib64/libnetsnmpagent.so.20
+	libnetsnmp.so.20 (libc6,x86-64) => /usr/lib64/libnetsnmp.so.20
+	libnetpbm.so.10 (libc6,x86-64) => /usr/lib64/libnetpbm.so.10
+	libnetpbm.so (libc6,x86-64) => /usr/lib64/libnetpbm.so
+	libnes-rdmav2.so (libc6,x86-64) => /usr/lib64/libnes-rdmav2.so
+	libneon.so.27 (libc6,x86-64) => /usr/lib64/libneon.so.27
+	libndr.so.0 (libc6,x86-64) => /usr/lib64/libndr.so.0
+	libndr-standard.so.0 (libc6,x86-64) => /usr/lib64/libndr-standard.so.0
+	libndr-nbt.so.0 (libc6,x86-64) => /usr/lib64/libndr-nbt.so.0
+	libndr-krb5pac.so.0 (libc6,x86-64) => /usr/lib64/libndr-krb5pac.so.0
+	libncursesw.so.5 (libc6,x86-64) => /lib64/libncursesw.so.5
+	libncursesw.so.5 (libc6) => /lib/libncursesw.so.5
+	libncursesw.so (libc6,x86-64) => /usr/lib64/libncursesw.so
+	libncursesw.so (libc6) => /usr/lib/libncursesw.so
+	libncurses.so.5 (libc6,x86-64) => /lib64/libncurses.so.5
+	libncurses.so.5 (libc6) => /lib/libncurses.so.5
+	libncurses.so (libc6,x86-64) => /usr/lib64/libncurses.so
+	libncurses.so (libc6) => /usr/lib/libncurses.so
+	libnautilus-extension.so.1 (libc6,x86-64) => /usr/lib64/libnautilus-extension.so.1
+	libm17n.so.0 (libc6,x86-64) => /usr/lib64/libm17n.so.0
+	libm17n-flt.so.0 (libc6,x86-64) => /usr/lib64/libm17n-flt.so.0
+	libm17n-core.so.0 (libc6,x86-64) => /usr/lib64/libm17n-core.so.0
+	libmysqlclient_r.so.16 (libc6,x86-64) => /usr/lib64/mysql/libmysqlclient_r.so.16
+	libmysqlclient_r.so (libc6,x86-64) => /usr/lib64/mysql/libmysqlclient_r.so
+	libmysqlclient.so.16 (libc6,x86-64) => /usr/lib64/mysql/libmysqlclient.so.16
+	libmysqlclient.so (libc6,x86-64) => /usr/lib64/mysql/libmysqlclient.so
+	libmxm.so.2 (libc6,x86-64) => /opt/mellanox/mxm/lib/libmxm.so.2
+	libmxm.so (libc6,x86-64) => /opt/mellanox/mxm/lib/libmxm.so
+	libmunge.so.2 (libc6,x86-64) => /usr/lib64/libmunge.so.2
+	libmunge.so (libc6,x86-64) => /usr/lib64/libmunge.so
+	libmultipath.so (libc6,x86-64) => /lib64/libmultipath.so
+	libmtdev.so.1 (libc6,x86-64) => /usr/lib64/libmtdev.so.1
+	libmpfr.so.1 (libc6,x86-64) => /usr/lib64/libmpfr.so.1
+	libmpfr.so (libc6,x86-64) => /usr/lib64/libmpfr.so
+	libmpc.so.2 (libc6,x86-64) => /usr/lib64/libmpc.so.2
+	libmpc.so (libc6,x86-64) => /usr/lib64/libmpc.so
+	libmpathpersist.so.0 (libc6,x86-64) => /lib64/libmpathpersist.so.0
+	libmpathpersist.so (libc6,x86-64) => /lib64/libmpathpersist.so
+	libmp.so.3 (libc6,x86-64) => /usr/lib64/libmp.so.3
+	libmp.so (libc6,x86-64) => /usr/lib64/libmp.so
+	libmount.so.1 (libc6,x86-64) => /lib64/libmount.so.1
+	libmng.so.1 (libc6,x86-64) => /usr/lib64/libmng.so.1
+	libmng.so (libc6,x86-64) => /usr/lib64/libmng.so
+	libmlx5-rdmav2.so (libc6,x86-64) => /usr/lib64/libmlx5-rdmav2.so
+	libmlx4-rdmav2.so (libc6,x86-64) => /usr/lib64/libmlx4-rdmav2.so
+	libmenuw.so.5 (libc6,x86-64) => /usr/lib64/libmenuw.so.5
+	libmenuw.so.5 (libc6) => /usr/lib/libmenuw.so.5
+	libmenuw.so (libc6,x86-64) => /usr/lib64/libmenuw.so
+	libmenuw.so (libc6) => /usr/lib/libmenuw.so
+	libmenu.so.5 (libc6,x86-64) => /usr/lib64/libmenu.so.5
+	libmenu.so.5 (libc6) => /usr/lib/libmenu.so.5
+	libmenu.so (libc6,x86-64) => /usr/lib64/libmenu.so
+	libmenu.so (libc6) => /usr/lib/libmenu.so
+	libmemusage.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libmemusage.so
+	libmemusage.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libmemusage.so
+	libmcpp.so.0 (libc6,x86-64) => /usr/lib64/libmcpp.so.0
+	libmagic.so.1 (libc6,x86-64) => /usr/lib64/libmagic.so.1
+	libm.so.6 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libm.so.6
+	libm.so.6 (libc6, hwcap: 0x0028000000000000, OS ABI: Linux 2.6.18) => /lib/i686/nosegneg/libm.so.6
+	libm.so.6 (libc6, OS ABI: Linux 2.6.18) => /lib/libm.so.6
+	libm.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libm.so
+	libm.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libm.so
+	liblzo2.so.2 (libc6,x86-64) => /usr/lib64/liblzo2.so.2
+	liblzma.so.0 (libc6,x86-64) => /usr/lib64/liblzma.so.0
+	liblzma.so (libc6,x86-64) => /usr/lib64/liblzma.so
+	liblwres.so.80 (libc6,x86-64) => /usr/lib64/liblwres.so.80
+	liblvm2cmd.so.2.02 (libc6,x86-64) => /lib64/liblvm2cmd.so.2.02
+	liblvm2app.so.2.2 (libc6,x86-64) => /lib64/liblvm2app.so.2.2
+	liblustreapi.so (libc6,x86-64) => /usr/lib64/liblustreapi.so
+	liblustre.so (libc6,x86-64) => /usr/lib64/liblustre.so
+	liblua-5.1.so (libc6,x86-64) => /usr/lib64/liblua-5.1.so
+	libltdl.so.7 (libc6,x86-64) => /usr/lib64/libltdl.so.7
+	libldif-2.4.so.2 (libc6,x86-64) => /lib64/libldif-2.4.so.2
+	libldif-2.4.so.2 (libc6,x86-64) => /usr/lib64/libldif-2.4.so.2
+	libldb.so.1 (libc6,x86-64) => /usr/lib64/libldb.so.1
+	libldap_r-2.4.so.2 (libc6,x86-64) => /lib64/libldap_r-2.4.so.2
+	libldap_r-2.4.so.2 (libc6,x86-64) => /usr/lib64/libldap_r-2.4.so.2
+	libldap-2.4.so.2 (libc6,x86-64) => /lib64/libldap-2.4.so.2
+	libldap-2.4.so.2 (libc6,x86-64) => /usr/lib64/libldap-2.4.so.2
+	liblcms.so.1 (libc6,x86-64) => /usr/lib64/liblcms.so.1
+	liblcms.so (libc6,x86-64) => /usr/lib64/liblcms.so
+	liblber-2.4.so.2 (libc6,x86-64) => /lib64/liblber-2.4.so.2
+	liblber-2.4.so.2 (libc6,x86-64) => /usr/lib64/liblber-2.4.so.2
+	libk5crypto.so.3 (libc6,x86-64) => /lib64/libk5crypto.so.3
+	libk5crypto.so (libc6,x86-64) => /usr/lib64/libk5crypto.so
+	libkrb5support.so.0 (libc6,x86-64) => /lib64/libkrb5support.so.0
+	libkrb5support.so (libc6,x86-64) => /usr/lib64/libkrb5support.so
+	libkrb5.so.3 (libc6,x86-64) => /lib64/libkrb5.so.3
+	libkrb5.so (libc6,x86-64) => /usr/lib64/libkrb5.so
+	libkpathsea.so.4 (libc6,x86-64) => /usr/lib64/libkpathsea.so.4
+	libkeyutils.so.1 (libc6,x86-64) => /lib64/libkeyutils.so.1
+	libkeyutils.so (libc6,x86-64) => /usr/lib64/libkeyutils.so
+	libkdb5.so.6 (libc6,x86-64) => /usr/lib64/libkdb5.so.6
+	libkdb5.so (libc6,x86-64) => /usr/lib64/libkdb5.so
+	libkadm5srv_mit.so.8 (libc6,x86-64) => /usr/lib64/libkadm5srv_mit.so.8
+	libkadm5srv_mit.so (libc6,x86-64) => /usr/lib64/libkadm5srv_mit.so
+	libkadm5clnt_mit.so.8 (libc6,x86-64) => /usr/lib64/libkadm5clnt_mit.so.8
+	libkadm5clnt_mit.so (libc6,x86-64) => /usr/lib64/libkadm5clnt_mit.so
+	libjpeg.so.62 (libc6,x86-64) => /usr/lib64/libjpeg.so.62
+	libjpeg.so.62 (libc6) => /usr/lib/libjpeg.so.62
+	libjpeg.so (libc6,x86-64) => /usr/lib64/libjpeg.so
+	libjasper.so.1 (libc6,x86-64) => /usr/lib64/libjasper.so.1
+	libjasper.so (libc6,x86-64) => /usr/lib64/libjasper.so
+	libiw.so.29 (libc6,x86-64) => /lib64/libiw.so.29
+	libiso9660.so.7 (libc6,x86-64) => /usr/lib64/libiso9660.so.7
+	libiso9660++.so.0 (libc6,x86-64) => /usr/lib64/libiso9660++.so.0
+	libisccfg.so.82 (libc6,x86-64) => /usr/lib64/libisccfg.so.82
+	libisccc.so.80 (libc6,x86-64) => /usr/lib64/libisccc.so.80
+	libisc.so.83 (libc6,x86-64) => /usr/lib64/libisc.so.83
+	libip6tc.so.0 (libc6,x86-64) => /lib64/libip6tc.so.0
+	libip4tc.so.0 (libc6,x86-64) => /lib64/libip4tc.so.0
+	libiptc.so.0 (libc6,x86-64) => /lib64/libiptc.so.0
+	libipq.so.0 (libc6,x86-64) => /lib64/libipq.so.0
+	libipmimonitoring.so.5 (libc6,x86-64) => /usr/lib64/libipmimonitoring.so.5
+	libipmidetect.so.0 (libc6,x86-64) => /usr/lib64/libipmidetect.so.0
+	libipmiconsole.so.2 (libc6,x86-64) => /usr/lib64/libipmiconsole.so.2
+	libipathverbs-rdmav2.so (libc6,x86-64) => /usr/lib64/libipathverbs-rdmav2.so
+	libipa_hbac.so.0 (libc6,x86-64) => /usr/lib64/libipa_hbac.so.0
+	libini_config.so.5 (libc6,x86-64) => /usr/lib64/libini_config.so.5
+	libinfinipath.so.4 (libc6,x86-64) => /usr/lib64/libinfinipath.so.4
+	libinfinipath.so (libc6,x86-64) => /usr/lib64/libinfinipath.so
+	libijs-0.35.so (libc6,x86-64) => /usr/lib64/libijs-0.35.so
+	libidn.so.11 (libc6,x86-64) => /lib64/libidn.so.11
+	libidn.so (libc6,x86-64) => /usr/lib64/libidn.so
+	libicuuc.so.42 (libc6,x86-64) => /usr/lib64/libicuuc.so.42
+	libicutu.so.42 (libc6,x86-64) => /usr/lib64/libicutu.so.42
+	libiculx.so.42 (libc6,x86-64) => /usr/lib64/libiculx.so.42
+	libicule.so.42 (libc6,x86-64) => /usr/lib64/libicule.so.42
+	libicui18n.so.42 (libc6,x86-64) => /usr/lib64/libicui18n.so.42
+	libicuio.so.42 (libc6,x86-64) => /usr/lib64/libicuio.so.42
+	libicudata.so.42 (libc6,x86-64) => /usr/lib64/libicudata.so.42
+	libibverbs.so.1 (libc6,x86-64) => /usr/lib64/libibverbs.so.1
+	libibverbs.so (libc6,x86-64) => /usr/lib64/libibverbs.so
+	libibumad.so.3 (libc6,x86-64) => /usr/lib64/libibumad.so.3
+	libibumad.so (libc6,x86-64) => /usr/lib64/libibumad.so
+	libibsysapi.so.1 (libc6,x86-64) => /opt/ibutils/lib64/libibsysapi.so.1
+	libibsysapi.so (libc6,x86-64) => /opt/ibutils/lib64/libibsysapi.so
+	libibsysapi-2.1.1.so (libc6,x86-64) => /usr/lib64/libibsysapi-2.1.1.so
+	libibprof.so.0 (libc6,x86-64) => /opt/mellanox/libibperf/lib/libibprof.so.0
+	libibprof.so (libc6,x86-64) => /opt/mellanox/libibperf/lib/libibprof.so
+	libibnetdisc.so.5 (libc6,x86-64) => /usr/lib64/libibnetdisc.so.5
+	libibnetdisc.so (libc6,x86-64) => /usr/lib64/libibnetdisc.so
+	libibmscli.so.1 (libc6,x86-64) => /opt/ibutils/lib64/libibmscli.so.1
+	libibmscli.so (libc6,x86-64) => /opt/ibutils/lib64/libibmscli.so
+	libibmad.so.5 (libc6,x86-64) => /usr/lib64/libibmad.so.5
+	libibmad.so (libc6,x86-64) => /usr/lib64/libibmad.so
+	libibis-2.1.1.so (libc6,x86-64) => /usr/lib64/libibis-2.1.1.so
+	libibdmcom.so.1 (libc6,x86-64) => /opt/ibutils/lib64/libibdmcom.so.1
+	libibdmcom.so (libc6,x86-64) => /opt/ibutils/lib64/libibdmcom.so
+	libibdmcom-2.1.1.so (libc6,x86-64) => /usr/lib64/libibdmcom-2.1.1.so
+	libibdm.so.1 (libc6,x86-64) => /opt/ibutils/lib64/libibdm.so.1
+	libibdm.so (libc6,x86-64) => /opt/ibutils/lib64/libibdm.so
+	libibdiagnet_plugins_ifc-2.1.1.so (libc6,x86-64) => /usr/lib64/libibdiagnet_plugins_ifc-2.1.1.so
+	libibdiag-2.1.1.so (libc6,x86-64) => /usr/lib64/libibdiag-2.1.1.so
+	libibcm.so.1 (libc6,x86-64) => /usr/lib64/libibcm.so.1
+	libibcm.so (libc6,x86-64) => /usr/lib64/libibcm.so
+	libhwloc.so.5 (libc6,x86-64) => /usr/lib64/libhwloc.so.5
+	libhwloc.so.1 (libc6,x86-64) => /usr/lib64/libhwloc.so.1
+	libhwloc.so (libc6,x86-64) => /usr/lib64/libhwloc.so
+	libhunspell-1.2.so.0 (libc6,x86-64) => /usr/lib64/libhunspell-1.2.so.0
+	libhistory.so.6 (libc6,x86-64) => /usr/lib64/libhistory.so.6
+	libhistory.so.5 (libc6,x86-64) => /usr/lib64/libhistory.so.5
+	libhistory.so (libc6,x86-64) => /usr/lib64/libhistory.so
+	libhesiod.so.0 (libc6,x86-64) => /usr/lib64/libhesiod.so.0
+	libhandle.so.1 (libc6,x86-64) => /lib64/libhandle.so.1
+	libhandle.so (libc6,x86-64) => /usr/lib64/libhandle.so
+	libhal.so.1 (libc6,x86-64) => /usr/lib64/libhal.so.1
+	libhal-storage.so.1 (libc6,x86-64) => /usr/lib64/libhal-storage.so.1
+	libg2c.so.0 (libc6,x86-64) => /usr/lib64/libg2c.so.0
+	libgvpr.so.1 (libc6,x86-64) => /usr/lib64/libgvpr.so.1
+	libgvfscommon.so.0 (libc6,x86-64) => /usr/lib64/libgvfscommon.so.0
+	libgvfscommon-dnssd.so.0 (libc6,x86-64) => /usr/lib64/libgvfscommon-dnssd.so.0
+	libgvc.so.5 (libc6,x86-64) => /usr/lib64/libgvc.so.5
+	libguilereadline-v-17.so.17 (libc6,x86-64) => /usr/lib64/libguilereadline-v-17.so.17
+	libguilereadline-v-17.so (libc6,x86-64) => /usr/lib64/libguilereadline-v-17.so
+	libguile.so.17 (libc6,x86-64) => /usr/lib64/libguile.so.17
+	libguile.so (libc6,x86-64) => /usr/lib64/libguile.so
+	libguile-srfi-srfi-60-v-2.so.2 (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-60-v-2.so.2
+	libguile-srfi-srfi-60-v-2.so (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-60-v-2.so
+	libguile-srfi-srfi-13-14-v-3.so.3 (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-13-14-v-3.so.3
+	libguile-srfi-srfi-13-14-v-3.so (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-13-14-v-3.so
+	libguile-srfi-srfi-4-v-3.so.3 (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-4-v-3.so.3
+	libguile-srfi-srfi-4-v-3.so (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-4-v-3.so
+	libguile-srfi-srfi-1-v-3.so.3 (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-1-v-3.so.3
+	libguile-srfi-srfi-1-v-3.so (libc6,x86-64) => /usr/lib64/libguile-srfi-srfi-1-v-3.so
+	libgudev-1.0.so.0 (libc6,x86-64) => /usr/lib64/libgudev-1.0.so.0
+	libgtk-1.2.so.0 (libc6,x86-64) => /usr/lib64/libgtk-1.2.so.0
+	libgtk-x11-2.0.so.0 (libc6,x86-64) => /usr/lib64/libgtk-x11-2.0.so.0
+	libgtk-x11-2.0.so (libc6,x86-64) => /usr/lib64/libgtk-x11-2.0.so
+	libgthread-2.0.so.0 (libc6,x86-64) => /lib64/libgthread-2.0.so.0
+	libgthread-2.0.so (libc6,x86-64) => /usr/lib64/libgthread-2.0.so
+	libgthread-1.2.so.0 (libc6,x86-64) => /usr/lib64/libgthread-1.2.so.0
+	libgstvideo-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstvideo-0.10.so.0
+	libgsttag-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgsttag-0.10.so.0
+	libgstsdp-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstsdp-0.10.so.0
+	libgstrtsp-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstrtsp-0.10.so.0
+	libgstrtp-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstrtp-0.10.so.0
+	libgstriff-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstriff-0.10.so.0
+	libgstreamer-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstreamer-0.10.so.0
+	libgstpbutils-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstpbutils-0.10.so.0
+	libgstnetbuffer-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstnetbuffer-0.10.so.0
+	libgstnet-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstnet-0.10.so.0
+	libgstinterfaces-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstinterfaces-0.10.so.0
+	libgstfft-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstfft-0.10.so.0
+	libgstdataprotocol-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstdataprotocol-0.10.so.0
+	libgstcontroller-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstcontroller-0.10.so.0
+	libgstcdda-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstcdda-0.10.so.0
+	libgstbase-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstbase-0.10.so.0
+	libgstaudio-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstaudio-0.10.so.0
+	libgstapp-0.10.so.0 (libc6,x86-64) => /usr/lib64/libgstapp-0.10.so.0
+	libgssrpc.so.4 (libc6,x86-64) => /lib64/libgssrpc.so.4
+	libgssrpc.so (libc6,x86-64) => /usr/lib64/libgssrpc.so
+	libgssglue.so.1 (libc6,x86-64) => /lib64/libgssglue.so.1
+	libgssapi_krb5.so.2 (libc6,x86-64) => /lib64/libgssapi_krb5.so.2
+	libgssapi_krb5.so (libc6,x86-64) => /usr/lib64/libgssapi_krb5.so
+	libgsf-1.so.114 (libc6,x86-64) => /usr/lib64/libgsf-1.so.114
+	libgs.so.8 (libc6,x86-64) => /usr/lib64/libgs.so.8
+	libgs.so (libc6,x86-64) => /usr/lib64/libgs.so
+	libgraph.so.4 (libc6,x86-64) => /usr/lib64/libgraph.so.4
+	libgp11.so.0 (libc6,x86-64) => /usr/lib64/libgp11.so.0
+	libgpm.so.2 (libc6,x86-64) => /usr/lib64/libgpm.so.2
+	libgpgme.so.11 (libc6,x86-64) => /usr/lib64/libgpgme.so.11
+	libgpgme-pthread.so.11 (libc6,x86-64) => /usr/lib64/libgpgme-pthread.so.11
+	libgpgme-pth.so.11 (libc6,x86-64) => /usr/lib64/libgpgme-pth.so.11
+	libgpg-error.so.0 (libc6,x86-64) => /lib64/libgpg-error.so.0
+	libgpg-error.so (libc6,x86-64) => /usr/lib64/libgpg-error.so
+	libgomp.so.1 (libc6,x86-64) => /usr/lib64/libgomp.so.1
+	libgobject-2.0.so.0 (libc6,x86-64) => /lib64/libgobject-2.0.so.0
+	libgobject-2.0.so (libc6,x86-64) => /usr/lib64/libgobject-2.0.so
+	libgnutlsxx.so.26 (libc6,x86-64) => /usr/lib64/libgnutlsxx.so.26
+	libgnutls.so.26 (libc6,x86-64) => /usr/lib64/libgnutls.so.26
+	libgnutls-extra.so.26 (libc6,x86-64) => /usr/lib64/libgnutls-extra.so.26
+	libgnomevfs-2.so.0 (libc6,x86-64) => /usr/lib64/libgnomevfs-2.so.0
+	libgnomeui-2.so.0 (libc6,x86-64) => /usr/lib64/libgnomeui-2.so.0
+	libgnomecanvas-2.so.0 (libc6,x86-64) => /usr/lib64/libgnomecanvas-2.so.0
+	libgnome-2.so.0 (libc6,x86-64) => /usr/lib64/libgnome-2.so.0
+	libgnome-keyring.so.0 (libc6,x86-64) => /usr/lib64/libgnome-keyring.so.0
+	libgnome-desktop-2.so.11 (libc6,x86-64) => /usr/lib64/libgnome-desktop-2.so.11
+	libgmpxx.so.4 (libc6,x86-64) => /usr/lib64/libgmpxx.so.4
+	libgmpxx.so (libc6,x86-64) => /usr/lib64/libgmpxx.so
+	libgmp.so.3 (libc6,x86-64) => /usr/lib64/libgmp.so.3
+	libgmp.so (libc6,x86-64) => /usr/lib64/libgmp.so
+	libgmodule-2.0.so.0 (libc6,x86-64) => /lib64/libgmodule-2.0.so.0
+	libgmodule-2.0.so (libc6,x86-64) => /usr/lib64/libgmodule-2.0.so
+	libgmodule-1.2.so.0 (libc6,x86-64) => /usr/lib64/libgmodule-1.2.so.0
+	libglut.so.3 (libc6,x86-64) => /usr/lib64/libglut.so.3
+	libglut.so (libc6,x86-64) => /usr/lib64/libglut.so
+	libglib-2.0.so.0 (libc6,x86-64) => /lib64/libglib-2.0.so.0
+	libglib-2.0.so (libc6,x86-64) => /usr/lib64/libglib-2.0.so
+	libglib-1.2.so.0 (libc6,x86-64) => /usr/lib64/libglib-1.2.so.0
+	libglapi.so.0 (libc6,x86-64) => /usr/lib64/libglapi.so.0
+	libglapi.so.0 (libc6) => /usr/lib/libglapi.so.0
+	libglapi.so (libc6,x86-64) => /usr/lib64/libglapi.so
+	libglapi.so (libc6) => /usr/lib/libglapi.so
+	libglade-2.0.so.0 (libc6,x86-64) => /usr/lib64/libglade-2.0.so.0
+	libgio-2.0.so.0 (libc6,x86-64) => /lib64/libgio-2.0.so.0
+	libgio-2.0.so (libc6,x86-64) => /usr/lib64/libgio-2.0.so
+	libgif.so.4 (libc6,x86-64) => /usr/lib64/libgif.so.4
+	libgif.so (libc6,x86-64) => /usr/lib64/libgif.so
+	libgfortran.so.3 (libc6,x86-64) => /usr/lib64/libgfortran.so.3
+	libgfortran.so.1 (libc6,x86-64) => /usr/lib64/libgfortran.so.1
+	libgettextsrc-0.17.so (libc6,x86-64) => /usr/lib64/libgettextsrc-0.17.so
+	libgettextlib-0.17.so (libc6,x86-64) => /usr/lib64/libgettextlib-0.17.so
+	libgeotiff.so.1.2 (libc6,x86-64) => /usr/lib64/libgeotiff.so.1.2
+	libgensec.so.0 (libc6,x86-64) => /usr/lib64/libgensec.so.0
+	libgdu.so.0 (libc6,x86-64) => /usr/lib64/libgdu.so.0
+	libgdk_pixbuf_xlib-2.0.so.0 (libc6,x86-64) => /usr/lib64/libgdk_pixbuf_xlib-2.0.so.0
+	libgdk_pixbuf_xlib-2.0.so (libc6,x86-64) => /usr/lib64/libgdk_pixbuf_xlib-2.0.so
+	libgdk_pixbuf-2.0.so.0 (libc6,x86-64) => /usr/lib64/libgdk_pixbuf-2.0.so.0
+	libgdk_pixbuf-2.0.so (libc6,x86-64) => /usr/lib64/libgdk_pixbuf-2.0.so
+	libgdk-1.2.so.0 (libc6,x86-64) => /usr/lib64/libgdk-1.2.so.0
+	libgdk-x11-2.0.so.0 (libc6,x86-64) => /usr/lib64/libgdk-x11-2.0.so.0
+	libgdk-x11-2.0.so (libc6,x86-64) => /usr/lib64/libgdk-x11-2.0.so
+	libgdbm.so.2 (libc6,x86-64) => /usr/lib64/libgdbm.so.2
+	libgdbm.so (libc6,x86-64) => /usr/lib64/libgdbm.so
+	libgd.so.2 (libc6,x86-64) => /usr/lib64/libgd.so.2
+	libgd.so (libc6,x86-64) => /usr/lib64/libgd.so
+	libgcrypt.so.11 (libc6,x86-64) => /lib64/libgcrypt.so.11
+	libgcrypt.so (libc6,x86-64) => /usr/lib64/libgcrypt.so
+	libgcr.so.0 (libc6,x86-64) => /usr/lib64/libgcr.so.0
+	libgconf-2.so.4 (libc6,x86-64) => /usr/lib64/libgconf-2.so.4
+	libgcc_s.so.1 (libc6,x86-64) => /lib64/libgcc_s.so.1
+	libgcc_s.so.1 (libc6) => /lib/libgcc_s.so.1
+	libgbm.so.1 (libc6,x86-64) => /usr/lib64/libgbm.so.1
+	libganglia.so.0 (libc6,x86-64) => /usr/lib64/libganglia.so.0
+	libganglia-3.6.0.so.0 (libc6,x86-64) => /usr/lib64/libganglia-3.6.0.so.0
+	libgamin-1.so.0 (libc6,x86-64) => /usr/lib64/libgamin-1.so.0
+	libgailutil.so.18 (libc6,x86-64) => /usr/lib64/libgailutil.so.18
+	libgailutil.so (libc6,x86-64) => /usr/lib64/libgailutil.so
+	libfreetype.so.6 (libc6,x86-64) => /usr/lib64/libfreetype.so.6
+	libfreetype.so.6 (libc6) => /usr/lib/libfreetype.so.6
+	libfreetype.so (libc6,x86-64) => /usr/lib64/libfreetype.so
+	libfreeipmi.so.13 (libc6,x86-64) => /usr/lib64/libfreeipmi.so.13
+	libfreebl3.so (libc6,x86-64) => /lib64/libfreebl3.so
+	libfreebl3.so (libc6,x86-64) => /usr/lib64/libfreebl3.so
+	libfreebl3.so (libc6) => /lib/libfreebl3.so
+	libfreebl3.so (libc6) => /usr/lib/libfreebl3.so
+	libfreeblpriv3.so (libc6,x86-64) => /lib64/libfreeblpriv3.so
+	libfreeblpriv3.so (libc6,x86-64) => /usr/lib64/libfreeblpriv3.so
+	libfreeblpriv3.so (libc6) => /lib/libfreeblpriv3.so
+	libfreeblpriv3.so (libc6) => /usr/lib/libfreeblpriv3.so
+	libformw.so.5 (libc6,x86-64) => /usr/lib64/libformw.so.5
+	libformw.so.5 (libc6) => /usr/lib/libformw.so.5
+	libformw.so (libc6,x86-64) => /usr/lib64/libformw.so
+	libformw.so (libc6) => /usr/lib/libformw.so
+	libform.so.5 (libc6,x86-64) => /usr/lib64/libform.so.5
+	libform.so.5 (libc6) => /usr/lib/libform.so.5
+	libform.so (libc6,x86-64) => /usr/lib64/libform.so
+	libform.so (libc6) => /usr/lib/libform.so
+	libfontenc.so.1 (libc6,x86-64) => /usr/lib64/libfontenc.so.1
+	libfontconfig.so.1 (libc6,x86-64) => /usr/lib64/libfontconfig.so.1
+	libfontconfig.so.1 (libc6) => /usr/lib/libfontconfig.so.1
+	libfontconfig.so (libc6,x86-64) => /usr/lib64/libfontconfig.so
+	libfltk_images.so.1.1 (libc6,x86-64) => /usr/lib64/libfltk_images.so.1.1
+	libfltk_gl.so.1.1 (libc6,x86-64) => /usr/lib64/libfltk_gl.so.1.1
+	libfltk_forms.so.1.1 (libc6,x86-64) => /usr/lib64/libfltk_forms.so.1.1
+	libfltk.so.1.1 (libc6,x86-64) => /usr/lib64/libfltk.so.1.1
+	libfipscheck.so.1 (libc6,x86-64) => /lib64/libfipscheck.so.1
+	libffi.so.5 (libc6,x86-64) => /usr/lib64/libffi.so.5
+	libffi.so (libc6,x86-64) => /usr/lib64/libffi.so
+	libfca.so.0 (libc6,x86-64) => /opt/mellanox/fca/lib/libfca.so.0
+	libfca.so (libc6,x86-64) => /opt/mellanox/fca/lib/libfca.so
+	libfam.so.0 (libc6,x86-64) => /usr/lib64/libfam.so.0
+	libe2p.so.2 (libc6,x86-64) => /lib64/libe2p.so.2
+	libe2p.so (libc6,x86-64) => /usr/lib64/libe2p.so
+	libext2fs.so.2 (libc6,x86-64) => /lib64/libext2fs.so.2
+	libext2fs.so (libc6,x86-64) => /usr/lib64/libext2fs.so
+	libexslt.so.0 (libc6,x86-64) => /usr/lib64/libexslt.so.0
+	libexslt.so (libc6,x86-64) => /usr/lib64/libexslt.so
+	libexpect5.44.1.15.so (libc6,x86-64) => /usr/lib64/libexpect5.44.1.15.so
+	libexpect.so (libc6,x86-64) => /usr/lib64/libexpect.so
+	libexpat.so.1 (libc6,x86-64) => /lib64/libexpat.so.1
+	libexpat.so.1 (libc6) => /lib/libexpat.so.1
+	libexpat.so (libc6,x86-64) => /usr/lib64/libexpat.so
+	libexif.so.12 (libc6,x86-64) => /usr/lib64/libexif.so.12
+	libexempi.so.3 (libc6,x86-64) => /usr/lib64/libexempi.so.3
+	libevview.so.1 (libc6,x86-64) => /usr/lib64/libevview.so.1
+	libevent_extra-1.4.so.2 (libc6,x86-64) => /usr/lib64/libevent_extra-1.4.so.2
+	libevent_core-1.4.so.2 (libc6,x86-64) => /usr/lib64/libevent_core-1.4.so.2
+	libevent-1.4.so.2 (libc6,x86-64) => /usr/lib64/libevent-1.4.so.2
+	libevdocument.so.1 (libc6,x86-64) => /usr/lib64/libevdocument.so.1
+	libevdev.so.2 (libc6,x86-64) => /usr/lib64/libevdev.so.2
+	libepoxy.so.0 (libc6,x86-64) => /usr/lib64/libepoxy.so.0
+	libelf.so.1 (libc6,x86-64) => /usr/lib64/libelf.so.1
+	libelf.so.1 (libc6) => /usr/lib/libelf.so.1
+	libeggdbus-1.so.0 (libc6,x86-64) => /usr/lib64/libeggdbus-1.so.0
+	libedit.so.0 (libc6,x86-64) => /usr/lib64/libedit.so.0
+	libecpg_compat.so.3 (libc6,x86-64) => /usr/lib64/libecpg_compat.so.3
+	libecpg_compat.so (libc6,x86-64) => /usr/lib64/libecpg_compat.so
+	libecpg.so.6 (libc6,x86-64) => /usr/lib64/libecpg.so.6
+	libecpg.so (libc6,x86-64) => /usr/lib64/libecpg.so
+	libdw.so.1 (libc6,x86-64) => /usr/lib64/libdw.so.1
+	libdump_pr.so.1 (libc6,x86-64) => /usr/lib64/libdump_pr.so.1
+	libdump_pr.so (libc6,x86-64) => /usr/lib64/libdump_pr.so
+	libdrm_radeon.so.1 (libc6,x86-64) => /usr/lib64/libdrm_radeon.so.1
+	libdrm_radeon.so.1 (libc6) => /usr/lib/libdrm_radeon.so.1
+	libdrm_radeon.so (libc6,x86-64) => /usr/lib64/libdrm_radeon.so
+	libdrm_nouveau2.so.2 (libc6,x86-64) => /usr/lib64/libdrm_nouveau2.so.2
+	libdrm_nouveau2.so.2 (libc6) => /usr/lib/libdrm_nouveau2.so.2
+	libdrm_nouveau2.so (libc6,x86-64) => /usr/lib64/libdrm_nouveau2.so
+	libdrm_nouveau.so.1 (libc6,x86-64) => /usr/lib64/libdrm_nouveau.so.1
+	libdrm_nouveau.so.1 (libc6) => /usr/lib/libdrm_nouveau.so.1
+	libdrm_nouveau.so (libc6,x86-64) => /usr/lib64/libdrm_nouveau.so
+	libdrm_intel.so.1 (libc6,x86-64) => /usr/lib64/libdrm_intel.so.1
+	libdrm_intel.so.1 (libc6) => /usr/lib/libdrm_intel.so.1
+	libdrm_intel.so (libc6,x86-64) => /usr/lib64/libdrm_intel.so
+	libdrm_amdgpu.so.1 (libc6,x86-64) => /usr/lib64/libdrm_amdgpu.so.1
+	libdrm_amdgpu.so.1 (libc6) => /usr/lib/libdrm_amdgpu.so.1
+	libdrm_amdgpu.so (libc6,x86-64) => /usr/lib64/libdrm_amdgpu.so
+	libdrm.so.2 (libc6,x86-64) => /usr/lib64/libdrm.so.2
+	libdrm.so.2 (libc6) => /usr/lib/libdrm.so.2
+	libdrm.so (libc6,x86-64) => /usr/lib64/libdrm.so
+	libdns.so.81 (libc6,x86-64) => /usr/lib64/libdns.so.81
+	libdmx.so.1 (libc6,x86-64) => /usr/lib64/libdmx.so.1
+	libdl.so.2 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libdl.so.2
+	libdl.so.2 (libc6, OS ABI: Linux 2.6.18) => /lib/libdl.so.2
+	libdl.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libdl.so
+	libdl.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libdl.so
+	libdhash.so.1 (libc6,x86-64) => /usr/lib64/libdhash.so.1
+	libdevmapper.so.1.02 (libc6,x86-64) => /lib64/libdevmapper.so.1.02
+	libdevmapper-event.so.1.02 (libc6,x86-64) => /lib64/libdevmapper-event.so.1.02
+	libdevmapper-event-lvm2thin.so (libc6,x86-64) => /lib64/libdevmapper-event-lvm2thin.so
+	libdevmapper-event-lvm2snapshot.so (libc6,x86-64) => /lib64/libdevmapper-event-lvm2snapshot.so
+	libdevmapper-event-lvm2raid.so (libc6,x86-64) => /lib64/libdevmapper-event-lvm2raid.so
+	libdevmapper-event-lvm2mirror.so (libc6,x86-64) => /lib64/libdevmapper-event-lvm2mirror.so
+	libdevmapper-event-lvm2.so.2.02 (libc6,x86-64) => /lib64/libdevmapper-event-lvm2.so.2.02
+	libdcerpc.so.0 (libc6,x86-64) => /usr/lib64/libdcerpc.so.0
+	libdcerpc-samr.so.0 (libc6,x86-64) => /usr/lib64/libdcerpc-samr.so.0
+	libdcerpc-binding.so.0 (libc6,x86-64) => /usr/lib64/libdcerpc-binding.so.0
+	libdcerpc-atsvc.so.0 (libc6,x86-64) => /usr/lib64/libdcerpc-atsvc.so.0
+	libdbus-1.so.3 (libc6,x86-64) => /lib64/libdbus-1.so.3
+	libdbus-glib-1.so.2 (libc6,x86-64) => /usr/lib64/libdbus-glib-1.so.2
+	libdb_cxx-4.7.so (libc6,x86-64) => /usr/lib64/libdb_cxx-4.7.so
+	libdb-4.7.so (libc6,x86-64) => /lib64/libdb-4.7.so
+	libdb-4.7.so (libc6,x86-64) => /usr/lib64/libdb-4.7.so
+	libdat2.so.2 (libc6,x86-64) => /usr/lib64/libdat2.so.2
+	libdat2.so (libc6,x86-64) => /usr/lib64/libdat2.so
+	libdaploucm.so.2 (libc6,x86-64) => /usr/lib64/libdaploucm.so.2
+	libdaploucm.so (libc6,x86-64) => /usr/lib64/libdaploucm.so
+	libdaploscm.so.2 (libc6,x86-64) => /usr/lib64/libdaploscm.so.2
+	libdaploscm.so (libc6,x86-64) => /usr/lib64/libdaploscm.so
+	libdaplofa.so.2 (libc6,x86-64) => /usr/lib64/libdaplofa.so.2
+	libdaplofa.so (libc6,x86-64) => /usr/lib64/libdaplofa.so
+	libdaemon.so.0 (libc6,x86-64) => /usr/lib64/libdaemon.so.0
+	libcxgb4-rdmav2.so (libc6,x86-64) => /usr/lib64/libcxgb4-rdmav2.so
+	libcxgb3-rdmav2.so (libc6,x86-64) => /usr/lib64/libcxgb3-rdmav2.so
+	libcurl.so.4 (libc6,x86-64) => /usr/lib64/libcurl.so.4
+	libcurl.so (libc6,x86-64) => /usr/lib64/libcurl.so
+	libcupsppdc.so.1 (libc6,x86-64) => /usr/lib64/libcupsppdc.so.1
+	libcupsmime.so.1 (libc6,x86-64) => /usr/lib64/libcupsmime.so.1
+	libcupsimage.so.2 (libc6,x86-64) => /usr/lib64/libcupsimage.so.2
+	libcupsdriver.so.1 (libc6,x86-64) => /usr/lib64/libcupsdriver.so.1
+	libcupscgi.so.1 (libc6,x86-64) => /usr/lib64/libcupscgi.so.1
+	libcups.so.2 (libc6,x86-64) => /usr/lib64/libcups.so.2
+	libcuda.so.1 (libc6,x86-64) => /usr/lib64/libcuda.so.1
+	libcuda.so (libc6,x86-64) => /usr/lib64/libcuda.so
+	libcryptsetup.so.1 (libc6,x86-64) => /lib64/libcryptsetup.so.1
+	libcrypto.so.10 (libc6,x86-64) => /usr/lib64/libcrypto.so.10
+	libcrypto.so (libc6,x86-64) => /usr/lib64/libcrypto.so
+	libcrypt.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libcrypt.so.1
+	libcrypt.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libcrypt.so.1
+	libcrypt.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libcrypt.so
+	libcrypt.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libcrypt.so
+	libcroco-0.6.so.3 (libc6,x86-64) => /usr/lib64/libcroco-0.6.so.3
+	libcrack.so.2 (libc6,x86-64) => /usr/lib64/libcrack.so.2
+	libcpupower.so.0 (libc6,x86-64) => /usr/lib64/libcpupower.so.0
+	libcppunit-1.12.so.1 (libc6,x86-64) => /usr/lib64/libcppunit-1.12.so.1
+	libconfuse.so.0 (libc6,x86-64) => /usr/lib64/libconfuse.so.0
+	libconfuse.so (libc6,x86-64) => /usr/lib64/libconfuse.so
+	libcom_err.so.2 (libc6,x86-64) => /lib64/libcom_err.so.2
+	libcom_err.so (libc6,x86-64) => /usr/lib64/libcom_err.so
+	libcollection.so.4 (libc6,x86-64) => /usr/lib64/libcollection.so.4
+	libcmdparser-1.0.0.so (libc6,x86-64) => /usr/lib64/libcmdparser-1.0.0.so
+	libcloog.so.0 (libc6,x86-64) => /usr/lib64/libcloog.so.0
+	libck-connector.so.0 (libc6,x86-64) => /usr/lib64/libck-connector.so.0
+	libcidn.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libcidn.so.1
+	libcidn.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libcidn.so.1
+	libcidn.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libcidn.so
+	libcidn.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libcidn.so
+	libcgroup.so.1 (libc6,x86-64) => /lib64/libcgroup.so.1
+	libcgroup.so (libc6,x86-64) => /usr/lib64/libcgroup.so
+	libcgraph.so.4 (libc6,x86-64) => /usr/lib64/libcgraph.so.4
+	libcdt.so.4 (libc6,x86-64) => /usr/lib64/libcdt.so.4
+	libcdio_paranoia.so.0 (libc6,x86-64) => /usr/lib64/libcdio_paranoia.so.0
+	libcdio_cdda.so.0 (libc6,x86-64) => /usr/lib64/libcdio_cdda.so.0
+	libcdio.so.10 (libc6,x86-64) => /usr/lib64/libcdio.so.10
+	libcdio++.so.0 (libc6,x86-64) => /usr/lib64/libcdio++.so.0
+	libcdda_paranoia.so.0 (libc6,x86-64) => /usr/lib64/libcdda_paranoia.so.0
+	libcdda_paranoia.so (libc6,x86-64) => /usr/lib64/libcdda_paranoia.so
+	libcdda_interface.so.0 (libc6,x86-64) => /usr/lib64/libcdda_interface.so.0
+	libcdda_interface.so (libc6,x86-64) => /usr/lib64/libcdda_interface.so
+	libccmgr.so.1 (libc6,x86-64) => /usr/lib64/libccmgr.so.1
+	libccmgr.so (libc6,x86-64) => /usr/lib64/libccmgr.so
+	libcares.so.2 (libc6,x86-64) => /usr/lib64/libcares.so.2
+	libcap.so.2 (libc6,x86-64) => /lib64/libcap.so.2
+	libcap-ng.so.0 (libc6,x86-64) => /lib64/libcap-ng.so.0
+	libcairo.so.2 (libc6,x86-64) => /usr/lib64/libcairo.so.2
+	libcairo.so (libc6,x86-64) => /usr/lib64/libcairo.so
+	libc.so.6 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libc.so.6
+	libc.so.6 (libc6, hwcap: 0x0028000000000000, OS ABI: Linux 2.6.18) => /lib/i686/nosegneg/libc.so.6
+	libc.so.6 (libc6, OS ABI: Linux 2.6.18) => /lib/libc.so.6
+	libbz2.so.1 (libc6,x86-64) => /lib64/libbz2.so.1
+	libbz2.so (libc6,x86-64) => /usr/lib64/libbz2.so
+	libbtparser.so.2 (libc6,x86-64) => /usr/lib64/libbtparser.so.2
+	libboost_wserialization.so.5 (libc6,x86-64) => /usr/lib64/libboost_wserialization.so.5
+	libboost_wserialization.so (libc6,x86-64) => /usr/lib64/libboost_wserialization.so
+	libboost_wserialization-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_wserialization-mt.so.5
+	libboost_wserialization-mt.so (libc6,x86-64) => /usr/lib64/libboost_wserialization-mt.so
+	libboost_wave-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_wave-mt.so.5
+	libboost_wave-mt.so (libc6,x86-64) => /usr/lib64/libboost_wave-mt.so
+	libboost_unit_test_framework.so.5 (libc6,x86-64) => /usr/lib64/libboost_unit_test_framework.so.5
+	libboost_unit_test_framework.so (libc6,x86-64) => /usr/lib64/libboost_unit_test_framework.so
+	libboost_unit_test_framework-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_unit_test_framework-mt.so.5
+	libboost_unit_test_framework-mt.so (libc6,x86-64) => /usr/lib64/libboost_unit_test_framework-mt.so
+	libboost_thread-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_thread-mt.so.5
+	libboost_thread-mt.so (libc6,x86-64) => /usr/lib64/libboost_thread-mt.so
+	libboost_system.so.5 (libc6,x86-64) => /usr/lib64/libboost_system.so.5
+	libboost_system.so (libc6,x86-64) => /usr/lib64/libboost_system.so
+	libboost_system-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_system-mt.so.5
+	libboost_system-mt.so (libc6,x86-64) => /usr/lib64/libboost_system-mt.so
+	libboost_signals.so.5 (libc6,x86-64) => /usr/lib64/libboost_signals.so.5
+	libboost_signals.so (libc6,x86-64) => /usr/lib64/libboost_signals.so
+	libboost_signals-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_signals-mt.so.5
+	libboost_signals-mt.so (libc6,x86-64) => /usr/lib64/libboost_signals-mt.so
+	libboost_serialization.so.5 (libc6,x86-64) => /usr/lib64/libboost_serialization.so.5
+	libboost_serialization.so (libc6,x86-64) => /usr/lib64/libboost_serialization.so
+	libboost_serialization-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_serialization-mt.so.5
+	libboost_serialization-mt.so (libc6,x86-64) => /usr/lib64/libboost_serialization-mt.so
+	libboost_regex.so.5 (libc6,x86-64) => /usr/lib64/libboost_regex.so.5
+	libboost_regex.so (libc6,x86-64) => /usr/lib64/libboost_regex.so
+	libboost_regex-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_regex-mt.so.5
+	libboost_regex-mt.so (libc6,x86-64) => /usr/lib64/libboost_regex-mt.so
+	libboost_python.so.5 (libc6,x86-64) => /usr/lib64/libboost_python.so.5
+	libboost_python.so (libc6,x86-64) => /usr/lib64/libboost_python.so
+	libboost_python-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_python-mt.so.5
+	libboost_python-mt.so (libc6,x86-64) => /usr/lib64/libboost_python-mt.so
+	libboost_program_options.so.5 (libc6,x86-64) => /usr/lib64/libboost_program_options.so.5
+	libboost_program_options.so (libc6,x86-64) => /usr/lib64/libboost_program_options.so
+	libboost_program_options-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_program_options-mt.so.5
+	libboost_program_options-mt.so (libc6,x86-64) => /usr/lib64/libboost_program_options-mt.so
+	libboost_prg_exec_monitor.so.5 (libc6,x86-64) => /usr/lib64/libboost_prg_exec_monitor.so.5
+	libboost_prg_exec_monitor.so (libc6,x86-64) => /usr/lib64/libboost_prg_exec_monitor.so
+	libboost_prg_exec_monitor-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_prg_exec_monitor-mt.so.5
+	libboost_prg_exec_monitor-mt.so (libc6,x86-64) => /usr/lib64/libboost_prg_exec_monitor-mt.so
+	libboost_math_tr1l.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1l.so.5
+	libboost_math_tr1l.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1l.so
+	libboost_math_tr1l-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1l-mt.so.5
+	libboost_math_tr1l-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1l-mt.so
+	libboost_math_tr1f.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1f.so.5
+	libboost_math_tr1f.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1f.so
+	libboost_math_tr1f-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1f-mt.so.5
+	libboost_math_tr1f-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1f-mt.so
+	libboost_math_tr1.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1.so.5
+	libboost_math_tr1.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1.so
+	libboost_math_tr1-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_tr1-mt.so.5
+	libboost_math_tr1-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_tr1-mt.so
+	libboost_math_c99l.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99l.so.5
+	libboost_math_c99l.so (libc6,x86-64) => /usr/lib64/libboost_math_c99l.so
+	libboost_math_c99l-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99l-mt.so.5
+	libboost_math_c99l-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_c99l-mt.so
+	libboost_math_c99f.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99f.so.5
+	libboost_math_c99f.so (libc6,x86-64) => /usr/lib64/libboost_math_c99f.so
+	libboost_math_c99f-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99f-mt.so.5
+	libboost_math_c99f-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_c99f-mt.so
+	libboost_math_c99.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99.so.5
+	libboost_math_c99.so (libc6,x86-64) => /usr/lib64/libboost_math_c99.so
+	libboost_math_c99-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_math_c99-mt.so.5
+	libboost_math_c99-mt.so (libc6,x86-64) => /usr/lib64/libboost_math_c99-mt.so
+	libboost_iostreams.so.5 (libc6,x86-64) => /usr/lib64/libboost_iostreams.so.5
+	libboost_iostreams.so (libc6,x86-64) => /usr/lib64/libboost_iostreams.so
+	libboost_iostreams-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_iostreams-mt.so.5
+	libboost_iostreams-mt.so (libc6,x86-64) => /usr/lib64/libboost_iostreams-mt.so
+	libboost_graph.so.5 (libc6,x86-64) => /usr/lib64/libboost_graph.so.5
+	libboost_graph.so (libc6,x86-64) => /usr/lib64/libboost_graph.so
+	libboost_graph-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_graph-mt.so.5
+	libboost_graph-mt.so (libc6,x86-64) => /usr/lib64/libboost_graph-mt.so
+	libboost_filesystem.so.5 (libc6,x86-64) => /usr/lib64/libboost_filesystem.so.5
+	libboost_filesystem.so (libc6,x86-64) => /usr/lib64/libboost_filesystem.so
+	libboost_filesystem-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_filesystem-mt.so.5
+	libboost_filesystem-mt.so (libc6,x86-64) => /usr/lib64/libboost_filesystem-mt.so
+	libboost_date_time.so.5 (libc6,x86-64) => /usr/lib64/libboost_date_time.so.5
+	libboost_date_time.so (libc6,x86-64) => /usr/lib64/libboost_date_time.so
+	libboost_date_time-mt.so.5 (libc6,x86-64) => /usr/lib64/libboost_date_time-mt.so.5
+	libboost_date_time-mt.so (libc6,x86-64) => /usr/lib64/libboost_date_time-mt.so
+	libbonoboui-2.so.0 (libc6,x86-64) => /usr/lib64/libbonoboui-2.so.0
+	libbonobo-2.so.0 (libc6,x86-64) => /usr/lib64/libbonobo-2.so.0
+	libbonobo-activation.so.4 (libc6,x86-64) => /usr/lib64/libbonobo-activation.so.4
+	libblkid.so.1 (libc6,x86-64) => /lib64/libblkid.so.1
+	libbiosconfig_expat.so.0 (libc6,x86-64) => /usr/lib64/libbiosconfig_expat.so.0
+	libbiosconfig_expat.so (libc6,x86-64) => /usr/lib64/libbiosconfig_expat.so
+	libbind9.so.80 (libc6,x86-64) => /usr/lib64/libbind9.so.80
+	libbfd-2.20.51.0.2-5.44.el6.so (libc6,x86-64) => /usr/lib64/libbfd-2.20.51.0.2-5.44.el6.so
+	libbasicobjects.so.0 (libc6,x86-64) => /usr/lib64/libbasicobjects.so.0
+	liba2ps.so.1 (libc6,x86-64) => /usr/lib64/liba2ps.so.1
+	libavahi-glib.so.1 (libc6,x86-64) => /usr/lib64/libavahi-glib.so.1
+	libavahi-core.so.6 (libc6,x86-64) => /usr/lib64/libavahi-core.so.6
+	libavahi-common.so.3 (libc6,x86-64) => /usr/lib64/libavahi-common.so.3
+	libavahi-client.so.3 (libc6,x86-64) => /usr/lib64/libavahi-client.so.3
+	libauparse.so.0 (libc6,x86-64) => /lib64/libauparse.so.0
+	libaudit.so.1 (libc6,x86-64) => /lib64/libaudit.so.1
+	libattr.so.1 (libc6,x86-64) => /lib64/libattr.so.1
+	libattr.so (libc6,x86-64) => /lib64/libattr.so
+	libattr.so (libc6,x86-64) => /usr/lib64/libattr.so
+	libatk-1.0.so.0 (libc6,x86-64) => /usr/lib64/libatk-1.0.so.0
+	libatk-1.0.so (libc6,x86-64) => /usr/lib64/libatk-1.0.so
+	libatasmart.so.4 (libc6,x86-64) => /usr/lib64/libatasmart.so.4
+	libasound.so.2 (libc6,x86-64) => /lib64/libasound.so.2
+	libasm.so.1 (libc6,x86-64) => /usr/lib64/libasm.so.1
+	libart_lgpl_2.so.2 (libc6,x86-64) => /usr/lib64/libart_lgpl_2.so.2
+	libart_lgpl_2.so (libc6,x86-64) => /usr/lib64/libart_lgpl_2.so
+	libarmgr.so.1 (libc6,x86-64) => /usr/lib64/libarmgr.so.1
+	libarmgr.so (libc6,x86-64) => /usr/lib64/libarmgr.so
+	libaprutil-1.so.0 (libc6,x86-64) => /usr/lib64/libaprutil-1.so.0
+	libaprutil-1.so (libc6,x86-64) => /usr/lib64/libaprutil-1.so
+	libapr-1.so.0 (libc6,x86-64) => /usr/lib64/libapr-1.so.0
+	libapr-1.so (libc6,x86-64) => /usr/lib64/libapr-1.so
+	libanl.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libanl.so.1
+	libanl.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libanl.so.1
+	libanl.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libanl.so
+	libanl.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libanl.so
+	libaio.so.1.0.0 (libc6,x86-64) => /lib64/libaio.so.1.0.0
+	libaio.so.1 (libc6,x86-64) => /lib64/libaio.so.1
+	libaio.so (libc6,x86-64) => /usr/lib64/libaio.so
+	libacl.so.1 (libc6,x86-64) => /lib64/libacl.so.1
+	libacl.so (libc6,x86-64) => /lib64/libacl.so
+	libacl.so (libc6,x86-64) => /usr/lib64/libacl.so
+	libX11.so.6 (libc6,x86-64) => /usr/lib64/libX11.so.6
+	libX11.so.6 (libc6) => /usr/lib/libX11.so.6
+	libX11.so (libc6,x86-64) => /usr/lib64/libX11.so
+	libX11-xcb.so.1 (libc6,x86-64) => /usr/lib64/libX11-xcb.so.1
+	libX11-xcb.so.1 (libc6) => /usr/lib/libX11-xcb.so.1
+	libX11-xcb.so (libc6,x86-64) => /usr/lib64/libX11-xcb.so
+	libXxf86vm.so.1 (libc6,x86-64) => /usr/lib64/libXxf86vm.so.1
+	libXxf86vm.so.1 (libc6) => /usr/lib/libXxf86vm.so.1
+	libXxf86vm.so (libc6,x86-64) => /usr/lib64/libXxf86vm.so
+	libXxf86misc.so.1 (libc6,x86-64) => /usr/lib64/libXxf86misc.so.1
+	libXxf86dga.so.1 (libc6,x86-64) => /usr/lib64/libXxf86dga.so.1
+	libXv.so.1 (libc6,x86-64) => /usr/lib64/libXv.so.1
+	libXv.so (libc6,x86-64) => /usr/lib64/libXv.so
+	libXtst.so.6 (libc6,x86-64) => /usr/lib64/libXtst.so.6
+	libXtst.so.6 (libc6) => /usr/lib/libXtst.so.6
+	libXtst.so (libc6,x86-64) => /usr/lib64/libXtst.so
+	libXt.so.6 (libc6,x86-64) => /usr/lib64/libXt.so.6
+	libXt.so.6 (libc6) => /usr/lib/libXt.so.6
+	libXt.so (libc6,x86-64) => /usr/lib64/libXt.so
+	libXt.so (libc6) => /usr/lib/libXt.so
+	libXss.so.1 (libc6,x86-64) => /usr/lib64/libXss.so.1
+	libXrender.so.1 (libc6,x86-64) => /usr/lib64/libXrender.so.1
+	libXrender.so.1 (libc6) => /usr/lib/libXrender.so.1
+	libXrender.so (libc6,x86-64) => /usr/lib64/libXrender.so
+	libXrandr.so.2 (libc6,x86-64) => /usr/lib64/libXrandr.so.2
+	libXrandr.so (libc6,x86-64) => /usr/lib64/libXrandr.so
+	libXpm.so.4 (libc6,x86-64) => /usr/lib64/libXpm.so.4
+	libXpm.so.4 (libc6) => /usr/lib/libXpm.so.4
+	libXpm.so (libc6,x86-64) => /usr/lib64/libXpm.so
+	libXp.so.6 (libc6,x86-64) => /usr/lib64/libXp.so.6
+	libXp.so.6 (libc6) => /usr/lib/libXp.so.6
+	libXp.so (libc6,x86-64) => /usr/lib64/libXp.so
+	libXmuu.so.1 (libc6,x86-64) => /usr/lib64/libXmuu.so.1
+	libXmuu.so.1 (libc6) => /usr/lib/libXmuu.so.1
+	libXmuu.so (libc6,x86-64) => /usr/lib64/libXmuu.so
+	libXmu.so.6 (libc6,x86-64) => /usr/lib64/libXmu.so.6
+	libXmu.so.6 (libc6) => /usr/lib/libXmu.so.6
+	libXmu.so (libc6,x86-64) => /usr/lib64/libXmu.so
+	libXm.so.4 (libc6,x86-64) => /usr/lib64/libXm.so.4
+	libXm.so.4 (libc6) => /usr/lib/libXm.so.4
+	libXm.so.3 (libc6,x86-64) => /usr/lib64/libXm.so.3
+	libXm.so (libc6,x86-64) => /usr/lib64/libXm.so
+	libXm.so (libc6) => /usr/lib/libXm.so
+	libXinerama.so.1 (libc6,x86-64) => /usr/lib64/libXinerama.so.1
+	libXinerama.so (libc6,x86-64) => /usr/lib64/libXinerama.so
+	libXi.so.6 (libc6,x86-64) => /usr/lib64/libXi.so.6
+	libXi.so.6 (libc6) => /usr/lib/libXi.so.6
+	libXi.so (libc6,x86-64) => /usr/lib64/libXi.so
+	libXft.so.2 (libc6,x86-64) => /usr/lib64/libXft.so.2
+	libXft.so.2 (libc6) => /usr/lib/libXft.so.2
+	libXft.so (libc6,x86-64) => /usr/lib64/libXft.so
+	libXfont.so.1 (libc6,x86-64) => /usr/lib64/libXfont.so.1
+	libXfixes.so.3 (libc6,x86-64) => /usr/lib64/libXfixes.so.3
+	libXfixes.so.3 (libc6) => /usr/lib/libXfixes.so.3
+	libXfixes.so (libc6,x86-64) => /usr/lib64/libXfixes.so
+	libXext.so.6 (libc6,x86-64) => /usr/lib64/libXext.so.6
+	libXext.so.6 (libc6) => /usr/lib/libXext.so.6
+	libXext.so (libc6,x86-64) => /usr/lib64/libXext.so
+	libXdmcp.so.6 (libc6,x86-64) => /usr/lib64/libXdmcp.so.6
+	libXdmcp.so (libc6,x86-64) => /usr/lib64/libXdmcp.so
+	libXdamage.so.1 (libc6,x86-64) => /usr/lib64/libXdamage.so.1
+	libXdamage.so.1 (libc6) => /usr/lib/libXdamage.so.1
+	libXdamage.so (libc6,x86-64) => /usr/lib64/libXdamage.so
+	libXcursor.so.1 (libc6,x86-64) => /usr/lib64/libXcursor.so.1
+	libXcursor.so (libc6,x86-64) => /usr/lib64/libXcursor.so
+	libXcomposite.so.1 (libc6,x86-64) => /usr/lib64/libXcomposite.so.1
+	libXcomposite.so (libc6,x86-64) => /usr/lib64/libXcomposite.so
+	libXaw3d.so.7 (libc6,x86-64) => /usr/lib64/libXaw3d.so.7
+	libXaw.so.7 (libc6,x86-64) => /usr/lib64/libXaw.so.7
+	libXaw.so (libc6,x86-64) => /usr/lib64/libXaw.so
+	libXau.so.6 (libc6,x86-64) => /usr/lib64/libXau.so.6
+	libXau.so.6 (libc6) => /usr/lib/libXau.so.6
+	libXau.so (libc6,x86-64) => /usr/lib64/libXau.so
+	libUil.so.4 (libc6,x86-64) => /usr/lib64/libUil.so.4
+	libUil.so.4 (libc6) => /usr/lib/libUil.so.4
+	libUil.so.3 (libc6,x86-64) => /usr/lib64/libUil.so.3
+	libUil.so (libc6,x86-64) => /usr/lib64/libUil.so
+	libUil.so (libc6) => /usr/lib/libUil.so
+	libTix.so (libc6,x86-64) => /usr/lib64/tcl8.5/libTix.so
+	libSegFault.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libSegFault.so
+	libSegFault.so (libc6, OS ABI: Linux 2.6.18) => /lib/libSegFault.so
+	libSM.so.6 (libc6,x86-64) => /usr/lib64/libSM.so.6
+	libSM.so.6 (libc6) => /usr/lib/libSM.so.6
+	libSM.so (libc6,x86-64) => /usr/lib64/libSM.so
+	libSDL-1.2.so.0 (libc6,x86-64) => /usr/lib64/libSDL-1.2.so.0
+	libQt3Support.so.4 (libc6,x86-64) => /usr/lib64/libQt3Support.so.4
+	libQt3Support.so (libc6,x86-64) => /usr/lib64/libQt3Support.so
+	libQtXmlPatterns.so.4 (libc6,x86-64) => /usr/lib64/libQtXmlPatterns.so.4
+	libQtXmlPatterns.so (libc6,x86-64) => /usr/lib64/libQtXmlPatterns.so
+	libQtXml.so.4 (libc6,x86-64) => /usr/lib64/libQtXml.so.4
+	libQtXml.so (libc6,x86-64) => /usr/lib64/libQtXml.so
+	libQtTest.so.4 (libc6,x86-64) => /usr/lib64/libQtTest.so.4
+	libQtTest.so (libc6,x86-64) => /usr/lib64/libQtTest.so
+	libQtSvg.so.4 (libc6,x86-64) => /usr/lib64/libQtSvg.so.4
+	libQtSvg.so (libc6,x86-64) => /usr/lib64/libQtSvg.so
+	libQtSql.so.4 (libc6,x86-64) => /usr/lib64/libQtSql.so.4
+	libQtSql.so (libc6,x86-64) => /usr/lib64/libQtSql.so
+	libQtScriptTools.so.4 (libc6,x86-64) => /usr/lib64/libQtScriptTools.so.4
+	libQtScriptTools.so (libc6,x86-64) => /usr/lib64/libQtScriptTools.so
+	libQtScript.so.4 (libc6,x86-64) => /usr/lib64/libQtScript.so.4
+	libQtScript.so (libc6,x86-64) => /usr/lib64/libQtScript.so
+	libQtOpenGL.so.4 (libc6,x86-64) => /usr/lib64/libQtOpenGL.so.4
+	libQtOpenGL.so (libc6,x86-64) => /usr/lib64/libQtOpenGL.so
+	libQtNetwork.so.4 (libc6,x86-64) => /usr/lib64/libQtNetwork.so.4
+	libQtNetwork.so (libc6,x86-64) => /usr/lib64/libQtNetwork.so
+	libQtMultimedia.so.4 (libc6,x86-64) => /usr/lib64/libQtMultimedia.so.4
+	libQtMultimedia.so (libc6,x86-64) => /usr/lib64/libQtMultimedia.so
+	libQtHelp.so.4 (libc6,x86-64) => /usr/lib64/libQtHelp.so.4
+	libQtHelp.so (libc6,x86-64) => /usr/lib64/libQtHelp.so
+	libQtGui.so.4 (libc6,x86-64) => /usr/lib64/libQtGui.so.4
+	libQtGui.so (libc6,x86-64) => /usr/lib64/libQtGui.so
+	libQtDesignerComponents.so.4 (libc6,x86-64) => /usr/lib64/libQtDesignerComponents.so.4
+	libQtDesignerComponents.so (libc6,x86-64) => /usr/lib64/libQtDesignerComponents.so
+	libQtDesigner.so.4 (libc6,x86-64) => /usr/lib64/libQtDesigner.so.4
+	libQtDesigner.so (libc6,x86-64) => /usr/lib64/libQtDesigner.so
+	libQtDBus.so.4 (libc6,x86-64) => /usr/lib64/libQtDBus.so.4
+	libQtDBus.so (libc6,x86-64) => /usr/lib64/libQtDBus.so
+	libQtCore.so.4 (libc6,x86-64) => /usr/lib64/libQtCore.so.4
+	libQtCore.so (libc6,x86-64) => /usr/lib64/libQtCore.so
+	libQtCLucene.so.4 (libc6,x86-64) => /usr/lib64/libQtCLucene.so.4
+	libQtCLucene.so (libc6,x86-64) => /usr/lib64/libQtCLucene.so
+	libQtAssistantClient.so.4 (libc6,x86-64) => /usr/lib64/libQtAssistantClient.so.4
+	libQtAssistantClient.so (libc6,x86-64) => /usr/lib64/libQtAssistantClient.so
+	libOpenIPMIutils.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMIutils.so.0
+	libOpenIPMIui.so.1 (libc6,x86-64) => /usr/lib64/libOpenIPMIui.so.1
+	libOpenIPMIpthread.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMIpthread.so.0
+	libOpenIPMIposix.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMIposix.so.0
+	libOpenIPMIglib.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMIglib.so.0
+	libOpenIPMIcmdlang.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMIcmdlang.so.0
+	libOpenIPMI.so.0 (libc6,x86-64) => /usr/lib64/libOpenIPMI.so.0
+	libOpenCL.so.1 (libc6,x86-64) => /usr/lib64/libOpenCL.so.1
+	libOpenCL.so (libc6,x86-64) => /usr/lib64/libOpenCL.so
+	libOSMesa32.so.6 (libc6,x86-64) => /usr/lib64/libOSMesa32.so.6
+	libOSMesa32.so (libc6,x86-64) => /usr/lib64/libOSMesa32.so
+	libOSMesa16.so.6 (libc6,x86-64) => /usr/lib64/libOSMesa16.so.6
+	libOSMesa16.so (libc6,x86-64) => /usr/lib64/libOSMesa16.so
+	libOSMesa.so.6 (libc6,x86-64) => /usr/lib64/libOSMesa.so.6
+	libOSMesa.so (libc6,x86-64) => /usr/lib64/libOSMesa.so
+	libORBitCosNaming-2.so.0 (libc6,x86-64) => /usr/lib64/libORBitCosNaming-2.so.0
+	libORBit-2.so.0 (libc6,x86-64) => /usr/lib64/libORBit-2.so.0
+	libORBit-imodule-2.so.0 (libc6,x86-64) => /usr/lib64/libORBit-imodule-2.so.0
+	libMrm.so.4 (libc6,x86-64) => /usr/lib64/libMrm.so.4
+	libMrm.so.4 (libc6) => /usr/lib/libMrm.so.4
+	libMrm.so.3 (libc6,x86-64) => /usr/lib64/libMrm.so.3
+	libMrm.so (libc6,x86-64) => /usr/lib64/libMrm.so
+	libMrm.so (libc6) => /usr/lib/libMrm.so
+	libMagickWand.so.5 (libc6,x86-64) => /usr/lib64/libMagickWand.so.5
+	libMagickWand.so (libc6,x86-64) => /usr/lib64/libMagickWand.so
+	libMagickCore.so.5 (libc6,x86-64) => /usr/lib64/libMagickCore.so.5
+	libMagickCore.so (libc6,x86-64) => /usr/lib64/libMagickCore.so
+	libMagick++.so.5 (libc6,x86-64) => /usr/lib64/libMagick++.so.5
+	libMagick++.so (libc6,x86-64) => /usr/lib64/libMagick++.so
+	libLLVM-3.6-mesa.so (libc6,x86-64) => /usr/lib64/libLLVM-3.6-mesa.so
+	libLLVM-3.6-mesa.so (libc6) => /usr/lib/libLLVM-3.6-mesa.so
+	libImlib2.so.1 (libc6,x86-64) => /usr/lib64/libImlib2.so.1
+	libImath.so.6 (libc6,x86-64) => /usr/lib64/libImath.so.6
+	libIlmThread.so.6 (libc6,x86-64) => /usr/lib64/libIlmThread.so.6
+	libIlmImf.so.6 (libc6,x86-64) => /usr/lib64/libIlmImf.so.6
+	libIex.so.6 (libc6,x86-64) => /usr/lib64/libIex.so.6
+	libIPMIlanserv.so.0 (libc6,x86-64) => /usr/lib64/libIPMIlanserv.so.0
+	libIDL-2.so.0 (libc6,x86-64) => /usr/lib64/libIDL-2.so.0
+	libIDL-2.so (libc6,x86-64) => /usr/lib64/libIDL-2.so
+	libICE.so.6 (libc6,x86-64) => /usr/lib64/libICE.so.6
+	libICE.so.6 (libc6) => /usr/lib/libICE.so.6
+	libICE.so (libc6,x86-64) => /usr/lib64/libICE.so
+	libHalf.so.6 (libc6,x86-64) => /usr/lib64/libHalf.so.6
+	libGLU.so.1 (libc6,x86-64) => /usr/lib64/libGLU.so.1
+	libGLU.so.1 (libc6) => /usr/lib/libGLU.so.1
+	libGLU.so (libc6,x86-64) => /usr/lib64/libGLU.so
+	libGLESv2.so.2 (libc6,x86-64) => /usr/lib64/libGLESv2.so.2
+	libGLESv2.so (libc6,x86-64) => /usr/lib64/libGLESv2.so
+	libGLESv1_CM.so.1 (libc6,x86-64) => /usr/lib64/libGLESv1_CM.so.1
+	libGLESv1_CM.so (libc6,x86-64) => /usr/lib64/libGLESv1_CM.so
+	libGL.so.1 (libc6,x86-64) => /usr/lib64/libGL.so.1
+	libGL.so (libc6,x86-64) => /usr/lib64/libGL.so
+	libEGL.so.1 (libc6,x86-64) => /usr/lib64/libEGL.so.1
+	libEGL.so (libc6,x86-64) => /usr/lib64/libEGL.so
+	libBrokenLocale.so.1 (libc6,x86-64, OS ABI: Linux 2.6.18) => /lib64/libBrokenLocale.so.1
+	libBrokenLocale.so.1 (libc6, OS ABI: Linux 2.6.18) => /lib/libBrokenLocale.so.1
+	libBrokenLocale.so (libc6,x86-64, OS ABI: Linux 2.6.18) => /usr/lib64/libBrokenLocale.so
+	libBrokenLocale.so (libc6, OS ABI: Linux 2.6.18) => /usr/lib/libBrokenLocale.so
+	ld-linux.so.2 (ELF) => /lib/ld-linux.so.2
+	ld-linux-x86-64.so.2 (libc6,x86-64) => /lib64/ld-linux-x86-64.so.2
+
+---------------
+df
+---------------
+Filesystem               1K-blocks          Used     Available Use% Mounted on
+10.9.103.1@o2ib3:10.9.103.2@o2ib3:/imapps
+                      135286266880    1277023408  132653637056   1% /plush/dugong
+10.9.103.1@o2ib3:10.9.103.2@o2ib3:/imapps
+                      135286266880    1277023408  132653637056   1% /opt
+/dev/ram                     10240          2052          8188  21% /ram
+none                      16487376           180      16487196   1% /dev
+none                      16493568            12      16493556   1% /dev/shm
+none                        102400             8        102392   1% /tmp
+/dev/sda3                460903324       1134304     436349792   1% /jobfs/local
+10.9.103.3@o2ib3:10.9.103.4@o2ib3:/homsys
+                      228379092480   26897999172  199192454036  12% /home
+10.9.103.3@o2ib3:10.9.103.4@o2ib3:/homsys
+                      228379092480   26897999172  199192454036  12% /system
+10.9.103.1@o2ib3:10.9.103.2@o2ib3:/imapps
+                      135286266880    1277023408  132653637056   1% /apps
+10.9.103.5@o2ib3:10.9.103.6@o2ib3:/short
+                     8256412275200 4337697602172 3514848915992  56% /projects
+10.9.103.5@o2ib3:10.9.103.6@o2ib3:/short
+                     8256412275200 4337697602172 3514848915992  56% /short
+10.12.0.11@o2ib4:10.12.0.12@o2ib4:/gdata1
+                     8119865446200 6494760832008 1218795458008  85% /g/data1
+10.13.0.13@o2ib5:10.13.0.14@o2ib5:/gdata2
+                     7356150051840 6294789502408  693430374092  91% /g/data2
+10.13.1.10@o2ib6:10.13.1.11@o2ib6:/gdata3
+                     7862421329280 6185376961344 1283774154472  83% /g/data3
+none                      16493568            12      16493556   1% /dev/shm
+none                        102400             8        102392   1% /tmp
+
+--------------------------------------------------
+-----------------SYSTEM SPECS END-----------------
+--------------------------------------------------
+2016-10-13T20:42:07 main.cpp 114: INFO: Own PID is '26820'
+---ORDER_FILE BEGIN---
+version = 2
+id = LS8-20160926
+Input:
+	satNum = 'Landsat8'
+	sensor = 'OLI_TIRS'
+	productType = 'MD'
+	linkInput = 'TRUE'
+	cleanBefore = 'TRUE'
+	cleanAfter = 'TRUE'
+	inputPath = /g/data/v10/repackaged/rawdata/0/2016/09/LS8_OLI-TIRS_STD-MDF_P00_LC81140740812016270LGN00_114_074-081_20160926T021444Z20160926T031053_1/product
+	workingFolder = /jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm
+	standardScene:
+	period:
+	floatingScene:
+
+
+Process Control:
+	Use max processing time = 'TRUE'
+		Max Processing Time:
+			Hours: 4
+			Minutes: 0
+			Seconds: 0
+
+Downloader Outputs:
+
+L0Ra Processing:
+	CPF:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>DIRECTORY: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile'
+	Output Path:
+		 = 'Extended mentadata = (FALSE) = '
+	Parameters:
+		May fallback on sensor: TRUE
+
+	Mrc:
+		Generate Mrc = FALSE
+		Orbit Number = -1
+
+
+L0Rp Processing:
+	Max Concurrent Scenes = 15
+	CPF:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>DIRECTORY: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile'
+	Output Path:
+		 = 'Extended mentadata = (FALSE) = '
+
+L1 Processing:
+	Max Concurrent Scenes = 15
+	Output Path:
+		 = 'Extended mentadata = (FALSE) = /jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/scenes'
+	EPH:
+	RLUT:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>DIRECTORY: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT'
+	BPF OLI:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>DIRECTORY: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09'
+	BPF TIRS:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>DIRECTORY: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09'
+	Estimated TIRS SSM position:
+		0 = 'May point to folder => TRUE: Use downloader => FALSE: Type =>FILE: /g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt'
+	L1T Processing:
+		DEM:
+			Path: '/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li'
+			Format: 'srtm90'
+		GCP:
+			Path: '/g/data/v10/eoancillarydata/GCP/Phase2_GCP'
+			Format: 'chips_30'
+		Parameters:
+			Minimum Required Gcps: '10'
+
+	Parameters:
+		LatitudeOfFirstStdParallel
+			L1G = 0.000000000000000
+			L1GT = 0.000000000000000
+			L1T = 0.000000000000000
+		LongitudeOfCentralMeridian
+			L1G = 0.000000000000000
+			L1GT = 0.000000000000000
+			L1T = 0.000000000000000
+		FalseEastingNorthingUnits
+			L1G = METERS
+			L1GT = METERS
+			L1T = METERS
+		FalseEasting
+			L1G = 0.000000000000000
+			L1GT = 0.000000000000000
+			L1T = 0.000000000000000
+		FalseNorthing
+			L1G = 0.000000000000000
+			L1GT = 0.000000000000000
+			L1T = 0.000000000000000
+		MaxScanGap
+			L1G = 2
+			L1GT = 2
+			L1T = 2
+		Resampler
+			L1G = CC
+			L1GT = CC
+			L1T = CC
+		Fallback Resampler
+			L1G = CC
+			L1GT = CC
+			L1T = CC
+		Hemisphere
+			L1G = S
+			L1GT = S
+			L1T = S
+		ScenePadding
+			L1G = 1.000000000000000
+			L1GT = 1.000000000000000
+			L1T = 1.000000000000000
+		PixelOrigin
+			L1G = UL
+			L1GT = UL
+			L1T = UL
+		Fallbacks
+			L1G = FALSE
+			L1GT = TRUE
+			L1R = FALSE
+		Orientation
+			L1G = NUP
+			L1GT = NUP
+			L1T = NUP
+		PixelSizesPan
+			L1G = 12.50000
+			L1GT = 12.50000
+			L1T = 12.50000
+		PixelSizesRef
+			L1G = 25.00000
+			L1GT = 25.00000
+			L1T = 25.00000
+		PixelSizesThm
+			L1G = 25.00000
+			L1GT = 25.00000
+			L1T = 25.00000
+		Datum
+			L1G = GDA_94
+			L1GT = GDA_94
+			L1T = GDA_94
+		Spheroid
+			L1G = GRS_80
+			L1GT = GRS_80
+			L1T = GRS_80
+		Projection
+			L1G = UTM
+			L1GT = UTM
+			L1T = UTM
+		Product Type = 'L1T'
+		Output format = 'GEOTIFF'
+
+
+---ORDER_FILE END---
+2016-10-13T20:42:07 Processor.cpp 149: INFO: Time out schedule to trigger at '2016-10-14 00:42:07'
+2016-10-13T20:42:07 Processor.cpp 112: INFO: Cleaning path '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm'
+2016-10-13T20:42:07 GenerateProcessChainLandsat.cpp 732: INFO: Creating log folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs'
+2016-10-13T20:42:07 GenerateProcessChainLandsat.cpp 191: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/MD'
+2016-10-13T20:42:07 GenerateProcessChainLandsat.cpp 66: INFO: Will link '/g/data/v10/repackaged/rawdata/0/2016/09/LS8_OLI-TIRS_STD-MDF_P00_LC81140740812016270LGN00_114_074-081_20160926T021444Z20160926T031053_1/product' to '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/MD'
+2016-10-13T20:42:07 GenerateProcessChainMdRcc2L0Ra.cpp 94: INFO: Creating L0Ra folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA'
+2016-10-13T20:42:07 AncDatabasePopulator.cpp 243: INFO: Locating all 'EPH' ancillary files
+2016-10-13T20:42:07 AncDatabasePopulator.cpp 243: INFO: Locating all 'CPF' ancillary files
+2016-10-13T20:42:38 AncDatabasePopulator.cpp 243: INFO: Locating all 'BPF' ancillary files
+2016-10-13T20:44:44 ProductMetadata.cpp 151: WARN: Path '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160914102104_20160914111455.01' is not a Landsat product
+2016-10-13T20:45:34 AncDatabasePopulator.cpp 243: INFO: Locating all 'RLUT' ancillary files
+2016-10-13T20:45:38 ul_Hdf5Reader.cpp 534: ERROR: Failed to open HDF 5 file '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20130211_20241231v03.h5'
+2016-10-13T20:45:38 ul_Hdf5Reader.cpp 563: ERROR: Failure returned from StartUpCall()
+2016-10-13T20:45:38 ProductMetadataSensor.cpp 555: ERROR: Failure returned from CHdf5Reader::Parse()
+2016-10-13T20:45:38 ProductMetadataSensor.cpp 610: ERROR: Failed to read all ancillary metadata
+2016-10-13T20:45:38 ProductMetadata.cpp 140: ERROR: Failed to populate all ancillary metadata
+2016-10-13T20:45:38 ul_Hdf5Reader.cpp 534: ERROR: Failed to open HDF 5 file '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20130211_20241231v04.h5'
+2016-10-13T20:45:38 ul_Hdf5Reader.cpp 563: ERROR: Failure returned from StartUpCall()
+2016-10-13T20:45:38 ProductMetadataSensor.cpp 555: ERROR: Failure returned from CHdf5Reader::Parse()
+2016-10-13T20:45:38 ProductMetadataSensor.cpp 610: ERROR: Failed to read all ancillary metadata
+2016-10-13T20:45:38 ProductMetadata.cpp 140: ERROR: Failed to populate all ancillary metadata
+2016-10-13T20:45:38 ul_Hdf5Reader.cpp 534: ERROR: Failed to open HDF 5 file '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20130211_20241231v01.h5'
+2016-10-13T20:45:38 ul_Hdf5Reader.cpp 563: ERROR: Failure returned from StartUpCall()
+2016-10-13T20:45:38 ProductMetadataSensor.cpp 555: ERROR: Failure returned from CHdf5Reader::Parse()
+2016-10-13T20:45:38 ProductMetadataSensor.cpp 610: ERROR: Failed to read all ancillary metadata
+2016-10-13T20:45:38 ProductMetadata.cpp 140: ERROR: Failed to populate all ancillary metadata
+2016-10-13T20:45:38 ul_Hdf5Reader.cpp 534: ERROR: Failed to open HDF 5 file '/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20130211_20241231v02.h5'
+2016-10-13T20:45:38 ul_Hdf5Reader.cpp 563: ERROR: Failure returned from StartUpCall()
+2016-10-13T20:45:38 ProductMetadataSensor.cpp 555: ERROR: Failure returned from CHdf5Reader::Parse()
+2016-10-13T20:45:38 ProductMetadataSensor.cpp 610: ERROR: Failed to read all ancillary metadata
+2016-10-13T20:45:38 ProductMetadata.cpp 140: ERROR: Failed to populate all ancillary metadata
+2016-10-13T20:45:38 AncDatabasePopulator.cpp 243: INFO: Locating all 'SSM' ancillary files
+2016-10-13T20:45:41 ProcessingStep.cpp 413: INFO: Starting processing step 'INGEST: MD -> L0Ra'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_INGEST_PROCESS_0 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA_WO" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/MD" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "OLI_TIRS" "TRUE" "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs" 2>&1'
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_INGEST_PROCESS_0 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA_WO" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/MD" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "OLI_TIRS" "TRUE" "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs" 2>&1' output =
+--------------------------------------------------
+-------------DPAS INGEST PROCESS------------------
+--------------------------------------------------
+Processing (ADC) ..... DONE
+Processing (LG) ..... DONE
+Processing (SFC) ..... DONE
+Processing (MG) ..... DONE
+
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_073_073')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_075_075')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_076_076')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_077_077')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_074_074')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_078_078')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_079_079')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_080_080')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_081_081')'
+2016-10-13T20:52:13 ProcessingStep.cpp 388: INFO: Starting processing step 'OLI_TIRS_SUBSETTER: L0Ra -> L0Rp ('114_082_082')'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 41: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_075_075'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_077_077'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_074_074'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_079_079'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_081_081'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_073_073'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_076_076'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_078_078'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_080_080'
+2016-10-13T20:52:13 PreProcessingStepL0Ra2L0Rp.cpp 53: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_082_082'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_1 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_075_075" "" "114" "75" "75" "2016:270:02:15:00.0510005" "2016:270:02:15:31.8210005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_075_075" "LC81140740812016270LGN00" "LC81140752016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_2 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_077_077" "" "114" "77" "77" "2016:270:02:15:47.9310005" "2016:270:02:16:19.7010005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_077_077" "LC81140740812016270LGN00" "LC81140772016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_3 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_074_074" "" "114" "74" "74" "2016:270:02:14:36.1130005" "2016:270:02:15:07.8830005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_074_074" "LC81140740812016270LGN00" "LC81140742016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_4 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_079_079" "" "114" "79" "79" "2016:270:02:16:35.8270005" "2016:270:02:17:07.5970005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_079_079" "LC81140740812016270LGN00" "LC81140792016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_5 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_081_081" "" "114" "81" "81" "2016:270:02:17:23.7190005" "2016:270:02:17:55.4890005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_081_081" "LC81140740812016270LGN00" "LC81140812016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_6 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_073_073" "" "114" "73" "73" "2016:270:02:14:34.5290005" "2016:270:02:14:42.1920005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_073_073" "LC81140740812016270LGN00" "LC81140732016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_7 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_076_076" "" "114" "76" "76" "2016:270:02:15:23.9930005" "2016:270:02:15:55.7630005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_076_076" "LC81140740812016270LGN00" "LC81140762016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_8 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_078_078" "" "114" "78" "78" "2016:270:02:16:11.8770005" "2016:270:02:16:43.6470005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_078_078" "LC81140740812016270LGN00" "LC81140782016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_9 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_080_080" "" "114" "80" "80" "2016:270:02:16:59.7730005" "2016:270:02:17:31.5430005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_080_080" "LC81140740812016270LGN00" "LC81140802016270LGN00" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_10 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_082_082" "" "114" "82" "82" "2016:270:02:17:49.4230005" "2016:270:02:17:57.0180005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_082_082" "LC81140740812016270LGN00" "LC81140822016270LGN00" 2>&1'
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_6 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_073_073" "" "114" "73" "73" "2016:270:02:14:34.5290005" "2016:270:02:14:42.1920005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_073_073" "LC81140740812016270LGN00" "LC81140732016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_10 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_082_082" "" "114" "82" "82" "2016:270:02:17:49.4230005" "2016:270:02:17:57.0180005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_082_082" "LC81140740812016270LGN00" "LC81140822016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_2 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_077_077" "" "114" "77" "77" "2016:270:02:15:47.9310005" "2016:270:02:16:19.7010005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_077_077" "LC81140740812016270LGN00" "LC81140772016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_7 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_076_076" "" "114" "76" "76" "2016:270:02:15:23.9930005" "2016:270:02:15:55.7630005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_076_076" "LC81140740812016270LGN00" "LC81140762016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_3 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_074_074" "" "114" "74" "74" "2016:270:02:14:36.1130005" "2016:270:02:15:07.8830005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_074_074" "LC81140740812016270LGN00" "LC81140742016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_8 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_078_078" "" "114" "78" "78" "2016:270:02:16:11.8770005" "2016:270:02:16:43.6470005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_078_078" "LC81140740812016270LGN00" "LC81140782016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_1 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_075_075" "" "114" "75" "75" "2016:270:02:15:00.0510005" "2016:270:02:15:31.8210005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_075_075" "LC81140740812016270LGN00" "LC81140752016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_5 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_081_081" "" "114" "81" "81" "2016:270:02:17:23.7190005" "2016:270:02:17:55.4890005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_081_081" "LC81140740812016270LGN00" "LC81140812016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_4 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_079_079" "" "114" "79" "79" "2016:270:02:16:35.8270005" "2016:270:02:17:07.5970005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_079_079" "LC81140740812016270LGN00" "LC81140792016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_SUBSET_PROCESS_9 "LANDSAT8" "OLI_TIRS" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RA" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_080_080" "" "114" "80" "80" "2016:270:02:16:59.7730005" "2016:270:02:17:31.5430005" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_080_080" "LC81140740812016270LGN00" "LC81140802016270LGN00" 2>&1' output =
+Processing (LANDSAT8_OLI_TIRS_subsetter) ..... DONE
+
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_082_082')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_076_076')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_081_081')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_074_074')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_075_075')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_077_077')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_079_079')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_073_073')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_078_078')'
+2016-10-13T20:53:28 ProcessingStep.cpp 388: INFO: Starting processing step 'LPGS: L0Rp -> L1 ('114_080_080')'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 71: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 82: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_080_080'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_080_080'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_074_074'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_074_074'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_073_073'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_081_081'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_073_073'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_077_077'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_081_081'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_077_077'
+<--------L1 Order ODL-------->
+<--START--(114_080_080)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_080_080"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 80
+  WRS_PATH = 114
+  WRS_START_ROW = 80
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_080_080)--END-->
+<--------L1 Order ODL-------->
+<--START--(114_074_074)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_074_074"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 74
+  WRS_PATH = 114
+  WRS_START_ROW = 74
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_074_074)--END-->
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_079_079'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_082_082'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_075_075'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_079_079'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_075_075'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_082_082'
+<--------L1 Order ODL-------->
+<--START--(114_073_073)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_073_073"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 73
+  WRS_PATH = 114
+  WRS_START_ROW = 73
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_073_073)--END-->
+<--------L1 Order ODL-------->
+<--START--(114_081_081)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_081_081"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -49
+  WRS_END_ROW = 81
+  WRS_PATH = 114
+  WRS_START_ROW = 81
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_081_081)--END-->
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_11 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_080_080" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_080_080" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_080_080" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_080_080" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_080_080/114_080_080.odl" 2>&1'
+<--------L1 Order ODL-------->
+<--START--(114_077_077)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_077_077"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 77
+  WRS_PATH = 114
+  WRS_START_ROW = 77
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_077_077)--END-->
+<--------L1 Order ODL-------->
+<--START--(114_079_079)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_079_079"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 79
+  WRS_PATH = 114
+  WRS_START_ROW = 79
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_079_079)--END-->
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_12 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_074_074" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_074_074" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_074_074" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_074_074" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_074_074/114_074_074.odl" 2>&1'
+<--------L1 Order ODL-------->
+<--START--(114_082_082)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_082_082"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -49
+  WRS_END_ROW = 82
+  WRS_PATH = 114
+  WRS_START_ROW = 82
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_082_082)--END-->
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_076_076'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 118: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_078_078'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_076_076'
+2016-10-13T20:53:28 PreProcessingStepL0Rp2L1.cpp 127: INFO: Creating folder '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_078_078'
+<--------L1 Order ODL-------->
+<--START--(114_075_075)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_075_075"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 75
+  WRS_PATH = 114
+  WRS_START_ROW = 75
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_075_075)--END-->
+<--------L1 Order ODL-------->
+<--START--(114_076_076)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_076_076"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 76
+  WRS_PATH = 114
+  WRS_START_ROW = 76
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_076_076)--END-->
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_13 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_075_075" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_075_075" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_075_075" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_075_075" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_075_075/114_075_075.odl" 2>&1'
+<--------L1 Order ODL-------->
+<--START--(114_078_078)--START-->
+GROUP = METADATA
+  ACQUISITION_DATE = "2016-09-26"
+  BPF_OLI_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LO8BPF20160926014820_20160926032601.01"
+  BPF_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/BiasParameterFile/2016/09/LT8BPF20160917100055_20161002083254.01"
+  CPF_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/CalibrationParameterFile/L8CPF20160701_20160930.03"
+  ORDER_ID = "114_078_078"
+  OUTPUT_FORMAT = "GEOTIFF"
+  PRODUCT_TYPE = ("L1T","L1GT")
+  RLUT_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/RLUT/L8RLUT20150303_20431231v11.h5"
+  SATELLITE = "LANDSAT8"
+  SAT_NUM = 8
+  SENSOR = "OLI_TIRS"
+  SSM_POSITION_ESTIMATES_TIRS_FILE_PATH = "/g/data/v10/eoancillarydata/sensor-specific/LANDSAT8/TIRS-SSM/20161013.l8_tirs_estimated_ssm_position.txt"
+  UTM_ZONE = -50
+  WRS_END_ROW = 78
+  WRS_PATH = 114
+  WRS_START_ROW = 78
+  GROUP = LANDSAT8_OLI_TIRS
+    GROUP = ADP
+      GROUP = ALL
+        ANCILLARY_FILENAME = "ancillary_file.h5"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = ADP
+    GROUP = ASSESS_CLOUD_COVER
+      GROUP = ALL
+        OUTPUT_FILENAME = "quality_band.h5"
+      END_GROUP = ALL
+      GROUP = L1G
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = ASSESS_CLOUD_COVER
+    GROUP = DFP
+      GROUP = ALL
+        DEM_FILENAME = "source_dem.h5"
+        INCLUDE_ANG_FILE_FLAG = 1
+        L0R_PACKAGE = 0
+        L1G_PACKAGE = 0
+        L1G_PRODUCT = 1
+        MD5_CHECKSUM_PACKAGES = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = DFP
+    GROUP = DGC
+      GROUP = ALL
+        BASE_GCP_FOLDER = "/g/data/v10/eoancillarydata/GCP/Phase2_GCP"
+        GCP_SOURCE = "CHIPS_30"
+      END_GROUP = ALL
+      GROUP = L1T
+        CHIP_HEADER_VERSION = 2
+        GCP_DIRECTORY = "gcp_lib"
+        GCP_TYPE = "BOTH"
+        TARGET_PROJECTION_SOURCE = "OMF"
+      END_GROUP = L1T
+    END_GROUP = DGC
+    GROUP = DRE
+      GROUP = ALL
+        BASE_DEM_FOLDER = "/g/data/v10/eoancillarydata/elevation/1secDSM-S_Jupp-Li"
+      END_GROUP = ALL
+      GROUP = L1GT
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1GT
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+      END_GROUP = L1T
+    END_GROUP = DRE
+    GROUP = DSW
+      GROUP = ALL
+        CREATE_GEOMETRIC_CHAR_FLAG = 0
+        CREATE_RADIOMETRIC_CHAR_FLAG = 0
+        INSERT_SCENES_ROW_FLAG = 0
+        MAX_PROCESSORS_TO_USE = 4
+      END_GROUP = ALL
+      GROUP = L1G
+        MAX_ELEVATION = 500
+        MIN_ELEVATION = 0
+      END_GROUP = L1G
+    END_GROUP = DSW
+    GROUP = DUMP_SSM_POSITIONS
+      GROUP = ALL
+        ESTIMATED_SSM_POSITION_FILENAME = "estimated_ssm_positions.txt"
+      END_GROUP = ALL
+    END_GROUP = DUMP_SSM_POSITIONS
+    GROUP = GEODETIC
+      GROUP = L1T
+        PROCESSING_PASS = 1
+        REPORT_FILENAME = "geodetic_characterization.rpt"
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEODETIC
+    GROUP = GEOMETRIC
+      GROUP = L1T
+        GEOMETRIC_REQUIRED_FLAG = 0
+        PROCESSING_PASS = 2
+        REPORT_FILENAME = "geometric_characterization.rpt"
+        REPORT_RES_FLAG = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = L1T
+    END_GROUP = GEOMETRIC
+    GROUP = GRID_TERRAIN
+      GROUP = L1GT
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1GT
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid.h5"
+        PROCESSING_PASS = 1
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN
+    GROUP = GRID_TERRAIN_PASS2
+      GROUP = L1T
+        CELL_LINES = 50
+        CELL_SAMPLES = 50
+        GEOM_GRID_FILENAME = "geomgrid_pass_2.h5"
+        PROCESSING_PASS = 2
+        SOURCE_BAND_NUMBER_LIST = 1
+        SOURCE_IMAGE_TYPE = 0
+        TARGET_BAND_NUMBER_LIST = 6
+      END_GROUP = L1T
+    END_GROUP = GRID_TERRAIN_PASS2
+    GROUP = L8GRID_PREC
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "precision_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 2
+      END_GROUP = ALL
+      GROUP = L1G
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_PREC
+    GROUP = L8GRID_SYS
+      GROUP = ALL
+        COORD_UNITS = "DEGREES"
+        FRAC_ROW = 0.000000000000000
+        GRID_FILENAME = "systematic_grid.h5"
+        LSCOORDS = (0.000000,0.000000)
+        NLINES = (0,0,0)
+        NSAMPS = (0,0,0)
+        PROCESSING_PASS = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        DATUM = "GDA_94"
+        FRAME_TYPE = 4
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (25.000000,12.500000,25.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        DATUM = "WGS_84"
+        FRAME_TYPE = 5
+        PIXEL_ORIGIN = "UL"
+        PIXEL_SIZE = (30.000000,15.000000,30.000000)
+        PROJ_PARMS = (6378137.000000000000000, 6356752.314140000380576, 0.000000000000000, 0.000000000000000, 0.000000, -71000000.000000000000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000)
+        PROJ_UNITS = "METERS"
+        SCENE_PADDING = 1.000000000000000
+        TARGET_PROJECTION = 1
+      END_GROUP = L1T
+    END_GROUP = L8GRID_SYS
+    GROUP = L8INIT
+      GROUP = ALL
+        MODEL_FILENAME = "systematic_model.h5"
+        PROCESSING_PASS = 1
+        STORE_CHARACTERIZATION_IN_DB = 0
+      END_GROUP = ALL
+    END_GROUP = L8INIT
+    GROUP = L8PRECISION_GCP
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "CONTROL"
+        HEMISPHERE = "S"
+        MEASURED_GCP = "measured.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 1
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP
+    GROUP = L8PRECISION_GCP_PASS2
+      GROUP = L1G
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1G
+      GROUP = L1GT
+        DATUM = "GDA_94"
+        HEMISPHERE = "S"
+        PIXEL_ORIGIN = "UL"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BEGIN_DATE = (0, 0)
+        CORRELATION_BAND = 6
+        DATUM = "GDA_94"
+        END_DATE = (0, 0)
+        GCP_TYPE = "VALIDATION"
+        HEMISPHERE = "S"
+        MAX_DISP = 16
+        MEASURED_GCP = "measured_pass2.gcp"
+        PIXEL_ORIGIN = "UL"
+        PROCESSING_PASS = 2
+        SRCH_WIN_SIZE = (64, 64)
+        X_OFFSET = 0
+        Y_OFFSET = 0
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_GCP_PASS2
+    GROUP = L8PRECISION_SOLVE
+      GROUP = L1T
+        DEM_FILENAME = "source_dem.h5"
+        MAX_ITER = 10
+        MIN_REQUIRED_GCPS = 10
+        OUT_SOLUTION = "precision.solution"
+        PARM_FLAG = "BOTH"
+        PRECISION_MODEL_FILENAME = "precision_model.h5"
+        PRECISION_REQUIRED_FLAG = 1
+        PROCESSING_PASS = 1
+        RESIDUAL_FILENAME = "precision.residuals"
+        STORE_CHARACTERIZATION_IN_DB = 0
+        TIME_FLAG = "YES"
+      END_GROUP = L1T
+    END_GROUP = L8PRECISION_SOLVE
+    GROUP = L8RESAMPLE_PREC
+      GROUP = L1G
+        RESAMPLE = "CC"
+      END_GROUP = L1G
+      GROUP = L1GT
+        RESAMPLE = "CC"
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGROUND = 0.000000000000000
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "l1t.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "CC"
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_PREC
+    GROUP = L8RESAMPLE_SYS
+      GROUP = ALL
+        BACKGROUND = 0.000000000000000
+        COMBINE_SCAS = 1
+        CREATE_ANG_FLAG = 1
+        DEM_FILENAME = "source_dem.h5"
+        INPUT_IMAGE_BUFFER_METHOD = "DEFAULT"
+        INPUT_IMAGE_BUFFER_TILE_THRESHOLD = 10500
+        L1G_FILENAME = "sys_l1g.h5"
+        MAX_PROCESSORS_TO_USE = 4
+        MINMAX_OUTPUT_DN = (1.000000, 65535.000000)
+        ODTYPE = "UI*2"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        SCA_OVERLAP_CHAR_TYPE = "FULL"
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 0
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (6)
+        RESAMPLE = "CC"
+        TERRAIN_FLAG = 1
+      END_GROUP = L1T
+    END_GROUP = L8RESAMPLE_SYS
+    GROUP = L8RPS
+      GROUP = ALL
+        ALGORITHMS = ("inoperable_detector_identification","dropped_frame_characterization","saturated_pixel_characterization","convert_to_float","tirs_3q_response_linearization","tirs_histogram_statistics_characterization","temperature_sensitivity_correction","tirs_bias_removal","tirs_secondary_linearization","tirs_gain_offset_removal","oli_bias_determination","oli_bias_removal","oli_lookup_response_linearization","oli_histogram_statistics_characterization","gain_application","sca_overlap_statistics_characterization","sca_discontinuity_correction","striping_characterization","saturated_pixel_replacement","inoperable_detectors_fill","reflectance_conversion")
+        APPLY_ABSOLUTE_GAIN = 1
+        APPLY_LINEARIZATION_CORRECTION = 1
+        APPLY_RELATIVE_GAIN = 1
+        BACKGROUND_RESPONSE_SELECTION = 3
+        BIAS_SOURCE = 2
+        DISCONTINUITY_CORRECTION_USE_CPF_FLAG = 1
+        GENERATE_REPORT = 0
+        L1R_FILENAME = "l1r_image.h5"
+        PERFORM_TEMP_SENS = 1
+        PER_FRAME_BIAS_FLAG = 0
+        POPULATE_SCENE_SUMMARY_STATS_FLAG = 0
+        STORE_CHARACTERIZATION_IN_DB = 0
+        USE_TIRS_CPF_BASELINE_RESPONSE = 1
+      END_GROUP = ALL
+      GROUP = L1G
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1G
+      GROUP = L1GT
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1GT
+      GROUP = L1T
+        BAND_LIST = (1,2,3,4,5,6,7,8,9,10,11)
+      END_GROUP = L1T
+    END_GROUP = L8RPS
+    GROUP = RESAMPLE_TERRAIN
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 1
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN
+    GROUP = RESAMPLE_TERRAIN_PASS2
+      GROUP = L1GT
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1GT
+      GROUP = L1T
+        BACKGRND = 0.000000000000000
+        BAND_LIST = 1
+        MINMAX_OUTPUT = (-500.000000,9000.000000)
+        ODTYPE = "I*2"
+        OUTPUT_IMAGE_FILENAME = "elev_pass_2.h5"
+        PCCALPHA = -0.500000000000000
+        PROCESSING_PASS = 2
+        RESAMPLE = "BI"
+        SOURCE_IMAGE_TYPE = 0
+        WINDOW_FLAG = 0
+      END_GROUP = L1T
+    END_GROUP = RESAMPLE_TERRAIN_PASS2
+    GROUP = TERRAIN_OCCLUSION
+      GROUP = L1GT
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 1
+      END_GROUP = L1GT
+      GROUP = L1T
+        OCCLUSION_BAND = 6
+        OCCLUSION_FILENAME = "occlusion_mask.h5"
+        PROCESSING_PASS = 2
+      END_GROUP = L1T
+    END_GROUP = TERRAIN_OCCLUSION
+  END_GROUP = LANDSAT8_OLI_TIRS
+END_GROUP = METADATA
+END
+<--END--(114_078_078)--END-->
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_14 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_081_081" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_081_081" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_081_081" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_081_081" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_081_081/114_081_081.odl" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_15 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_077_077" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_077_077" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_077_077" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_077_077" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_077_077/114_077_077.odl" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_16 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_079_079" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_079_079" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_079_079" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_079_079" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_079_079/114_079_079.odl" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_17 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_082_082" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_082_082" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_082_082" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_082_082" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_082_082/114_082_082.odl" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_18 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_073_073" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_073_073" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_073_073" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_073_073" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_073_073/114_073_073.odl" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_19 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_076_076" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_076_076" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_076_076" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_076_076" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_076_076/114_076_076.odl" 2>&1'
+Execute command = '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_20 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_078_078" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_078_078" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_078_078" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_078_078" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_078_078/114_078_078.odl" 2>&1'
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_18 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_073_073" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_073_073" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_073_073" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_073_073" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_073_073/114_073_073.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... FAILED
+Failure returned from CallIt()
+Failure returned from ExecRunLpgs() for L1T
+Processing a 'L1GT' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_17 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_082_082" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_082_082" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_082_082" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_082_082" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_082_082/114_082_082.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... FAILED
+Failure returned from CallIt()
+Failure returned from ExecRunLpgs() for L1T
+Processing a 'L1GT' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_16 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_079_079" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_079_079" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_079_079" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_079_079" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_079_079/114_079_079.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_12 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_074_074" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_074_074" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_074_074" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_074_074" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_074_074/114_074_074.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_20 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_078_078" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_078_078" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_078_078" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_078_078" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_078_078/114_078_078.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_15 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_077_077" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_077_077" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_077_077" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_077_077" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_077_077/114_077_077.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_11 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_080_080" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_080_080" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_080_080" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_080_080" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_080_080/114_080_080.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_19 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_076_076" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_076_076" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_076_076" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_076_076" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_076_076/114_076_076.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_14 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_081_081" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_081_081" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_081_081" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_081_081" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_081_081/114_081_081.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+Command '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/PerlWO/OP_LPGS_PROCESS_13 "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L0RP/114_075_075" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1/114_075_075" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO/114_075_075" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/Logs/114_075_075" "/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm/L1_WO_ODL/114_075_075/114_075_075.odl" 2>&1' output =
+Failed to locate 'METADATA.PATH_TO_PERL_EXE' from ODL parameters
+Failure returned from GetOdlTagValue()
+Could not locate 'METADATA.PATH_TO_PERL_EXE' will use system default
+Addeding LPGS perl lib to PERL5LIB
+Processing a 'L1T' product with format 'GEOTIFF'
+Processing (DSW) ..... DONE
+Processing (DRE) ..... DONE
+Processing (DGC) ..... DONE
+Processing (ADP) ..... DONE
+Processing (L8INIT) ..... DONE
+Processing (L8RPS) ..... DONE
+Processing (L8GRID_SYS) ..... DONE
+Processing (GRID_TERRAIN) ..... DONE
+Processing (RESAMPLE_TERRAIN) ..... DONE
+Processing (L8RESAMPLE_SYS) ..... DONE
+Processing (L8PRECISION_GCP) ..... DONE
+Processing (L8PRECISION_SOLVE) ..... DONE
+Processing (GEODETIC) ..... DONE
+Processing (L8GRID_PREC) ..... DONE
+Processing (GRID_TERRAIN_PASS2) ..... DONE
+Processing (RESAMPLE_TERRAIN_PASS2) ..... DONE
+Processing (L8RESAMPLE_PREC) ..... DONE
+Processing (L8PRECISION_GCP_PASS2) ..... DONE
+Processing (GEOMETRIC) ..... DONE
+Processing (TERRAIN_OCCLUSION) ..... DONE
+Processing (ASSESS_CLOUD_COVER) ..... DONE
+Processing (DFP) ..... DONE
+
+2016-10-13T21:11:10 Processor.cpp 112: INFO: Cleaning path '/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm'
+Output XML = 
+<LandsatProcessingResult status="success">
+	<Message>Processing was successful</Message>
+	<LandsatProcessingRequest id="LS8-20160926" version="2">
+		<Input format="MD" satellite="LANDSAT8" sensor="OLI_TIRS">
+			<WorkingFolder cleanBefore="TRUE" cleanAfter="TRUE">/jobfs/local/9456756.r-man2/lpgs-work8PT8e5/dee471ed-5aa5-46f5-96b5-1e1ea91ffee4/lpgs-work/pm</WorkingFolder>
+			<InputPath linkInput="TRUE">/g/data/v10/repackaged/rawdata/0/2016/09/LS8_OLI-TIRS_STD-MDF_P00_LC81140740812016270LGN00_114_074-081_20160926T021444Z20160926T031053_1/product</InputPath>
+		</Input>
+	</LandsatProcessingRequest>
+	<Version>4.1.4110</Version>
+	<HostName>r2353</HostName>
+	<StartTime>2016-10-13T20:42:06</StartTime>
+	<StopTime>2016-10-13T21:11:11</StopTime>
+	<TotalTime>00:29:05</TotalTime>
+	<L0RaProcessing status="succeeded"/>
+	<L0RpProcessing maxConcurrentScenes="15" fail="0" busy="0" queued="0" success="10" canceled="0" timedout="0">
+		<Succeeded sceneType="partial">114_073_073</Succeeded>
+		<Succeeded sceneType="full">114_074_074</Succeeded>
+		<Succeeded sceneType="full">114_075_075</Succeeded>
+		<Succeeded sceneType="full">114_076_076</Succeeded>
+		<Succeeded sceneType="full">114_077_077</Succeeded>
+		<Succeeded sceneType="full">114_078_078</Succeeded>
+		<Succeeded sceneType="full">114_079_079</Succeeded>
+		<Succeeded sceneType="full">114_080_080</Succeeded>
+		<Succeeded sceneType="full">114_081_081</Succeeded>
+		<Succeeded sceneType="partial">114_082_082</Succeeded>
+	</L0RpProcessing>
+	<L1Processing maxConcurrentScenes="15" fail="0" busy="0" queued="0" success="10" canceled="0" timedout="0" L1R="0" L1G="0" L1Gt="2" L1T="8">
+		<Succeeded sceneType="full" level="L1T">114_076_076</Succeeded>
+		<Succeeded sceneType="partial" level="L1GT">114_082_082</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_074_074</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_081_081</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_075_075</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_077_077</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_079_079</Succeeded>
+		<Succeeded sceneType="partial" level="L1GT">114_073_073</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_078_078</Succeeded>
+		<Succeeded sceneType="full" level="L1T">114_080_080</Succeeded>
+	</L1Processing>
+</LandsatProcessingResult>
+

--- a/integration_tests/test_duplicates.py
+++ b/integration_tests/test_duplicates.py
@@ -6,7 +6,7 @@ from typing import Tuple
 
 from datacube.index._api import Index
 from digitalearthau import duplicates
-from digitalearthau.index import AgdcDatasetPathIndex, DatasetLite
+from digitalearthau.index import add_dataset
 
 import click.testing
 
@@ -35,8 +35,8 @@ def indexed_ls8_l1_scenes(dea_index: Index, integration_test_data: Path) -> Tupl
     ds1 = integration_test_data.joinpath(*ON_DISK1_OFFSET)
     ds2 = integration_test_data.joinpath(*ON_DISK2_OFFSET)
 
-    AgdcDatasetPathIndex(dea_index).add_dataset(DatasetLite(ON_DISK1_ID), ds1.as_uri())
-    AgdcDatasetPathIndex(dea_index).add_dataset(DatasetLite(ON_DISK2_ID), ds2.as_uri())
+    add_dataset(dea_index, ON_DISK1_ID, ds1.as_uri())
+    add_dataset(dea_index, ON_DISK2_ID, ds2.as_uri())
 
     return ON_DISK1_ID, ON_DISK2_ID
 
@@ -47,7 +47,7 @@ def duplicate_ls8_l1_scene(dea_index: Index, integration_test_data: Path) -> uui
         'dupe', 'LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926_2', 'ga-metadata.yaml'
     )
 
-    AgdcDatasetPathIndex(dea_index).add_dataset(DatasetLite(ON_DISK1_DUP_ID), dd1.as_uri())
+    add_dataset(dea_index, ON_DISK1_DUP_ID, dd1.as_uri())
     return ON_DISK1_DUP_ID
 
 

--- a/integration_tests/test_full_sync.py
+++ b/integration_tests/test_full_sync.py
@@ -26,22 +26,6 @@ from integration_tests.conftest import DatasetOnDisk
 # pylint: disable=too-many-locals, protected-access, redefined-outer-name
 
 
-@pytest.fixture(scope="session", autouse=True)
-def configure_log_output(request):
-    structlog.configure(
-        processors=[
-            structlog.stdlib.add_log_level,
-            structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M.%S"),
-            structlog.processors.StackInfoRenderer(),
-            structlog.processors.format_exc_info,
-            # Coloured output if to terminal.
-            CleanConsoleRenderer()
-        ],
-        context_class=dict,
-        cache_logger_on_first_use=True,
-    )
-
-
 def test_new_and_old_on_disk(test_dataset: DatasetOnDisk,
                              integration_test_data: Path,
                              other_dataset: DatasetOnDisk):

--- a/integration_tests/test_full_sync.py
+++ b/integration_tests/test_full_sync.py
@@ -19,6 +19,8 @@ from digitalearthau.index import DatasetLite, MemoryDatasetPathIndex, AgdcDatase
 from digitalearthau.paths import register_base_directory
 from digitalearthau.sync import differences as mm, fixes, scan, Mismatch
 
+from integration_tests.conftest import TestDataset
+
 
 # These are ok in tests.
 # pylint: disable=too-many-locals, protected-access, redefined-outer-name
@@ -40,223 +42,147 @@ def configure_log_output(request):
     )
 
 
-ON_DISK1_ID = DatasetLite(uuid.UUID('86150afc-b7d5-4938-a75e-3445007256d3'))
-ON_DISK2_ID = DatasetLite(uuid.UUID('10c4a9fe-2890-11e6-8ec8-a0000100fe80'))
-
-ON_DISK1_OFFSET = ('LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20160926', 'ga-metadata.yaml')
-ON_DISK2_OFFSET = ('LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924', 'ga-metadata.yaml')
-
-# Source datasets that will be indexed if on_disk1 is indexed
-ON_DISK1_PARENT = DatasetLite(uuid.UUID('dee471ed-5aa5-46f5-96b5-1e1ea91ffee4'))
-
-
-@pytest.fixture
-def syncable_environment(integration_test_data, dea_index):
-    test_data = integration_test_data
-
-    # Tests assume one dataset for the collection, so delete the second.
-    shutil.rmtree(str(test_data.joinpath('LS8_OLITIRS_OTH_P51_GALPGS01-032_114_080_20150924')))
-    index = AgdcDatasetPathIndex(dea_index)
-    ls8_collection = Collection(
-        name='ls8_scene_test',
-        query={},
-        file_patterns=[str(test_data.joinpath('LS8*/ga-metadata.yaml'))],
-        unique=[],
-        index=index
-    )
-    collections._add(ls8_collection)
-
-    ls5_nc_collection = Collection(
-        name='ls5_nc_test',
-        query={},
-        file_patterns=[str(test_data.joinpath('LS5*.nc'))],
-        unique=[],
-        index=index
-    )
-    collections._add(ls8_collection)
-
-    # register this as a base directory so that datasets can be trashed within it.
-    register_base_directory(str(test_data))
-
-    cache_path = test_data.joinpath('cache')
-    cache_path.mkdir()
-
-    on_disk_uri = test_data.joinpath(*ON_DISK1_OFFSET).as_uri()
-
-    return ls8_collection, ON_DISK1_ID, on_disk_uri, Path(str(test_data))
-
-
-@pytest.fixture
-def other_dataset_id_path(syncable_environment):
-    ls8_collection, on_disk, on_disk_uri, root = syncable_environment
-
-    ds_id = uuid.UUID("5294efa6-348d-11e7-a079-185e0f80a5c0")
-    paths.write_files(
-        {
-            'LS8_INDEXED_ALREADY': {
-                'ga-metadata.yaml': ("""
-id: %s
-platform:
-    code: LANDSAT_8
-instrument:
-    name: OLI_TIRS
-format:
-    name: GeoTIFF
-product_type: level1
-product_level: L1T
-image:
-    bands: {}
-lineage:
-    source_datasets: {}
-    """ % str(ds_id)),
-                'dummy-file.txt': ''
-            }
-        },
-        containing_dir=root
-    )
-    ds_path = root.joinpath('LS8_INDEXED_ALREADY', 'ga-metadata.yaml')
-    return DatasetLite(ds_id), ds_path
-
-
-def test_new_and_old_on_disk(syncable_environment, other_dataset_id_path):
+def test_new_and_old_on_disk(test_dataset: TestDataset,
+                             integration_test_data: Path,
+                             other_dataset: TestDataset):
     # type: (Tuple[Collection, DatasetLite, str, Path]) -> None
-    ls8_collection, on_disk, on_disk_uri, root = syncable_environment
+    # ls8_collection, on_disk, on_disk_uri, root = syncable_environment
+
     old_indexed = DatasetLite(uuid.UUID('5294efa6-348d-11e7-a079-185e0f80a5c0'))
 
     # An indexed file not on disk, and disk file not in index.
 
-    missing, missing_path = other_dataset_id_path
-    missing_uri = missing_path.as_uri()
-    ls8_collection._index.add_dataset(missing, missing_uri)
+    missing_dataset = other_dataset
+
+    test_dataset.collection._index.add_dataset(missing_dataset.dataset, missing_dataset.uri)
+
     # Make it missing
-    shutil.rmtree(str(missing_path.parent))
+    shutil.rmtree(str(missing_dataset.path.parent))
 
     _check_sync(
-        collection=ls8_collection,
+        collection=test_dataset.collection,
         expected_paths=[
-            missing_uri,
-            on_disk_uri
+            missing_dataset.uri,
+            test_dataset.uri
         ],
         expected_mismatches=[
-            mm.LocationMissingOnDisk(old_indexed, missing_path.as_uri()),
-            mm.DatasetNotIndexed(on_disk, on_disk_uri)
+            mm.LocationMissingOnDisk(old_indexed, missing_dataset.uri),
+            mm.DatasetNotIndexed(test_dataset.dataset, test_dataset.uri)
         ],
         expected_index_result={
-            on_disk: (on_disk_uri,),
+            test_dataset.dataset: (test_dataset.uri,),
             old_indexed: (),
-            ON_DISK1_PARENT: (),
+            test_dataset.parent: (),
         },
-        cache_path=root,
+        cache_path=integration_test_data,
         fix_settings=dict(index_missing=True, update_locations=True)
     )
 
 
-def test_replace_on_disk(syncable_environment, other_dataset_id_path):
+def test_replace_on_disk(test_dataset: TestDataset,
+                         integration_test_data: Path,
+                         other_dataset: TestDataset):
     # type: (Tuple[Collection, DatasetLite, str, Path]) -> None
     """
     File on disk has a different id to the one in the index (ie. it was quietly reprocessed)
     """
-    ls8_collection, on_disk, on_disk_uri, root = syncable_environment
 
-    other, other_path = other_dataset_id_path
-    ls8_collection._index.add_dataset(on_disk, on_disk_uri)
+    test_dataset.collection._index.add_dataset(test_dataset.dataset, test_dataset.uri)
 
     # move a new one over the top
-    shutil.move(other_path, str(uri_to_local_path(on_disk_uri)))
+    shutil.move(other_dataset.path, str(uri_to_local_path(test_dataset.uri)))
 
     _check_sync(
-        collection=ls8_collection,
+        collection=test_dataset.collection,
         expected_paths=[
-            on_disk_uri
+            test_dataset.uri
         ],
         expected_mismatches=[
-            mm.LocationMissingOnDisk(on_disk, on_disk_uri),
-            mm.DatasetNotIndexed(other, on_disk_uri),
+            mm.LocationMissingOnDisk(test_dataset.dataset, test_dataset.uri),
+            mm.DatasetNotIndexed(other_dataset.dataset, test_dataset.uri),
         ],
         expected_index_result={
-            on_disk: (),
-            other: (on_disk_uri,),
-            ON_DISK1_PARENT: (),
+            test_dataset.dataset: (),
+            other_dataset.dataset: (test_dataset.uri,),
+            test_dataset.parent: (),
         },
-        cache_path=root,
+        cache_path=integration_test_data,
         fix_settings=dict(index_missing=True, update_locations=True)
     )
 
 
-def test_move_on_disk(syncable_environment, other_dataset_id_path):
+def test_move_on_disk(test_dataset: TestDataset,
+                      integration_test_data: Path,
+                      other_dataset: TestDataset):
     # type: (Tuple[Collection, DatasetLite, str, Path]) -> None
     """
     Indexed dataset was moved over the top of another indexed dataset
     """
-    ls8_collection, on_disk, on_disk_uri, root = syncable_environment
+    test_dataset.collection._index.add_dataset(test_dataset.dataset, test_dataset.uri)
+    test_dataset.collection._index.add_dataset(other_dataset.dataset, other_dataset.path.as_uri())
 
-    other, other_path = other_dataset_id_path
-    ls8_collection._index.add_dataset(on_disk, on_disk_uri)
-    ls8_collection._index.add_dataset(other, other_path.as_uri())
-
-    shutil.move(other_path, str(uri_to_local_path(on_disk_uri)))
+    shutil.move(other_dataset.path, str(uri_to_local_path(test_dataset.uri)))
 
     _check_sync(
-        collection=ls8_collection,
+        collection=test_dataset.collection,
         expected_paths=[
-            on_disk_uri,
-            other_path.as_uri(),
+            test_dataset.uri,
+            other_dataset.path.as_uri(),
         ],
         expected_mismatches=[
-            mm.LocationMissingOnDisk(on_disk, on_disk_uri),
-            mm.LocationNotIndexed(other, on_disk_uri),
-            mm.LocationMissingOnDisk(other, other_path.as_uri()),
+            mm.LocationMissingOnDisk(test_dataset.dataset, test_dataset.uri),
+            mm.LocationNotIndexed(other_dataset.dataset, test_dataset.uri),
+            mm.LocationMissingOnDisk(other_dataset.dataset, other_dataset.path.as_uri()),
         ],
         expected_index_result={
-            on_disk: (),
-            other: (on_disk_uri,),
-            ON_DISK1_PARENT: (),
+            test_dataset.dataset: (),
+            other_dataset.dataset: (test_dataset.uri,),
+            test_dataset.parent: (),
         },
-        cache_path=root,
+        cache_path=integration_test_data,
         fix_settings=dict(index_missing=True, update_locations=True)
     )
 
 
-def test_archived_on_disk(syncable_environment):
+def test_archived_on_disk(test_dataset: TestDataset,
+                          integration_test_data: Path):
     # type: (Tuple[Collection, DatasetLite, str, Path]) -> None
     """
     A an already-archived dataset on disk. Should report it, but not touch the file (trash_archived is false)
     """
-    ls8_collection, on_disk, on_disk_uri, root = syncable_environment
-
     # archived_on_disk = DatasetLite(on_disk.id, archived_time=(datetime.utcnow() - timedelta(days=5)))
-    ls8_collection._index.add_dataset(on_disk, on_disk_uri)
-    ls8_collection._index._index.datasets.archive([on_disk.id])
-    archived_time = ls8_collection._index._index.datasets.get(on_disk.id).archived_time
+    test_dataset.collection._index.add_dataset(test_dataset.dataset, test_dataset.uri)
+    test_dataset.collection._index._index.datasets.archive([test_dataset.dataset.id])
+    archived_time = test_dataset.collection._index._index.datasets.get(test_dataset.dataset.id).archived_time
 
-    assert uri_to_local_path(on_disk_uri).exists(), "On-disk location should exist before test begins."
+    assert uri_to_local_path(test_dataset.uri).exists(), "On-disk location should exist before test begins."
     _check_sync(
-        collection=ls8_collection,
+        collection=test_dataset.collection,
         expected_paths=[
-            on_disk_uri
+            test_dataset.uri
         ],
         expected_mismatches=[
-            mm.ArchivedDatasetOnDisk(DatasetLite(on_disk.id, archived_time), on_disk_uri),
+            mm.ArchivedDatasetOnDisk(DatasetLite(test_dataset.dataset.id, archived_time), test_dataset.uri),
         ],
         expected_index_result={
             # Not active in index, as it's archived.
             # on_disk: (on_disk_uri,),
             # But the parent dataset still is:
-            ON_DISK1_PARENT: (),
+            test_dataset.parent: (),
         },
-        cache_path=root,
+        cache_path=integration_test_data,
         fix_settings=dict(index_missing=True, update_locations=True)
     )
-    assert uri_to_local_path(on_disk_uri).exists(), "On-disk location shouldn't be touched"
+    assert uri_to_local_path(test_dataset.uri).exists(), "On-disk location shouldn't be touched"
 
 
-def test_detect_corrupt_existing(syncable_environment):
+def test_detect_corrupt_existing(test_dataset: TestDataset,
+                                 integration_test_data: Path):
     # type: (Tuple[Collection, str, str, Path]) -> None
     """If a dataset exists but cannot be read, report as corrupt"""
-    ls8_collection, on_disk, on_disk_uri, root = syncable_environment
-    path = uri_to_local_path(on_disk_uri)
+    path = uri_to_local_path(test_dataset.uri)
 
-    ls8_collection._index.add_dataset(on_disk, on_disk_uri)
+    test_dataset.collection._index.add_dataset(test_dataset.dataset, test_dataset.uri)
     assert path.exists()
 
     # Overwrite with corrupted file.
@@ -268,26 +194,27 @@ def test_detect_corrupt_existing(syncable_environment):
     # Another dataset exists in the same location
 
     _check_sync(
-        collection=ls8_collection,
-        expected_paths=[on_disk_uri],
+        collection=test_dataset.collection,
+        expected_paths=[test_dataset.uri],
         expected_mismatches=[
             # We don't know if it's the same dataset
-            mm.UnreadableDataset(None, on_disk_uri)
+            mm.UnreadableDataset(None, test_dataset.uri)
         ],
         # Unmodified index
-        expected_index_result=ls8_collection._index.as_map(),
-        cache_path=root,
+        expected_index_result=test_dataset.collection._index.as_map(),
+        cache_path=integration_test_data,
         fix_settings=dict(trash_missing=True, trash_archived=True, update_locations=True)
     )
     # If a dataset is in the index pointing to the corrupt location, it shouldn't be trashed with trash_archived=True
     assert path.exists(), "Corrupt dataset with sibling in index should not be trashed"
 
 
-def test_detect_corrupt_new(syncable_environment):
+def test_detect_corrupt_new(test_dataset: TestDataset,
+                            integration_test_data: Path):
     # type: (Tuple[Collection, str, str, Path]) -> None
     """If a dataset exists but cannot be read handle as corrupt"""
-    ls8_collection, on_disk, on_disk_uri, root = syncable_environment
-    path = uri_to_local_path(on_disk_uri)
+
+    path = uri_to_local_path(test_dataset.uri)
 
     # Write corrupted file.
     os.unlink(str(path))
@@ -297,13 +224,13 @@ def test_detect_corrupt_new(syncable_environment):
 
     # No dataset in index at the corrupt location, so it should be trashed.
     _check_sync(
-        collection=ls8_collection,
-        expected_paths=[on_disk_uri],
+        collection=test_dataset.collection,
+        expected_paths=[test_dataset.uri],
         expected_mismatches=[
-            mm.UnreadableDataset(None, on_disk_uri)
+            mm.UnreadableDataset(None, test_dataset.uri)
         ],
         expected_index_result={},
-        cache_path=root,
+        cache_path=integration_test_data,
         fix_settings=dict(trash_missing=True, trash_archived=True, update_locations=True)
     )
     assert not path.exists(), "Corrupt dataset without sibling should be trashed with trash_archived=True"
@@ -313,39 +240,37 @@ _TRASH_PREFIX = ('.trash', (datetime.utcnow().strftime('%Y-%m-%d')))
 
 
 # noinspection PyShadowingNames
-def test_remove_missing(syncable_environment, other_dataset_id_path):
+def test_remove_missing(test_dataset: TestDataset,
+                        integration_test_data: Path,
+                        other_dataset: TestDataset):
     """An on-disk dataset that's not indexed should be trashed when trash_missing=True"""
-    ls8_collection, on_disk, on_disk_uri, root = syncable_environment
-
-    register_base_directory(root)
-    on_disk_path = root.joinpath(*ON_DISK1_OFFSET)
-    trashed_path = root.joinpath(*_TRASH_PREFIX, *ON_DISK1_OFFSET)
+    register_base_directory(integration_test_data)
+    trashed_path = test_dataset.base_path.joinpath(*_TRASH_PREFIX, *test_dataset.path_offset)
 
     # Add a second dataset that's indexed. Should not be touched!
-    other, other_path = other_dataset_id_path
-    ls8_collection._index.add_dataset(other, other_path.as_uri())
+    test_dataset.collection._index.add_dataset(other_dataset.dataset, other_dataset.path.as_uri())
 
-    assert other_path.exists()
+    assert other_dataset.path.exists()
 
-    assert on_disk_path.exists(), "On-disk location should exist before test begins."
+    assert test_dataset.path.exists(), "On-disk location should exist before test begins."
     assert not trashed_path.exists(), "Trashed file shouldn't exit."
     _check_sync(
-        collection=ls8_collection,
+        collection=test_dataset.collection,
         expected_paths=[
-            on_disk_uri,
-            other_path.as_uri(),
+            test_dataset.uri,
+            other_dataset.path.as_uri(),
         ],
         expected_mismatches=[
-            mm.DatasetNotIndexed(on_disk, on_disk_uri)
+            mm.DatasetNotIndexed(test_dataset.dataset, test_dataset.uri)
         ],
         # Unmodified index
-        expected_index_result=ls8_collection._index.as_map(),
-        cache_path=root,
+        expected_index_result=test_dataset.collection._index.as_map(),
+        cache_path=integration_test_data,
         fix_settings=dict(trash_missing=True, update_locations=True)
     )
-    assert not on_disk_path.exists(), "On-disk location should exist before test begins."
+    assert not test_dataset.path.exists(), "On-disk location should exist before test begins."
     assert trashed_path.exists(), "Trashed file shouldn't exit."
-    assert other_path.exists(), "Dataset outside of collection folder shouldn't be touched"
+    assert other_dataset.path.exists(), "Dataset outside of collection folder shouldn't be touched"
 
 
 def now_utc():
@@ -361,34 +286,36 @@ def now_utc():
     # One day in the future, not trashed.
     (now_utc() + timedelta(days=1), False),
 ])
-def test_is_trashed(syncable_environment, archived_dt, expect_to_be_trashed):
-    ls8_collection, on_disk, on_disk_uri, root = syncable_environment
+def test_is_trashed(test_dataset: TestDataset,
+                    integration_test_data: Path,
+                    archived_dt,
+                    expect_to_be_trashed):
+    root = integration_test_data
 
     # Same test, but trash_archived=True, so it should be renamed to the.
     register_base_directory(root)
-    archived_on_disk = DatasetLite(on_disk.id, archived_time=archived_dt)
-    ls8_collection._index.add_dataset(archived_on_disk, on_disk_uri)
-    archive_dataset(archived_dt, on_disk.id, ls8_collection)
+    archived_on_disk = DatasetLite(test_dataset.dataset.id, archived_time=archived_dt)
+    test_dataset.collection._index.add_dataset(archived_on_disk, test_dataset.uri)
+    archive_dataset(archived_dt, test_dataset.dataset.id, test_dataset.collection)
 
-    on_disk_path = root.joinpath(*ON_DISK1_OFFSET)
+    trashed_path = test_dataset.base_path.joinpath(*_TRASH_PREFIX, *test_dataset.path_offset)
 
-    trashed_path = root.joinpath(*_TRASH_PREFIX, *ON_DISK1_OFFSET)
     # Before the test, file is in place and nothing trashed.
-    assert on_disk_path.exists(), "On-disk location should exist before test begins."
+    assert test_dataset.path.exists(), "On-disk location should exist before test begins."
     assert not trashed_path.exists(), "Trashed file shouldn't exit."
     _check_sync(
-        collection=ls8_collection,
+        collection=test_dataset.collection,
         expected_paths=[
-            on_disk_uri
+            test_dataset.uri
         ],
         expected_mismatches=[
-            mm.ArchivedDatasetOnDisk(archived_on_disk, on_disk_uri),
+            mm.ArchivedDatasetOnDisk(archived_on_disk, test_dataset.uri),
         ],
         expected_index_result={
             # Archived: shouldn't be active in index.
             # on_disk: (on_disk_uri,),
             # Prov parent should still exist as it wasn't archived.
-            ON_DISK1_PARENT: (),
+            test_dataset.parent: (),
         },
         cache_path=root,
         fix_settings=dict(index_missing=True, update_locations=True, trash_archived=True)
@@ -401,10 +328,10 @@ def test_is_trashed(syncable_environment, archived_dt, expect_to_be_trashed):
 
     if expect_to_be_trashed:
         assert trashed_path.exists(), "File isn't in trash."
-        assert not on_disk_path.exists(), "On-disk location still exists (should have been moved to trash)."
+        assert not test_dataset.path.exists(), "On-disk location still exists (should have been moved to trash)."
     else:
         assert not trashed_path.exists(), "File shouldn't have been trashed."
-        assert on_disk_path.exists(), "On-disk location should still be in place."
+        assert test_dataset.path.exists(), "On-disk location should still be in place."
 
 
 def archive_dataset(archived_dt, dataset_id, collection):

--- a/integration_tests/test_full_sync.py
+++ b/integration_tests/test_full_sync.py
@@ -18,7 +18,7 @@ from digitalearthau.index import DatasetLite, add_dataset
 from digitalearthau.paths import register_base_directory
 from digitalearthau.sync import differences as mm, fixes, scan, Mismatch
 
-from integration_tests.conftest import DatasetForTests
+from integration_tests.conftest import DatasetForTests, as_map
 
 
 # These are ok in tests.
@@ -40,7 +40,7 @@ def test_new_and_old_on_disk(test_dataset: DatasetForTests,
     missing_dataset.add_to_index()
 
     # Make it missing
-    shutil.rmtree(str(missing_dataset.path.parent))
+    shutil.rmtree(str(missing_dataset.copyable_path))
 
     _check_sync(
         collection=test_dataset.collection,
@@ -402,16 +402,3 @@ def _check_mismatch_fix(index: Index,
     # Now perform fixes, check that they match expected.
     fixes.fix_mismatches(mismatches, index, **fix_settings)
     assert expected_index_result == as_map(index)
-
-
-def as_map(index: Index) -> Mapping[DatasetLite, Iterable[str]]:
-    """
-    All contained (dataset_id, [location]) values, to check test results.
-    """
-    return dict(
-        (
-            DatasetLite(dataset.id, archived_time=dataset.archived_time),
-            tuple(dataset.uris)
-        )
-        for dataset in index.datasets.search()
-    )

--- a/integration_tests/test_full_sync.py
+++ b/integration_tests/test_full_sync.py
@@ -19,7 +19,7 @@ from digitalearthau.index import DatasetLite, MemoryDatasetPathIndex, AgdcDatase
 from digitalearthau.paths import register_base_directory
 from digitalearthau.sync import differences as mm, fixes, scan, Mismatch
 
-from integration_tests.conftest import TestDataset
+from integration_tests.conftest import DatasetOnDisk
 
 
 # These are ok in tests.
@@ -42,9 +42,9 @@ def configure_log_output(request):
     )
 
 
-def test_new_and_old_on_disk(test_dataset: TestDataset,
+def test_new_and_old_on_disk(test_dataset: DatasetOnDisk,
                              integration_test_data: Path,
-                             other_dataset: TestDataset):
+                             other_dataset: DatasetOnDisk):
     # type: (Tuple[Collection, DatasetLite, str, Path]) -> None
     # ls8_collection, on_disk, on_disk_uri, root = syncable_environment
 
@@ -79,9 +79,9 @@ def test_new_and_old_on_disk(test_dataset: TestDataset,
     )
 
 
-def test_replace_on_disk(test_dataset: TestDataset,
+def test_replace_on_disk(test_dataset: DatasetOnDisk,
                          integration_test_data: Path,
-                         other_dataset: TestDataset):
+                         other_dataset: DatasetOnDisk):
     # type: (Tuple[Collection, DatasetLite, str, Path]) -> None
     """
     File on disk has a different id to the one in the index (ie. it was quietly reprocessed)
@@ -111,9 +111,9 @@ def test_replace_on_disk(test_dataset: TestDataset,
     )
 
 
-def test_move_on_disk(test_dataset: TestDataset,
+def test_move_on_disk(test_dataset: DatasetOnDisk,
                       integration_test_data: Path,
-                      other_dataset: TestDataset):
+                      other_dataset: DatasetOnDisk):
     # type: (Tuple[Collection, DatasetLite, str, Path]) -> None
     """
     Indexed dataset was moved over the top of another indexed dataset
@@ -144,7 +144,7 @@ def test_move_on_disk(test_dataset: TestDataset,
     )
 
 
-def test_archived_on_disk(test_dataset: TestDataset,
+def test_archived_on_disk(test_dataset: DatasetOnDisk,
                           integration_test_data: Path):
     # type: (Tuple[Collection, DatasetLite, str, Path]) -> None
     """
@@ -176,7 +176,7 @@ def test_archived_on_disk(test_dataset: TestDataset,
     assert uri_to_local_path(test_dataset.uri).exists(), "On-disk location shouldn't be touched"
 
 
-def test_detect_corrupt_existing(test_dataset: TestDataset,
+def test_detect_corrupt_existing(test_dataset: DatasetOnDisk,
                                  integration_test_data: Path):
     # type: (Tuple[Collection, str, str, Path]) -> None
     """If a dataset exists but cannot be read, report as corrupt"""
@@ -209,7 +209,7 @@ def test_detect_corrupt_existing(test_dataset: TestDataset,
     assert path.exists(), "Corrupt dataset with sibling in index should not be trashed"
 
 
-def test_detect_corrupt_new(test_dataset: TestDataset,
+def test_detect_corrupt_new(test_dataset: DatasetOnDisk,
                             integration_test_data: Path):
     # type: (Tuple[Collection, str, str, Path]) -> None
     """If a dataset exists but cannot be read handle as corrupt"""
@@ -240,9 +240,9 @@ _TRASH_PREFIX = ('.trash', (datetime.utcnow().strftime('%Y-%m-%d')))
 
 
 # noinspection PyShadowingNames
-def test_remove_missing(test_dataset: TestDataset,
+def test_remove_missing(test_dataset: DatasetOnDisk,
                         integration_test_data: Path,
-                        other_dataset: TestDataset):
+                        other_dataset: DatasetOnDisk):
     """An on-disk dataset that's not indexed should be trashed when trash_missing=True"""
     register_base_directory(integration_test_data)
     trashed_path = test_dataset.base_path.joinpath(*_TRASH_PREFIX, *test_dataset.path_offset)
@@ -286,7 +286,7 @@ def now_utc():
     # One day in the future, not trashed.
     (now_utc() + timedelta(days=1), False),
 ])
-def test_is_trashed(test_dataset: TestDataset,
+def test_is_trashed(test_dataset: DatasetOnDisk,
                     integration_test_data: Path,
                     archived_dt,
                     expect_to_be_trashed):

--- a/integration_tests/test_full_sync.py
+++ b/integration_tests/test_full_sync.py
@@ -18,16 +18,16 @@ from digitalearthau.index import DatasetLite, add_dataset
 from digitalearthau.paths import register_base_directory
 from digitalearthau.sync import differences as mm, fixes, scan, Mismatch
 
-from integration_tests.conftest import DatasetOnDisk
+from integration_tests.conftest import DatasetForTests
 
 
 # These are ok in tests.
 # pylint: disable=too-many-locals, protected-access, redefined-outer-name
 
 
-def test_new_and_old_on_disk(test_dataset: DatasetOnDisk,
+def test_new_and_old_on_disk(test_dataset: DatasetForTests,
                              integration_test_data: Path,
-                             other_dataset: DatasetOnDisk):
+                             other_dataset: DatasetForTests):
     # type: (Tuple[Collection, DatasetLite, str, Path]) -> None
     # ls8_collection, on_disk, on_disk_uri, root = syncable_environment
 
@@ -62,9 +62,9 @@ def test_new_and_old_on_disk(test_dataset: DatasetOnDisk,
     )
 
 
-def test_replace_on_disk(test_dataset: DatasetOnDisk,
+def test_replace_on_disk(test_dataset: DatasetForTests,
                          integration_test_data: Path,
-                         other_dataset: DatasetOnDisk):
+                         other_dataset: DatasetForTests):
     # type: (Tuple[Collection, DatasetLite, str, Path]) -> None
     """
     File on disk has a different id to the one in the index (ie. it was quietly reprocessed)
@@ -93,9 +93,9 @@ def test_replace_on_disk(test_dataset: DatasetOnDisk,
     )
 
 
-def test_move_on_disk(test_dataset: DatasetOnDisk,
+def test_move_on_disk(test_dataset: DatasetForTests,
                       integration_test_data: Path,
-                      other_dataset: DatasetOnDisk):
+                      other_dataset: DatasetForTests):
     # type: (Tuple[Collection, DatasetLite, str, Path]) -> None
     """
     Indexed dataset was moved over the top of another indexed dataset
@@ -126,7 +126,7 @@ def test_move_on_disk(test_dataset: DatasetOnDisk,
     )
 
 
-def test_archived_on_disk(test_dataset: DatasetOnDisk,
+def test_archived_on_disk(test_dataset: DatasetForTests,
                           integration_test_data: Path):
     # type: (Tuple[Collection, DatasetLite, str, Path]) -> None
     """
@@ -158,7 +158,7 @@ def test_archived_on_disk(test_dataset: DatasetOnDisk,
     assert uri_to_local_path(test_dataset.uri).exists(), "On-disk location shouldn't be touched"
 
 
-def test_detect_corrupt_existing(test_dataset: DatasetOnDisk,
+def test_detect_corrupt_existing(test_dataset: DatasetForTests,
                                  integration_test_data: Path):
     # type: (Tuple[Collection, str, str, Path]) -> None
     """If a dataset exists but cannot be read, report as corrupt"""
@@ -191,7 +191,7 @@ def test_detect_corrupt_existing(test_dataset: DatasetOnDisk,
     assert path.exists(), "Corrupt dataset with sibling in index should not be trashed"
 
 
-def test_detect_corrupt_new(test_dataset: DatasetOnDisk,
+def test_detect_corrupt_new(test_dataset: DatasetForTests,
                             integration_test_data: Path):
     # type: (Tuple[Collection, str, str, Path]) -> None
     """If a dataset exists but cannot be read handle as corrupt"""
@@ -222,9 +222,9 @@ _TRASH_PREFIX = ('.trash', (datetime.utcnow().strftime('%Y-%m-%d')))
 
 
 # noinspection PyShadowingNames
-def test_remove_missing(test_dataset: DatasetOnDisk,
+def test_remove_missing(test_dataset: DatasetForTests,
                         integration_test_data: Path,
-                        other_dataset: DatasetOnDisk):
+                        other_dataset: DatasetForTests):
     """An on-disk dataset that's not indexed should be trashed when trash_missing=True"""
     register_base_directory(integration_test_data)
     trashed_path = test_dataset.base_path.joinpath(*_TRASH_PREFIX, *test_dataset.path_offset)
@@ -268,7 +268,7 @@ def now_utc():
     # One day in the future, not trashed.
     (now_utc() + timedelta(days=1), False),
 ])
-def test_is_trashed(test_dataset: DatasetOnDisk,
+def test_is_trashed(test_dataset: DatasetForTests,
                     integration_test_data: Path,
                     archived_dt,
                     expect_to_be_trashed):

--- a/integration_tests/test_move.py
+++ b/integration_tests/test_move.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+from click.testing import CliRunner, Result
+
+from digitalearthau import move, collections, paths
+from digitalearthau.collections import Collection
+from digitalearthau.index import add_dataset
+from integration_tests.conftest import DatasetOnDisk
+
+import pytest
+import structlog
+from dateutil import tz
+
+
+def test_move(global_integration_cli_args, test_dataset: DatasetOnDisk, other_dataset: DatasetOnDisk, tmpdir):
+    """
+    With two datasets in a collection, try to move one.
+    """
+
+    # Add second dataset
+    add_dataset(test_dataset.collection.index, test_dataset.dataset.id, test_dataset.uri)
+    add_dataset(other_dataset.collection.index, other_dataset.dataset.id, other_dataset.uri)
+
+    # Move one dataset.
+
+    runner = CliRunner()
+
+    destination = Path(tmpdir).joinpath('destination_collection')
+    destination.mkdir(exist_ok=False)
+
+    paths.register_base_directory(destination)
+
+    # dest_collection = Collection(
+    #     name='ls8_scene_dest',
+    #     query={},
+    #
+    #     index=test_dataset.collection.index
+    # )
+    # collections._add(dest_collection)
+
+    res: Result = runner.invoke(
+        move.cli,
+        [*global_integration_cli_args, '-d', str(destination), str(test_dataset.path)],
+        catch_exceptions=False
+    )
+
+    print(res.output)
+    assert res.exit_code == 0, res.output
+
+    assert destination.exists(), "File was not moved to destination?"
+    assert test_dataset.path.exists(), "Old file was deleted: should only have been archived"
+
+    # Only the destination should be active now, so only it will be returned in search
+
+    all_indexed_uris = set(test_dataset.collection.iter_index_uris())
+    # The 'other' dataset should be unchanged.
+    expected_new_path = destination.joinpath(*test_dataset.path_offset)
+    assert all_indexed_uris == {
+        # The old uri one still indexed (but archived)
+        test_dataset.uri,
+        # The new uri
+        expected_new_path.as_uri(),
+        # The other dataset unchanged
+        other_dataset.uri
+    }
+
+    dataset = test_dataset.collection.index.get(test_dataset.dataset.id)
+
+    test_dataset.collection.iter_index_uris()

--- a/integration_tests/test_move.py
+++ b/integration_tests/test_move.py
@@ -1,15 +1,27 @@
+import shutil
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner, Result
 
 from digitalearthau import move, paths
-from integration_tests.conftest import DatasetForTests
+from integration_tests.conftest import DatasetForTests, as_map
+
+
+@pytest.fixture
+def destination_path(tmpdir) -> Path:
+    """A new "base folder" that a dataset could be moved to."""
+
+    destination = Path(tmpdir).joinpath('destination_collection')
+    destination.mkdir(exist_ok=False)
+    paths.register_base_directory(destination)
+    return destination
 
 
 def test_move(global_integration_cli_args,
               test_dataset: DatasetForTests,
               other_dataset: DatasetForTests,
-              tmpdir):
+              destination_path):
     """
     With two datasets in a collection, try to move one to a new disk location.
 
@@ -18,26 +30,96 @@ def test_move(global_integration_cli_args,
     test_dataset.add_to_index()
     other_dataset.add_to_index()
 
-    destination = Path(tmpdir).joinpath('destination_collection')
-    destination.mkdir(exist_ok=False)
+    # Expect a destination_path with the same offset (eg "year/LS8_SOMETHING_AROTHER") but in our new base folder.
+    expected_new_path = destination_path.joinpath(*test_dataset.path_offset)
 
-    paths.register_base_directory(destination)
-
-    res = _call_move(
-        # Move one path to destination
-        ['-d', str(destination), str(test_dataset.path)],
+    res: Result = _call_move(
+        # Move one path to destination_path
+        ['-d', str(destination_path), str(test_dataset.path)],
 
         global_integration_cli_args
     )
 
-    print(res.output)
-    assert res.exit_code == 0, res.output
+    _check_successful_move(test_dataset, expected_new_path, other_dataset, res)
 
-    assert destination.exists(), "File was not moved to destination?"
+
+@pytest.mark.xfail(reason="Not yet implemented", strict=True)
+def test_move_when_already_exists_at_dest(global_integration_cli_args,
+                                          test_dataset: DatasetForTests,
+                                          other_dataset: DatasetForTests,
+                                          destination_path):
+    """
+    Move a dataset to a new location, but it already exists and is valid at the destination
+
+    This situation arose in real usage when datasets were
+    1) moved, without cleaning up the archived datasets
+    2) and then moved back (archived destination exists already).
+    """
+    test_dataset.add_to_index()
+    other_dataset.add_to_index()
+
+    expected_new_path = destination_path.joinpath(*test_dataset.path_offset)
+
+    # Preemptively copy dataset to destination.
+    shutil.copytree(str(test_dataset.copyable_path), str(expected_new_path.parent))
+
+    res = _call_move(
+        # Move one path to destination_path
+        ['-d', str(destination_path), str(test_dataset.path)],
+
+        global_integration_cli_args
+    )
+
+    _check_successful_move(test_dataset, expected_new_path, other_dataset, res)
+
+
+def test_move_when_corrupt_exists_at_dest(global_integration_cli_args,
+                                          test_dataset: DatasetForTests,
+                                          other_dataset: DatasetForTests,
+                                          destination_path):
+    """
+    Move a dataset to a location that already exists but is invalid.
+
+    It should see that the destination is corrupt and skip the move.
+    """
+    test_dataset.add_to_index()
+    other_dataset.add_to_index()
+
+    expected_new_path: Path = destination_path.joinpath(*test_dataset.path_offset)
+
+    # Create a corrupt dataset at destination
+    expected_new_path.parent.mkdir(parents=True)
+    expected_new_path.write_text("invalid")
+
+    original_index = as_map(test_dataset.collection.index_)
+    res = _call_move(
+        # Move one path to destination_path
+        ['-d', str(destination_path), str(test_dataset.path)],
+
+        global_integration_cli_args
+    )
+
+    # Move script should have completed, but dataset should have been skipped.
+    assert res.exit_code == 0, res.output
+    print(res.output)
+
+    now_index = as_map(test_dataset.collection.index_)
+
+    assert original_index == now_index
+
+    assert test_dataset.path.exists()
+
+
+def _check_successful_move(test_dataset: DatasetForTests,
+                           expected_new_path: Path,
+                           unrelated_untouched_dataset: DatasetForTests,
+                           res: Result):
+    assert res.exit_code == 0, res.output
+    print(res.output)
+
+    assert expected_new_path.exists(), "File was not moved to destination_path?"
     assert test_dataset.path.exists(), "Old file was deleted: should only have been archived"
 
-    # Expect a destination with the same offset (eg "year/LS8_SOMETHING_AROTHER") but in our new base folder.
-    expected_new_path = destination.joinpath(*test_dataset.path_offset)
     expected_new_uri = expected_new_path.as_uri()
 
     # All three uris should be in the system still.
@@ -48,9 +130,8 @@ def test_move(global_integration_cli_args,
         # The new uri
         expected_new_uri,
         # The other dataset unchanged
-        other_dataset.uri
+        unrelated_untouched_dataset.uri
     }
-
     # ... but only the new uri is active, so the moved dataset should only list that one:
     dataset = test_dataset.get_index_record()
     assert dataset is not None, "Moved dataset is no longer indexed??"

--- a/integration_tests/test_move.py
+++ b/integration_tests/test_move.py
@@ -2,46 +2,32 @@ from pathlib import Path
 
 from click.testing import CliRunner, Result
 
-from digitalearthau import move, collections, paths
-from digitalearthau.collections import Collection
-from digitalearthau.index import add_dataset
-from integration_tests.conftest import DatasetOnDisk
-
-import pytest
-import structlog
-from dateutil import tz
+from digitalearthau import move, paths
+from integration_tests.conftest import DatasetForTests
 
 
-def test_move(global_integration_cli_args, test_dataset: DatasetOnDisk, other_dataset: DatasetOnDisk, tmpdir):
+def test_move(global_integration_cli_args,
+              test_dataset: DatasetForTests,
+              other_dataset: DatasetForTests,
+              tmpdir):
     """
-    With two datasets in a collection, try to move one.
+    With two datasets in a collection, try to move one to a new disk location.
+
+    One should be unchanged, the other should be moved.
     """
-
-    # Add second dataset
-    add_dataset(test_dataset.collection.index, test_dataset.dataset.id, test_dataset.uri)
-    add_dataset(other_dataset.collection.index, other_dataset.dataset.id, other_dataset.uri)
-
-    # Move one dataset.
-
-    runner = CliRunner()
+    test_dataset.add_to_index()
+    other_dataset.add_to_index()
 
     destination = Path(tmpdir).joinpath('destination_collection')
     destination.mkdir(exist_ok=False)
 
     paths.register_base_directory(destination)
 
-    # dest_collection = Collection(
-    #     name='ls8_scene_dest',
-    #     query={},
-    #
-    #     index=test_dataset.collection.index
-    # )
-    # collections._add(dest_collection)
+    res = _call_move(
+        # Move one path to destination
+        ['-d', str(destination), str(test_dataset.path)],
 
-    res: Result = runner.invoke(
-        move.cli,
-        [*global_integration_cli_args, '-d', str(destination), str(test_dataset.path)],
-        catch_exceptions=False
+        global_integration_cli_args
     )
 
     print(res.output)
@@ -50,20 +36,32 @@ def test_move(global_integration_cli_args, test_dataset: DatasetOnDisk, other_da
     assert destination.exists(), "File was not moved to destination?"
     assert test_dataset.path.exists(), "Old file was deleted: should only have been archived"
 
-    # Only the destination should be active now, so only it will be returned in search
-
-    all_indexed_uris = set(test_dataset.collection.iter_index_uris())
-    # The 'other' dataset should be unchanged.
+    # Expect a destination with the same offset (eg "year/LS8_SOMETHING_AROTHER") but in our new base folder.
     expected_new_path = destination.joinpath(*test_dataset.path_offset)
+    expected_new_uri = expected_new_path.as_uri()
+
+    # All three uris should be in the system still.
+    all_indexed_uris = set(test_dataset.collection.iter_index_uris())
     assert all_indexed_uris == {
         # The old uri one still indexed (but archived)
         test_dataset.uri,
         # The new uri
-        expected_new_path.as_uri(),
+        expected_new_uri,
         # The other dataset unchanged
         other_dataset.uri
     }
 
-    dataset = test_dataset.collection.index.get(test_dataset.dataset.id)
+    # ... but only the new uri is active, so the moved dataset should only list that one:
+    dataset = test_dataset.get_index_record()
+    assert dataset is not None, "Moved dataset is no longer indexed??"
+    assert dataset.uris == [expected_new_uri], "Expect only the newly moved location to be listed for the dataset"
 
-    test_dataset.collection.iter_index_uris()
+
+def _call_move(args, global_integration_cli_args) -> Result:
+    # We'll call the cli interface itself, rather than the python api, to get wider coverage in our test.
+    res: Result = CliRunner().invoke(
+        move.cli,
+        [*global_integration_cli_args, *args],
+        catch_exceptions=False
+    )
+    return res

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,10 @@ setup(
     author='Geoscience Australia',
     license='Apache License 2.0',
 
-    packages=find_packages(),
+    packages=find_packages(
+        exclude=('tests', 'tests.*',
+                 'integration_tests', 'integration_tests.*')
+    ),
     package_data={
         '': ['*.yaml', '*/*.yaml'],
     },

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
             'dea-coherence = digitalearthau.coherence:main',
             'dea-duplicates = digitalearthau.duplicates:main',
             'dea-harvest = digitalearthau.harvest.iso19115:main',
-            'dea-move = digitalearthau.move:main',
+            'dea-move = digitalearthau.move:cli',
             'dea-submit-ingest = digitalearthau.submit.ingest:cli',
             'dea-submit-ncmler = digitalearthau.submit.ncmler:cli',
             'dea-submit-sync = digitalearthau.sync.submit_job:main',


### PR DESCRIPTION
There's one move test marked as xfail: it tests whether you can move a dataset when the destination already exists. But this is no longer likely to be implemented this week, so I've left it disabled. The current behavior is to skip those datasets, logging a warning.