### PR TITLE
Publish DEA modules to the public directory

### DIFF
--- a/modules/dea/package-module.sh
+++ b/modules/dea/package-module.sh
@@ -13,7 +13,7 @@ umask 002
 
 # Default module dirs. You can set the variables before calling this script to override them.
 agdc_module_dir="${agdc_module_dir:-/g/data/v10/public/modules}"
-module_dir="${module_dir:-/g/data/v10/private/modules}"
+module_dir="${module_dir:-/g/data/v10/public/modules}"
 
 
 if [[ $# -lt 1 ]] || [[ "$1" == "--help" ]];

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'console_scripts': [
             'dea-clean = digitalearthau.cleanup:main',
             'dea-coherence = digitalearthau.coherence:main',
-            'dea-duplicates = digitalearthau.duplicates:main',
+            'dea-duplicates = digitalearthau.duplicates:cli',
             'dea-harvest = digitalearthau.harvest.iso19115:main',
             'dea-move = digitalearthau.move:cli',
             'dea-submit-ingest = digitalearthau.submit.ingest:cli',


### PR DESCRIPTION
The usage of the DEA repo has evolved, and is no longer only for private (collection management) scripts. Several other public repos now use it as a library. It should go in the same module directory as the others.
