### PR TITLE
Fix sync cli argument reference

### DIFF
--- a/digitalearthau/sync/__init__.py
+++ b/digitalearthau/sync/__init__.py
@@ -55,7 +55,7 @@ _LOG = structlog.get_logger()
 @click.option('-o', '--output', 'output_file',
               type=click.Path(writable=True, dir_okay=False),
               help="Output to file instead of stdout")
-@click.argument('collections', 'collection_specifiers',
+@click.argument('collection_specifiers',
                 # help = "Either names of collections or subfolders of collections"
                 nargs=-1, )
 @ui.pass_index(expect_initialised=False)


### PR DESCRIPTION
Two names in the click option lead to errors on every call. 

I'm adding to the todo list that the integration tests should call the cli layer, not the python api, to cover it too. But there's a little too much work involved to do this before today's release (and the cli layer is quite thin, so is easy to test). I've run a sync manually on my machine to confirm.
