### PR TITLE
Add option for specifying number of workers per node

### DIFF
--- a/digitalearthau/runners/celery_environment.py
+++ b/digitalearthau/runners/celery_environment.py
@@ -294,7 +294,7 @@ def launch_celery_worker_environment(task_desc: TaskDescription,
                                            redis_port,
                                            one_worker_per_node))
 
-    _LOG.info('{} workers launched.'.format(len(worker_procs)))
+    _LOG.info('%d workers launched.', len(worker_procs))
 
     def start_shutdown():
         cr.app.control.shutdown()
@@ -326,7 +326,7 @@ def _spawn_pbs_workers(redis_host: str,
     worker_env = pbs.get_env()
 
     _LOG.info('Launching PBS workers.')
-    _LOG.info('one worker per node: {}.'.format(one_worker_per_node))
+    _LOG.info('one worker per node: %s.', str(one_worker_per_node))
 
     for node in pbs.nodes():
         nprocs = node.num_cores
@@ -341,5 +341,5 @@ def _spawn_pbs_workers(redis_host: str,
             f'exec python -m datacube_apps.worker --executor celery {redis_host}:{redis_port} --nprocs {nprocs}',
             env=worker_env
         )
-        _LOG.info(f"Started node {node.offset} (pbsdsh pid {proc.pid})")
+        _LOG.info(f"Started node {node.offset} named {node.name} (pbsdsh pid {proc.pid})")
         yield proc

--- a/digitalearthau/runners/celery_environment.py
+++ b/digitalearthau/runners/celery_environment.py
@@ -262,7 +262,7 @@ def _just_the_hostname(hostname: str):
 
 def launch_celery_worker_environment(task_desc: TaskDescription,
                                      redis_params: dict,
-                                     worker_per_node: int):
+                                     workers_per_node: int):
     redis_port = redis_params['port']
     redis_host = pbs.hostname()
     redis_password = cr.get_redis_password(generate_if_missing=True)
@@ -292,7 +292,7 @@ def launch_celery_worker_environment(task_desc: TaskDescription,
 
     worker_procs = list(_spawn_pbs_workers(redis_host,
                                            redis_port,
-                                           worker_per_node))
+                                           workers_per_node))
 
     _LOG.info('%d workers launched.', len(worker_procs))
 
@@ -322,19 +322,19 @@ def launch_celery_worker_environment(task_desc: TaskDescription,
 
 def _spawn_pbs_workers(redis_host: str,
                        redis_port: str,
-                       worker_per_node: int) -> Iterable[subprocess.Popen]:
+                       workers_per_node: int) -> Iterable[subprocess.Popen]:
     worker_env = pbs.get_env()
 
     _LOG.info('Launching PBS workers.')
-    _LOG.info('worker per node: %d.', worker_per_node)
+    _LOG.info('Workers per node: %d.', workers_per_node)
 
     for node in pbs.nodes():
         nprocs = node.num_cores
         if node.is_main:
             nprocs = max(1, nprocs - 2)
 
-        if worker_per_node:
-            nprocs = min(worker_per_node, nprocs)
+        if workers_per_node:
+            nprocs = min(workers_per_node, nprocs)
 
         _LOG.info(f'datacube_apps.worker --executor celery {redis_host}:{redis_port} --nprocs {nprocs}')
 

--- a/digitalearthau/runners/celery_environment.py
+++ b/digitalearthau/runners/celery_environment.py
@@ -262,7 +262,7 @@ def _just_the_hostname(hostname: str):
 
 def launch_celery_worker_environment(task_desc: TaskDescription,
                                      redis_params: dict,
-                                     workers_per_node: int):
+                                     workers_per_node: int = None):
     redis_port = redis_params['port']
     redis_host = pbs.hostname()
     redis_password = cr.get_redis_password(generate_if_missing=True)
@@ -322,7 +322,7 @@ def launch_celery_worker_environment(task_desc: TaskDescription,
 
 def _spawn_pbs_workers(redis_host: str,
                        redis_port: str,
-                       workers_per_node: int) -> Iterable[subprocess.Popen]:
+                       workers_per_node: int = None) -> Iterable[subprocess.Popen]:
     worker_env = pbs.get_env()
 
     _LOG.info('Launching PBS workers.')
@@ -333,7 +333,7 @@ def _spawn_pbs_workers(redis_host: str,
         if node.is_main:
             nprocs = max(1, nprocs - 2)
 
-        if workers_per_node:
+        if workers_per_node is not None:
             nprocs = min(workers_per_node, nprocs)
 
         _LOG.info(f'datacube_apps.worker --executor celery {redis_host}:{redis_port} --nprocs {nprocs}')


### PR DESCRIPTION
Some tasks can utilize multiple cores effectively such as Dale Roberts'
geomedian and SMAD routines. Add an option where only a specified
number of workers are spawned per node.

- Add option `--workers-per-node` to the CLI
- Add log messages to facilitate debugging