### PR TITLE
Improve dea-move to support NetCDF datasets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
     - popd
     - export CPLUS_INCLUDE_PATH="/usr/include/gdal"
     - export C_INCLUDE_PATH="/usr/include/gdal"
-    - travis_retry pip install pylint yamllint pytest-cov pep8 GDAL==1.10.0
+    - travis_retry pip install pylint yamllint pytest-cov pycodestyle GDAL==1.10.0
     # Dask.array seems to need this?
     - travis_retry pip install cloudpickle
     - travis_retry pip install git+https://github.com/GeoscienceAustralia/eo-datasets.git

--- a/check-code.sh
+++ b/check-code.sh
@@ -17,7 +17,7 @@ pylint --rcfile=integration_tests/pylintrc integration_tests/**/*.py
 # E711: "is None" instead of "= None". Duplicates pylint check.
 # E701: "multiple statements on one line" is buggy as it doesn't understand py 3 types
 # E501: "line too long" duplicates pylint check
-pep8 --ignore=E122,E711,E701,E501 --max-line-length 120  \
+pycodestyle --ignore=E122,E711,E701,E501 --max-line-length 120  \
     digitalearthau \
     integration_tests \
     scripts/**/*.py

--- a/digitalearthau/collections.py
+++ b/digitalearthau/collections.py
@@ -198,8 +198,8 @@ def init_nci_collections(index: Index):
             file_patterns=(
                 '/g/data/v10/repackaged/rawdata/0/[0-9][0-9][0-9][0-9]/[0-9][0-9]/*/ga-metadata.yaml',
             ),
-            index_=index,
             unique=('time.lower.day', 'platform'),
+            index_=index,
             trust=Trust.DISK
         )
     )
@@ -210,6 +210,7 @@ def init_nci_collections(index: Index):
             name,
             query,
             file_patterns=file_patterns,
+            index_=index,
             unique=('time.lower.day', 'sat_path.lower', 'sat_row.lower'),
             delete_archived_after_days=delete_archived_after_days,
             # Scenes default to trusting disk. They're atomically written to the destination,
@@ -318,8 +319,8 @@ def init_nci_collections(index: Index):
                     'LS5_TM_{name}/*_*/LS5*{name}*.nc'.format(project=project,
                                                               name=name.upper()),
                 ),
-                index_=index,
                 unique=('time.lower.day', 'lat', 'lon'),
+                index_=index,
                 # Tiles default to trusting index over the disk: they were indexed at the end of the job,
                 # so unfinished tiles could be left on disk.
                 trust=Trust.INDEX
@@ -332,8 +333,8 @@ def init_nci_collections(index: Index):
                     '*_*/LS7*{name}*.nc'.format(project=project,
                                                 name=name.upper()),
                 ),
-                index_=index,
                 unique=('time.lower.day', 'lat', 'lon'),
+                index_=index,
                 # Tiles default to trusting index over the disk: they were indexed at the end of the job,
                 # so unfinished tiles could be left on disk.
                 trust=Trust.INDEX
@@ -346,8 +347,8 @@ def init_nci_collections(index: Index):
                     '*_*/LS8*{name}*.nc'.format(project=project,
                                                 name=name.upper()),
                 ),
-                index_=index,
                 unique=('time.lower.day', 'lat', 'lon'),
+                index_=index,
                 # Tiles default to trusting index over the disk: they were indexed at the end of the job,
                 # so unfinished tiles could be left on disk.
                 trust=Trust.INDEX

--- a/digitalearthau/collections.py
+++ b/digitalearthau/collections.py
@@ -357,7 +357,43 @@ def init_nci_collections(index: Index):
     add_albers_collections('pq')
     add_albers_collections('nbar')
     add_albers_collections('nbart')
-    add_albers_collections('fc', project='fk4')
+
+    # Old FC
+    for sat in ['ls5', 'ls7', 'ls8']:
+        name = 'fc'
+        glob_offset = f'{sat.upper()}_TM_{name}/*_*/{sat.upper()}*{name}*.nc'
+        _add(
+            Collection(
+                name=f'{sat}_{name}_albers',
+                query={'product': '{sat}_{name}_albers'},
+                file_patterns=(
+                    f'/g/data/fk4/datacube/002/' + glob_offset,
+                    f'/g/data/fk4/datacube/.trash/' + glob_offset,
+                ),
+                unique=('time.lower.day', 'lat', 'lon'),
+                # Tiles default to trusting index over the disk: they were indexed at the end of the job,
+                # so unfinished tiles could be left on disk.
+                trust=Trust.INDEX
+            )
+        )
+    # New FC
+    for sat in ['ls5', 'ls7', 'ls8']:
+        name = 'fc'
+        glob_offset = f'{sat.upper()}_TM_{name}/*_*/{sat.upper()}*{name}*.nc'
+        _add(
+            Collection(
+                name=f'{sat}_{name}_albers_staging',
+                query={'product': '{sat}_{name}_albers_staging'},
+                file_patterns=(
+                    f'/g/data/v10/public/data/fc/' + glob_offset,
+                    f'/g/data/fk4/datacube/002/' + glob_offset,
+                ),
+                unique=('time.lower.day', 'lat', 'lon'),
+                # Tiles default to trusting index over the disk: they were indexed at the end of the job,
+                # so unfinished tiles could be left on disk.
+                trust=Trust.INDEX
+            )
+        )
 
     assert get_collection('ls5_fc_albers').file_patterns == (
         '/g/data/fk4/datacube/002/LS5_TM_FC/*_*/LS5*FC*.nc',

--- a/digitalearthau/collections.py
+++ b/digitalearthau/collections.py
@@ -361,7 +361,7 @@ def init_nci_collections(index: Index):
     # Old FC
     for sat in ['ls5', 'ls7', 'ls8']:
         name = 'fc'
-        glob_offset = f'{sat.upper()}_TM_{name}/*_*/{sat.upper()}*{name}*.nc'
+        glob_offset = f'{sat.upper()}_TM_{name.upper()}/*_*/{sat.upper()}*{name.upper()}*.nc'
         _add(
             Collection(
                 name=f'{sat}_{name}_albers',
@@ -379,7 +379,7 @@ def init_nci_collections(index: Index):
     # New FC
     for sat in ['ls5', 'ls7', 'ls8']:
         name = 'fc'
-        glob_offset = f'{sat.upper()}_TM_{name}/*_*/{sat.upper()}*{name}*.nc'
+        glob_offset = f'{sat.upper()}_TM_{name.upper()}/*_*/{sat.upper()}*{name.upper()}*.nc'
         _add(
             Collection(
                 name=f'{sat}_{name}_albers_staging',
@@ -395,9 +395,7 @@ def init_nci_collections(index: Index):
             )
         )
 
-    assert get_collection('ls5_fc_albers').file_patterns == (
-        '/g/data/fk4/datacube/002/LS5_TM_FC/*_*/LS5*FC*.nc',
-    )
+    assert '/g/data/fk4/datacube/002/LS5_TM_FC/*_*/LS5*FC*.nc' in get_collection('ls5_fc_albers').file_patterns
     assert get_collection('ls8_nbar_albers').file_patterns == (
         '/g/data/rs0/datacube/002/LS8_OLI_NBAR/*_*/LS8*NBAR*.nc',
     )

--- a/digitalearthau/move.py
+++ b/digitalearthau/move.py
@@ -98,6 +98,11 @@ def move_all(index: Index, paths: Iterable[Path], destination_base_path: Path, d
 
 class FileMover:
     """
+    Move datasets around on the Filesystem, while keeping the DEA index up to date.
+
+    The move is in terms of the index. Files on disk are copied, and it's a second, later
+    step to remove them from their original location.
+
     There are several types of Datasets we may want to move around.
 
     1. A single file dataset. Eg. A *.nc file with an embedded `datasets` variable containing all metadata

--- a/digitalearthau/move.py
+++ b/digitalearthau/move.py
@@ -48,7 +48,7 @@ def cli(index, dry_run, paths, destination, checksum):
     * Source datasets with failing checksums will be left as-is, with a warning logged.
 
     * Both the source(s) and destination paths are expected to be paths containing existing DEA collections.
-    (See collections.py)
+    (See collections.py and paths.py)
     """
     uiutil.init_logging()
     collections.init_nci_collections(index)

--- a/digitalearthau/paths.py
+++ b/digitalearthau/paths.py
@@ -123,7 +123,7 @@ def split_path_from_base(file_path):
     raise ValueError("Unknown location: can't calculate base directory: " + str(file_path))
 
 
-def write_files(file_dict, containing_dir=None):
+def write_files(files_spec, containing_dir=None):
     """
     Convenience method for writing a tree of files to a temporary directory.
 
@@ -135,21 +135,22 @@ def write_files(file_dict, containing_dir=None):
 
     write_files({'test.txt': 'contents of text file'})
 
-    :param containing_dir: Optionally specify the directory to add the files to.
-    :type file_dict: dict
+    :param containing_dir: Optionally specify the directory to add the files to, otherwise a temporary directory
+                           will be created.
+    :type files_spec: dict
     :rtype: pathlib.Path
     :return: Created temporary directory path
     """
     if not containing_dir:
         containing_dir = Path(tempfile.mkdtemp(suffix='neotestrun'))
 
-    _write_files_to_dir(str(containing_dir), file_dict)
+    _write_files_to_dir(containing_dir, files_spec)
 
     def remove_if_exists(path):
         if os.path.exists(path):
             shutil.rmtree(path)
 
-    atexit.register(remove_if_exists, str(containing_dir))
+    atexit.register(remove_if_exists, containing_dir)
     return containing_dir
 
 

--- a/digitalearthau/paths.py
+++ b/digitalearthau/paths.py
@@ -135,8 +135,8 @@ def write_files(files_spec, containing_dir=None):
 
     write_files({'test.txt': 'contents of text file'})
 
-    :param containing_dir: Optionally specify the directory to add the files to, otherwise a temporary directory
-                           will be created.
+    :param containing_dir: Optionally specify the directory to add the files to,
+                           otherwise a temporary directory will be created.
     :type files_spec: dict
     :rtype: pathlib.Path
     :return: Created temporary directory path

--- a/digitalearthau/paths.py
+++ b/digitalearthau/paths.py
@@ -19,12 +19,14 @@ _LOG = structlog.getLogger()
 
 # This may eventually go to a config file...
 # ".trash" directories will be created at this level for any datasets contained within.
+# TODO: Could these be inferred from the collections paths?
 BASE_DIRECTORIES = [
     '/g/data/fk4/datacube',
     '/g/data/rs0/datacube',
     '/g/data/v10/reprocess',
     '/g/data/rs0/scenes',
     '/short/v10/scenes',
+    '/g/data/v10/public/data',
 ]
 
 # Use a static variable so that trashed items in the same run will be in the same trash bin.

--- a/digitalearthau/sync/submit_job.py
+++ b/digitalearthau/sync/submit_job.py
@@ -19,6 +19,7 @@ from click import style
 
 from datacube.index import index_connect
 from digitalearthau import collections
+from digitalearthau.collections import Trust
 from digitalearthau.paths import get_dataset_paths
 from digitalearthau.sync import scan
 
@@ -128,8 +129,8 @@ class SyncSubmission(object):
                 # Only complete scenes are written to fs, so '--index-missing' instead of trash.
 
                 trust_options = {
-                    'disk': ['--index-missing'],
-                    'index': ['--trash-missing'],
+                    Trust.DISK: ['--index-missing'],
+                    Trust.INDEX: ['--trash-missing'],
                 }
                 if task.collection.trust not in trust_options:
                     raise RuntimeError("Unknown trust type %r", task.collection.trust)

--- a/docs/internal/new_product.rst
+++ b/docs/internal/new_product.rst
@@ -10,6 +10,23 @@ Notes for adding new products to NCI datacube
 .. warning ::
     This is still work in progress
 
+Profile/Module Setup
+--------------------
+
+These instructions assume you have access to the `v10` project on the NCI.
+
+Ensure you have access to both public and private modules, and have loaded
+the `dea-prod` module. It makes sense to include the `module use` commands
+in your `~/.modulerc` or `~/.bashrc` or `~/.bash_profile`, but run the
+`module load` command when required. The `dea-*` module include `DEA`
+customised versions of some of the `ODC` management tools.
+
+.. code-block:: bash
+
+    module use /g/data/v10/private/modules/modulefiles/
+    module use /g/data/v10/private/modules/modulefiles/
+    module load dea-prod
+
 
 Test Database Access
 --------------------

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -166,7 +166,7 @@ def test_dataset(integration_test_data, dea_index) -> DatasetForTests:
         unique=[],
         index_=dea_index
     )
-    collections._add(ls8_collection)
+    collections._add(ls5_nc_collection)
 
     # register this as a base directory so that datasets can be trashed within it.
     register_base_directory(str(test_data))

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -2,6 +2,7 @@ import shutil
 import uuid
 from datetime import datetime
 from pathlib import Path
+from textwrap import dedent
 from typing import Tuple, NamedTuple, Optional, Mapping, Iterable
 
 import pytest
@@ -58,9 +59,9 @@ def load_yaml_file(path):
 
 @pytest.fixture
 def integration_test_data(tmpdir):
-    d = tmpdir.join('integration_data')
-    shutil.copytree(str(INTEGRATION_TEST_DATA), str(d))
-    return Path(str(d))
+    temp_data_dir = Path(tmpdir) / 'integration_data'
+    shutil.copytree(INTEGRATION_TEST_DATA, temp_data_dir)
+    return temp_data_dir
 
 
 ON_DISK2_ID = DatasetLite(uuid.UUID('10c4a9fe-2890-11e6-8ec8-a0000100fe80'))
@@ -192,21 +193,20 @@ def other_dataset(integration_test_data: Path, test_dataset: DatasetForTests) ->
     paths.write_files(
         {
             'LS8_INDEXED_ALREADY': {
-                'ga-metadata.yaml': ("""
-id: %s
-platform:
-    code: LANDSAT_8
-instrument:
-    name: OLI_TIRS
-format:
-    name: GeoTIFF
-product_type: level1
-product_level: L1T
-image:
-    bands: {}
-lineage:
-    source_datasets: {}
-    """ % str(ds_id)),
+                'ga-metadata.yaml': (dedent("""\
+                                     id: %s
+                                     platform:
+                                         code: LANDSAT_8
+                                     instrument:
+                                         name: OLI_TIRS
+                                     format:
+                                         name: GeoTIFF
+                                     product_type: level1
+                                     product_level: L1T
+                                     image:
+                                         bands: {}
+                                     lineage:
+                                         source_datasets: {}""" % str(ds_id))),
                 'dummy-file.txt': ''
             }
         },

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -240,7 +240,7 @@ def archive_dataset(dataset_id, collection, archived_dt=None):
             )
 
 
-def as_map(index: Index) -> Mapping[DatasetLite, Iterable[str]]:
+def freeze_index(index: Index) -> Mapping[DatasetLite, Iterable[str]]:
     """
     All contained (dataset_id, [location]) values, to check test results.
     """

--- a/integration_tests/data/example_fc_dataset.yaml
+++ b/integration_tests/data/example_fc_dataset.yaml
@@ -1,0 +1,71 @@
+creation_dt: '2017-10-20T11:16:35.598998'
+extent:
+  center_dt: '1989-09-07T00:12:31.500000'
+  coord:
+    ll: {lat: -36.586929923540985, lon: 134.20244074953945}
+    lr: {lat: -36.586530293219305, lon: 134.2308942253773}
+    ul: {lat: -36.50043883542415, lon: 134.2005996670824}
+    ur: {lat: -36.5000396442146, lon: 134.2290293674532}
+  from_dt: '1989-09-07T00:12:31.500000'
+  to_dt: '1989-09-07T00:12:31.500000'
+format: {name: NetCDF}
+grid_spatial:
+  projection:
+    geo_ref_points:
+      ll: {x: 100000.0, y: -4000000.0}
+      lr: {x: 200000.0, y: -4000000.0}
+      ul: {x: 100000.0, y: -3900000.0}
+      ur: {x: 200000.0, y: -3900000.0}
+    spatial_reference: EPSG:3577
+    valid_data:
+      coordinates:
+      - - [200000.0, -4000000.0]
+        - [197448.63290386382, -4000000.0]
+        - [200000.0, -3990416.9091419443]
+        - [200000.0, -4000000.0]
+      type: Polygon
+id: a402cb5a-df15-4f90-af18-c635f743a3c5
+image:
+  bands:
+    BS: {layer: BS, path: ''}
+    NPV: {layer: NPV, path: ''}
+    PV: {layer: PV, path: ''}
+    UE: {layer: UE, path: ''}
+instrument: {name: TM}
+lineage:
+  algorithm:
+    name: datacube-fc
+    parameters: {configuration_file: /g/data2/v10/public/modules/fc/1.2.4/lib/python3.6/site-packages/fc/config/ls5_fc_albers.yaml}
+    repo_url: https://github.com/GeoscienceAustralia/fc.git
+    version: 1.2.4
+  machine:
+    hostname: r1626
+    software_versions:
+      datacube: {repo_url: 'https://github.com/opendatacube/datacube-core.git', version: 1.5.3}
+      python: {version: "3.6.3 | packaged by conda-forge | (default, Oct  5 2017,
+          14:07:33) n[GCC 4.8.2 20140120 (Red Hat 4.8.2-15)]"}
+    uname: 'Linux r1626 3.10.0-693.2.1.el6.x86_64 #1 SMP Thu Sep 7 10:50:09 AEST 2017
+      x86_64'
+  source_datasets:
+    '0':
+      creation_dt: '2016-07-27T05:23:08.759021'
+      extent:
+        center_dt: '1989-09-07T00:12:31.500000'
+        coord:
+          ll: {lat: -36.586929923541, lon: 134.20244074953945}
+          lr: {lat: -36.586530293219305, lon: 134.23089422537734}
+          ul: {lat: -36.50043883542418, lon: 134.20059966708243}
+          ur: {lat: -36.50003964421462, lon: 134.22902936745322}
+        from_dt: '1989-09-07T00:12:31.500000'
+        to_dt: '1989-09-07T00:12:31.500000'
+      format: {name: NetCDF}
+      grid_spatial:
+        projection:
+          geo_ref_points:
+            ll: {x: 100000.0, y: -4000000.0}
+            lr: {x: 200000.0, y: -4000000.0}
+            ul: {x: 100000.0, y: -3900000.0}
+            ur: {x: 200000.0, y: -3900000.0}
+          spatial_reference: EPSG:3577
+platform: {code LANDSAT_5}
+product_typ: fractional_cover

--- a/integration_tests/data/example_nbar_dataset.yaml
+++ b/integration_tests/data/example_nbar_dataset.yaml
@@ -30,13 +30,27 @@ grid_spatial:
 id: 6b8d2798-cbc2-4244-847f-807cd068e9ad
 image:
   bands:
-    blue: {layer: blue, path:}
-    coastal_aerosol: {layer: coastal_aerosol, path:}
-    green: {layer: green, path:}
-    nir: {layer: nir, path:}
-    red: {layer: red, path:}
-    swir1: {layer: swir1, path:}
-    swir2: {layer: swir2, path:}
+    blue:
+      layer: blue
+      path: ''
+    coastal_aerosol:
+      layer: coastal_aerosol
+      path: ''
+    green:
+      layer: green
+      path: ''
+    nir:
+      layer: nir
+      path: ''
+    red:
+      layer: red
+      path: ''
+    swir1:
+      layer: swir1
+      path: ''
+    swir2:
+      layer: swir2
+      path: ''
 instrument: {name: OLI_TIRS}
 lineage:
   algorithm:

--- a/integration_tests/data/example_nbar_dataset.yaml
+++ b/integration_tests/data/example_nbar_dataset.yaml
@@ -1,0 +1,56 @@
+creation_dt: 2017-10-19T15:50:54.259199
+extent:
+  center_dt: 2016-10-18T00:00:35.500000
+  coord:
+    ll: {lat: -25.73901694876295, lon: 149.19794273627843}
+    lr: {lat: -25.615849571403892, lon: 150.19633085878846}
+    ul: {lat: -25.105819069649144, lon: 149.10153765505237}
+    ur: {lat: -24.983280846371933, lon: 150.09447584223076}
+  from_dt: 2016-10-18T00:00:35.500000
+  to_dt: 2016-10-18T00:00:35.500000
+format: {name: NetCDF}
+grid_spatial:
+  projection:
+    geo_ref_points:
+      ll: {x: 1700000.0, y: -2900000.0}
+      lr: {x: 1800000.0, y: -2900000.0}
+      ul: {x: 1700000.0, y: -2800000.0}
+      ur: {x: 1800000.0, y: -2800000.0}
+    spatial_reference: EPSG:3577
+    valid_data:
+      coordinates:
+      - - [1788394.306068444, -2900000.0]
+        - [1700000.0, -2900000.0]
+        - [1700000.0, -2828381.055575777]
+        - [1714967.6157059935, -2833988.74335441]
+        - [1800000.0, -2865861.784622513]
+        - [1800000.0, -2868026.3247520067]
+        - [1788394.306068444, -2900000.0]
+      type: Polygon
+id: 6b8d2798-cbc2-4244-847f-807cd068e9ad
+image:
+  bands:
+    blue: {layer: blue, path:}
+    coastal_aerosol: {layer: coastal_aerosol, path:}
+    green: {layer: green, path:}
+    nir: {layer: nir, path:}
+    red: {layer: red, path:}
+    swir1: {layer: swir1, path:}
+    swir2: {layer: swir2, path:}
+instrument: {name: OLI_TIRS}
+lineage:
+  algorithm:
+    name: datacube-ingest
+    parameters: {configuration_file: ls8_nbar_albers.yaml}
+    repo_url: https://github.com/GeoscienceAustralia/datacube-ingester.git
+    version: ${version}
+  machine:
+    hostname: r2983
+    software_versions:
+      datacube: {repo_url: 'https://github.com/opendatacube/datacube-core.git', version: 1.5.3}
+      python: {version: "3.6.3 | packaged by conda-forge | (default, Oct  5 2017,
+          14:07:33) \\n[GCC 4.8.2 20140120 (Red Hat 4.8.2-15)]"}
+    uname: 'Linux r2983 3.10.0-693.2.1.el6.x86_64 #1 SMP Thu Sep 7 10:50:09 AEST 2017 x86_64'
+  source_datasets: {}
+platform: {code: LANDSAT_8}
+product_type: nbar

--- a/integration_tests/test_full_sync.py
+++ b/integration_tests/test_full_sync.py
@@ -14,11 +14,10 @@ from datacube.index._api import Index
 from datacube.utils import uri_to_local_path
 from digitalearthau import paths
 from digitalearthau.collections import Collection
-from digitalearthau.index import DatasetLite, add_dataset
+from digitalearthau.index import DatasetLite
 from digitalearthau.paths import register_base_directory
 from digitalearthau.sync import differences as mm, fixes, scan, Mismatch
-
-from integration_tests.conftest import DatasetForTests, as_map
+from integration_tests.conftest import DatasetForTests, freeze_index
 
 
 # These are ok in tests.
@@ -183,7 +182,7 @@ def test_detect_corrupt_existing(test_dataset: DatasetForTests,
             mm.UnreadableDataset(None, test_dataset.uri)
         ],
         # Unmodified index
-        expected_index_result=as_map(test_dataset.collection.index_),
+        expected_index_result=freeze_index(test_dataset.collection.index_),
         cache_path=integration_test_data,
         fix_settings=dict(trash_missing=True, trash_archived=True, update_locations=True)
     )
@@ -246,7 +245,7 @@ def test_remove_missing(test_dataset: DatasetForTests,
             mm.DatasetNotIndexed(test_dataset.dataset, test_dataset.uri)
         ],
         # Unmodified index
-        expected_index_result=as_map(test_dataset.collection.index_),
+        expected_index_result=freeze_index(test_dataset.collection.index_),
         cache_path=integration_test_data,
         fix_settings=dict(trash_missing=True, update_locations=True)
     )
@@ -393,12 +392,12 @@ def _check_mismatch_fix(index: Index,
     """Check that the index is correctly updated when fixing mismatches"""
 
     # First check that no change is made to the index if we have all fixes set to False.
-    starting_index = as_map(index)
+    starting_index = freeze_index(index)
     # Default settings are all false.
     fixes.fix_mismatches(mismatches, index)
-    assert starting_index == as_map(index), "Changes made to index despite all fix settings being " \
-                                            "false (index_missing=False etc)"
+    assert starting_index == freeze_index(index), "Changes made to index despite all fix settings being " \
+                                                  "false (index_missing=False etc)"
 
     # Now perform fixes, check that they match expected.
     fixes.fix_mismatches(mismatches, index, **fix_settings)
-    assert expected_index_result == as_map(index)
+    assert expected_index_result == freeze_index(index)

--- a/integration_tests/test_move.py
+++ b/integration_tests/test_move.py
@@ -94,7 +94,7 @@ def test_nc_move(global_integration_cli_args,
 def test_move_when_already_exists_at_dest(global_integration_cli_args,
                                           test_dataset: DatasetForTests,
                                           other_dataset: DatasetForTests,
-                                          base_directory):
+                                          target_directory):
     """
     Move a dataset to a new location, but it already exists and is valid at the destination
 
@@ -105,13 +105,13 @@ def test_move_when_already_exists_at_dest(global_integration_cli_args,
     test_dataset.add_to_index()
     other_dataset.add_to_index()
 
-    expected_new_path = base_directory.joinpath(*test_dataset.path_offset)
+    expected_new_path = target_directory.joinpath(*test_dataset.path_offset)
 
     # Preemptively copy dataset to destination.
     shutil.copytree(str(test_dataset.copyable_path), str(expected_new_path.parent))
 
     # Move one path to destination_path
-    res = _call_move(['--destination', base_directory, test_dataset.path], global_integration_cli_args)
+    res = _call_move(['--destination', target_directory, test_dataset.path], global_integration_cli_args)
 
     _check_successful_move(test_dataset, expected_new_path, other_dataset, res)
 

--- a/modules/py-environment/environment.yaml
+++ b/modules/py-environment/environment.yaml
@@ -64,7 +64,7 @@ dependencies:
 - pytest-cov
 - python-dateutil
 - pyyaml
-- rasterio >=0.9 # required for zip reading, 0.9 gets around 1.0a ordering problems
+- rasterio >=0.9  # required for zip reading, 0.9 gets around 1.0a ordering problems
 - redis
 - redis-py
 - rtree


### PR DESCRIPTION
Add support to `dea-move` to move datasets comprising ODC NetCDF files. These files don't contain a separate checksum file, so it is necessary to run `dea-move` with the `--no-checksum` option.

I've also implemented a test for moving of these types of files, and made a few refactors to try and improve the code readability.

Also:
- Include new directories to `paths.py` and `collections.py` for Fractional Cover Dataset management
- Improve documentation on creating new Products on the NCI