### PR TITLE
Add a DEA TaskApp version of Stacker

### DIFF
--- a/digitalearthau/qsub.py
+++ b/digitalearthau/qsub.py
@@ -646,8 +646,9 @@ def with_qsub_runner():
         state(ctx).qsize = value
 
     def capture_qsub(ctx, param, value):
+        if value is None:
+            return
         state(ctx).qsub = value
-        return value
 
     def decorate(f):
         opts = [

--- a/digitalearthau/runners/util.py
+++ b/digitalearthau/runners/util.py
@@ -37,7 +37,8 @@ def init_task_app(
     work_path = paths.get_product_work_directory(
         # First is the primary...
         output_product=output_products[0],
-        time=task_datetime
+        time=task_datetime,
+        task_type=job_type
     )
     _LOG.info("Created work directory %s", work_path)
 

--- a/digitalearthau/stacker.py
+++ b/digitalearthau/stacker.py
@@ -127,7 +127,7 @@ def make_tag(task_desc: TaskDescription):
 def generate(index: Index,
              task_desc_file: str,
              no_qsub: bool):
-    config, task_desc = _make_config_and_description(index, Path(task_desc_file), tag)
+    config, task_desc = _make_config_and_description(index, Path(task_desc_file))
 
     num_tasks_saved = task_app.save_tasks(
         config,

--- a/digitalearthau/stacker.py
+++ b/digitalearthau/stacker.py
@@ -3,22 +3,26 @@ A DEA version of `stacker` from ODC
 
 Uses the exact same implementation, but wraps it in QSUB Running/Event logging goodness.
 
-As such, it is a three step process:
+As such, it is a three step process, with the second two happening automatically after the first:
+
 1. Submit
-    Submit a single threaded PBS job to calculate how big the requested job is.
- - Executes very quickly
- - Creates the 'job' directory which groups logs and metadata about all the steps
- - Schedules a 'Generate' job to run through PBS
+
+ Submit a single threaded PBS job to calculate how big the requested job is.
+ This step executes very quickly, creates the 'job' directory which groups log files
+ and metadata for the full job, then finally schedules a 'generate' job to run using
+ PBS qsub.
 
 2. Generate
-    Run as a single threaded process inside PBS
-    calculate how much work is required,
-    write the tasks out to a task file,
-    Schedule another PBS job of an appropriate size to 'Run' the stacking
+
+ Run as a single threaded process inside PBS to:
+ calculate how much work is required,
+ write the tasks out to a task file and then
+ schedule another PBS job of an appropriate size to 'Run' the stacking
 
 3. Run
-  Do all of the stacking. Spin up a Redis queue and use celery to farm the tasks
-  out across a large PBS job.
+
+ Do all of the stacking. Spin up a Redis queue and use celery to farm the tasks
+ out across a large PBS job.
 """
 import logging
 from datetime import datetime
@@ -49,7 +53,7 @@ _LOG = logging.getLogger(__file__)
 APP_NAME = 'dea-stacker'
 
 
-@click.group(help='DEA Stacker')
+@click.group(help='DEA Stacker\n\n' + __doc__)
 @click.version_option(version=__version__)
 def cli():
     pass
@@ -82,7 +86,7 @@ def submit(index: Index,
     app_config = paths.read_document(app_config_path)
 
     task_desc, task_path = init_task_app(
-        job_type="stacking",
+        job_type="stack",
         source_products=[app_config['output_product']],  # With stacker, source=output
         output_products=[app_config['output_product']],  # With stacker, source=output
         # TODO: Use @datacube.ui.click.parsed_search_expressions to allow params other than time from the cli?

--- a/digitalearthau/stacker.py
+++ b/digitalearthau/stacker.py
@@ -188,9 +188,9 @@ def _make_config_and_description(index: Index, task_desc_path: Path) -> Tuple[di
 def estimate_job_size(num_tasks):
     """ Translate num_tasks to number of nodes and walltime
     """
-    max_nodes = 20
+    max_nodes = 5
     cores_per_node = 16
-    task_time_mins = 5
+    task_time_mins = 10
 
     if num_tasks < max_nodes * cores_per_node:
         nodes = ceil(num_tasks / cores_per_node / 4)  # If fewer tasks than max cores, try to get 4 tasks to a core
@@ -200,9 +200,7 @@ def estimate_job_size(num_tasks):
     tasks_per_cpu = ceil(num_tasks / (nodes * cores_per_node))
     wall_time_mins = '{mins}m'.format(mins=(task_time_mins * tasks_per_cpu))
 
-    #    return nodes, wall_time_mins
-    # TODO: Replace with something specific to stacker
-    return 1, '120m'
+    return nodes, wall_time_mins
 
 
 @cli.command(help='Process all tasks in a task file')

--- a/digitalearthau/stacker.py
+++ b/digitalearthau/stacker.py
@@ -140,7 +140,7 @@ def generate(index: Index,
 
     num_tasks_saved = task_app.save_tasks(
         config,
-        stacker.make_stacker_tasks(index, config, query=task_desc.parameters.query),
+        stacker.make_stacker_tasks(index, config, **task_desc.parameters.query),
         task_desc.runtime_state.task_serialisation_path
     )
     _LOG.info('Found and saved %d tasks', num_tasks_saved)

--- a/digitalearthau/stacker.py
+++ b/digitalearthau/stacker.py
@@ -177,7 +177,7 @@ def _make_config_and_description(index: Index, task_desc_path: Path) -> Tuple[di
     config = paths.read_document(app_config)
 
     config['output_type'] = config['output_product']  # TODO: Temporary until ODC code is updated
-    config['app_config_file'] = Path(app_config)
+    config['app_config_file'] = str(app_config)
     config = stacker.make_stacker_config(index, config)
     config['taskfile_version'] = make_tag(task_desc)
     config['version'] = digitalearthau.__version__ + ' ' + datacube.__version__

--- a/digitalearthau/stacker.py
+++ b/digitalearthau/stacker.py
@@ -216,7 +216,8 @@ def estimate_job_size(num_tasks):
 def run(index,
         dry_run: bool,
         task_desc_file: str,
-        runner: TaskRunner):
+        runner: TaskRunner,
+        qsub):
     _LOG.info('Starting DEA Stacker processing...')
 
     task_desc = serialise.load_structure(Path(task_desc_file), TaskDescription)

--- a/digitalearthau/stacker.py
+++ b/digitalearthau/stacker.py
@@ -33,6 +33,8 @@ from typing import Tuple
 
 import click
 
+import datacube
+import digitalearthau
 from datacube.api.query import Query
 from datacube.index._api import Index
 from datacube.ui import click as ui
@@ -178,6 +180,7 @@ def _make_config_and_description(index: Index, task_desc_path: Path) -> Tuple[di
     config['app_config_file'] = Path(app_config)
     config = stacker.make_stacker_config(index, config)
     config['taskfile_version'] = make_tag(task_desc)
+    config['version'] = digitalearthau.__version__ + ' ' + datacube.__version__
 
     return config, task_desc
 

--- a/digitalearthau/stacker.py
+++ b/digitalearthau/stacker.py
@@ -1,0 +1,254 @@
+"""
+A DEA version of `stacker` from ODC
+
+Uses the exact same implementation, but wraps it in QSUB Running/Event logging goodness.
+
+As such, it is a three step process:
+1. Submit
+    Submit a single threaded PBS job to calculate how big the requested job is.
+ - Executes very quickly
+ - Creates the 'job' directory which groups logs and metadata about all the steps
+ - Schedules a 'Generate' job to run through PBS
+
+2. Generate
+    Run as a single threaded process inside PBS
+    calculate how much work is required,
+    write the tasks out to a task file,
+    Schedule another PBS job of an appropriate size to 'Run' the stacking
+
+3. Run
+  Do all of the stacking. Spin up a Redis queue and use celery to farm the tasks
+  out across a large PBS job.
+"""
+import logging
+from datetime import datetime
+from functools import partial
+from math import ceil
+from pathlib import Path
+from typing import Tuple
+
+import click
+
+from datacube.api.query import Query
+from datacube.index._api import Index
+from datacube.ui import click as ui
+from datacube.ui import task_app
+from datacube_apps.stacker import stacker
+from digitalearthau import __version__
+from digitalearthau import paths, serialise
+# pylint: disable=invalid-name
+from digitalearthau.qsub import with_qsub_runner, QSubLauncher, TaskRunner
+from digitalearthau.runners.model import TaskDescription
+from digitalearthau.runners.util import init_task_app, submit_subjob
+
+tag_option = click.option('--tag', type=str,
+                          default='notset',
+                          help='Unique id for the job')
+
+_LOG = logging.getLogger(__file__)
+APP_NAME = 'dea-stacker'
+
+
+@click.group(help='DEA Stacker')
+@click.version_option(version=__version__)
+def cli():
+    pass
+
+
+@cli.command(help='Kick off two stage PBS job')
+@click.option('--project', '-P', default='u46')
+@click.option('--queue', '-q', default='normal',
+              type=click.Choice(['normal', 'express']))
+@click.option('--year', 'time_range',
+              callback=task_app.validate_year,
+              help='Limit the process to a particular year')
+@click.option('--no-qsub', is_flag=True, default=False,
+              help="Skip submitting job")
+@tag_option
+@task_app.app_config_option
+@ui.config_option
+@ui.verbose_option
+@ui.pass_index(app_name=APP_NAME)
+def submit(index: Index,
+           app_config: str,
+           project: str,
+           queue: str,
+           no_qsub: bool,
+           time_range: Tuple[datetime, datetime],
+           tag: str):
+    _LOG.info('Tag: %s', tag)
+
+    app_config_path = Path(app_config).resolve()
+    app_config = paths.read_document(app_config_path)
+
+    task_desc, task_path = init_task_app(
+        job_type="stacking",
+        source_products=[app_config['source_product']],
+        # TODO: Use @datacube.ui.click.parsed_search_expressions to allow params other than time from the cli?
+        datacube_query_args=Query(index=index, time=time_range).search_terms,
+        app_config_path=app_config_path,
+        pbs_project=project,
+        pbs_queue=queue
+    )
+    _LOG.info("Created task description: %s", task_path)
+
+    if no_qsub:
+        _LOG.info('Skipping submission due to --no-qsub')
+        return 0
+
+    submit_subjob(
+        name='generate',
+        task_desc=task_desc,
+        command=[
+            'generate', '-v', '-v',
+            '--task-desc', str(task_path),
+            '--tag', tag
+        ],
+        qsub_params=dict(
+            mem='20G',
+            wd=True,
+            ncpus=1,
+            walltime='1h',
+            name='stack-generate-{}'.format(tag)
+        )
+    )
+
+
+@cli.command(help='Generate Tasks into file and Queue PBS job to process them')
+@click.option('--no-qsub', is_flag=True, default=False, help="Skip submitting qsub for next step")
+@click.option(
+    '--task-desc', 'task_desc_file', help='Task environment description file',
+    required=True,
+    type=click.Path(exists=True, readable=True, writable=False, dir_okay=False)
+)
+@tag_option
+@ui.verbose_option
+@ui.log_queries_option
+@ui.pass_index(app_name=APP_NAME)
+def generate(index: Index,
+             task_desc_file: str,
+             no_qsub: bool,
+             tag: str):
+    _LOG.info('Tag: %s', tag)
+
+    config, task_desc = _make_config_and_description(index, Path(task_desc_file))
+
+    num_tasks_saved = task_app.save_tasks(
+        config,
+        stacker.make_stacker_tasks(index, config, query=task_desc.parameters.query),
+        task_desc.runtime_state.task_serialisation_path
+    )
+    _LOG.info('Found %d tasks', num_tasks_saved)
+
+    if not num_tasks_saved:
+        _LOG.info("No tasks. Finishing.")
+        sys.exit(0)
+
+    nodes, walltime = estimate_job_size(num_tasks_saved)
+    _LOG.info('Will request %d nodes and %s time', nodes, walltime)
+
+    if no_qsub:
+        _LOG.info('Skipping submission due to --no-qsub')
+        return 0
+
+    submit_subjob(
+        name='run',
+        task_desc=task_desc,
+
+        command=[
+            'run',
+            '-vv',
+            '--task-desc', str(task_desc_file),
+            '--celery', 'pbs-launch',
+            '--tag', tag,
+        ],
+        qsub_params=dict(
+            name='stack-run-{}'.format(tag),
+            mem='small',
+            wd=True,
+            nodes=nodes,
+            walltime=walltime
+        ),
+    )
+
+
+def _make_config_and_description(index: Index, task_desc_path: Path) -> Tuple[dict, TaskDescription]:
+    task_desc = serialise.load_structure(task_desc_path, TaskDescription)
+
+    task_time: datetime = task_desc.task_dt
+    app_config = task_desc.runtime_state.config_path
+
+    config = paths.read_document(app_config)
+
+    # TODO: This carries over the old behaviour of each load. Should probably be replaced with *tag*
+    config['task_timestamp'] = int(task_time.timestamp())
+    config['app_config_file'] = Path(app_config)
+    config = stacker.make_stacker_config(index, config)
+
+    return config, task_desc
+
+
+def estimate_job_size(num_tasks):
+    """ Translate num_tasks to number of nodes and walltime
+    """
+    max_nodes = 20
+    cores_per_node = 16
+    task_time_mins = 5
+
+    # TODO: Tune this code:
+    # "We have found for best throughput 25 nodes can produce about 11.5 tiles per minute per node,
+    # with a CPU efficiency of about 96%."
+    if num_tasks < max_nodes * cores_per_node:
+        nodes = ceil(num_tasks / cores_per_node / 4)  # If fewer tasks than max cores, try to get 4 tasks to a core
+    else:
+        nodes = max_nodes
+
+    tasks_per_cpu = ceil(num_tasks / (nodes * cores_per_node))
+    wall_time_mins = '{mins}m'.format(mins=(task_time_mins * tasks_per_cpu))
+
+    #    return nodes, wall_time_mins
+    return 1, '120m'
+
+
+@cli.command(help='Actually process generated task file')
+@click.option('--dry-run', is_flag=True, default=False, help='Check if output files already exist')
+@click.option(
+    '--task-desc', 'task_desc_file', help='Task environment description file',
+    required=True,
+    type=click.Path(exists=True, readable=True, writable=False, dir_okay=False)
+)
+@with_qsub_runner()
+@task_app.load_tasks_option
+@tag_option
+@ui.config_option
+@ui.verbose_option
+@ui.pass_index(app_name=APP_NAME)
+def run(index,
+        dry_run: bool,
+        tag: str,
+        task_desc_file: str,
+        qsub: QSubLauncher,
+        runner: TaskRunner,
+        *args, **kwargs):
+    _LOG.info('Starting Fractional Cover processing...')
+    _LOG.info('Tag: %r', tag)
+
+    task_desc = serialise.load_structure(Path(task_desc_file), TaskDescription)
+    config, tasks = task_app.load_tasks(task_desc.runtime_state.task_serialisation_path)
+
+    if dry_run:
+        task_app.check_existing_files((task['filename'] for task in tasks))
+        return 0
+
+    task_func = partial(stacker.do_stack_task, config)
+    process_func = partial(stacker.process_result, index)
+
+    try:
+        runner(task_desc, tasks, task_func, process_func)
+        _LOG.info("Runner finished normally, triggering shutdown.")
+    finally:
+        runner.stop()
+
+
+if __name__ == "__main__":
+    cli()

--- a/digitalearthau/stacker.py
+++ b/digitalearthau/stacker.py
@@ -189,9 +189,6 @@ def estimate_job_size(num_tasks):
     cores_per_node = 16
     task_time_mins = 5
 
-    # TODO: Tune this code:
-    # "We have found for best throughput 25 nodes can produce about 11.5 tiles per minute per node,
-    # with a CPU efficiency of about 96%."
     if num_tasks < max_nodes * cores_per_node:
         nodes = ceil(num_tasks / cores_per_node / 4)  # If fewer tasks than max cores, try to get 4 tasks to a core
     else:
@@ -201,6 +198,7 @@ def estimate_job_size(num_tasks):
     wall_time_mins = '{mins}m'.format(mins=(task_time_mins * tasks_per_cpu))
 
     #    return nodes, wall_time_mins
+    # TODO: Replace with something specific to stacker
     return 1, '120m'
 
 
@@ -212,15 +210,13 @@ def estimate_job_size(num_tasks):
     type=click.Path(exists=True, readable=True, writable=False, dir_okay=False)
 )
 @with_qsub_runner()
-@task_app.load_tasks_option
 @ui.config_option
 @ui.verbose_option
 @ui.pass_index(app_name=APP_NAME)
 def run(index,
         dry_run: bool,
         task_desc_file: str,
-        runner: TaskRunner,
-        *args, **kwargs):
+        runner: TaskRunner):
     _LOG.info('Starting DEA Stacker processing...')
 
     task_desc = serialise.load_structure(Path(task_desc_file), TaskDescription)

--- a/modules/py-environment/environment.yaml
+++ b/modules/py-environment/environment.yaml
@@ -52,8 +52,6 @@ dependencies:
 - openblas
 - openssl
 - pandas
-- pathlib
-- pathlib2
 - pep8
 - pip
 - plotly

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
             'dea-submit-ncmler = digitalearthau.submit.ncmler:cli',
             'dea-submit-sync = digitalearthau.sync.submit_job:main',
             'dea-sync = digitalearthau.sync:cli',
+            'dea-stacker = digitalearthau.stacker:cli',
             'dea-system = digitalearthau.system:cli',
         ]
     },


### PR DESCRIPTION
In an attempt to run all of our tasks in a consistent manner, this PR contains a new tool, `dea-stacker`. It is able to stack individual time slice datasets into a time-deep _stacked NetCDF_ file format. It is hard-coded to stack all available slices for a year into a single file. It operates on the same configuration file as `ingest` or `fc_app`, and so works on the same Grid Specification for tiling.

All the code it runs is pulled in from `datacube_apps.stacker`, but is wrapped in the typical **Submit**, **Generate**, **Run** commands used for running DEA processes on the NCI.

The app is based on `fc_app.py` in the [Fractional Cover Repo](GeoscienceAustralia/fc), which means a mass of duplication. My intention is to have a look at what is required, and replace both with a more extensible type of `TaskApp/DEATaskApp`, but this is work for the future.