### PR TITLE
Capture CLI `--qsub` argument

### DIFF
--- a/digitalearthau/qsub.py
+++ b/digitalearthau/qsub.py
@@ -649,6 +649,7 @@ def with_qsub_runner():
         if value is None:
             return
         state(ctx).qsub = value
+        return value
 
     def decorate(f):
         opts = [


### PR DESCRIPTION
The function `capture_qsub` is supposed to return the supplied value of the `--qsub` parameter in addition to storing it in the state object. It did in its original implementation in the `agdc_statistics` but somehow after the port it is not doing that anymore.

- Return the captured `value` for the `--qsub` parameter from `capture_qsub`