### PR TITLE
October miscellaneous

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ docs/html/
 
 # Generated Documentation
 docs/dev/generate/
+
+# MYPY static type checker cache
+.mypy_cache

--- a/modules/agdc/package-module.sh
+++ b/modules/agdc/package-module.sh
@@ -101,21 +101,6 @@ fi
 popd
 
 
-read -p "Do you want to also install datacube-stats? [y/N]" -n 1 -r
-echo    # (optional) move to a new line
-if [[ $REPLY =~ ^[Yy]$ ]]
-then
-    export PYTHONPATH=${PYTHONPATH:+${PYTHONPATH}:}${python_dest}
-    # Install datacube-stats as well
-    rm -rf agdc_statistics > /dev/null 2>&1
-    git clone https://github.com/GeoscienceAustralia/agdc_statistics.git
-    pushd agdc_statistics
-    python setup.py sdist
-    pip install dist/*.tar.gz --no-deps --prefix "${package_dest}"
-    popd
-fi
-
-
 # Should be immutable once built.
 chmod -R a-w "${package_dest}"
 

--- a/modules/py-environment/environment.yaml
+++ b/modules/py-environment/environment.yaml
@@ -60,7 +60,7 @@ dependencies:
 - psutil
 - psycopg2
 - py6s
-- pylint = 1.6.4
+- pylint
 - pytables
 - pytest
 - pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 import versioneer
 
-tests_require = ['pytest', 'pytest-cov', 'mock', 'pep8', 'pylint==1.6.4', 'hypothesis', 'compliance-checker']
+tests_require = ['pytest', 'pytest-cov', 'mock', 'pep8', 'pylint', 'hypothesis', 'compliance-checker']
 
 extras_require = {
     'doc': ['Sphinx', 'setuptools', 'sphinx_rtd_theme'],


### PR DESCRIPTION
- Don't install `agdc-statistics` with `datacube-core`. We're going to keep it in a separate module now, so that when we want a new release of it we don't need a new release of anything else.
- I don't recall why pylint was pinned to 1.6.4 everywhere, but that release is broken for me...
- Ignore mypy cache directory, to hopefully start running static type checks across the codebase with mypy
