### PR TITLE
Increase memory margin per node

### DIFF
--- a/digitalearthau/qsub.py
+++ b/digitalearthau/qsub.py
@@ -345,7 +345,7 @@ def norm_qsub_params(p):
     mem = normalise_mem(p.get('mem', 'small'))
 
     if nodes:
-        mem = int((mem * NUM_CPUS_PER_NODE * 1024 - 512) * nodes)
+        mem = int((mem * NUM_CPUS_PER_NODE * 1024 - 2048) * nodes)
     else:
         mem = int(mem * ncpus * 1024)
 

--- a/digitalearthau/qsub.py
+++ b/digitalearthau/qsub.py
@@ -21,6 +21,7 @@ from .runners import celery_environment
 from .runners.model import TaskDescription
 
 NUM_CPUS_PER_NODE = 16
+RESERVED_MEM_PER_NODE = 2048   # in MB
 QSUB_L_FLAGS = 'mem ncpus walltime wd'.split(' ')
 
 # Keys that can be sent as-is to the qsub builder without normalisation (I think?)
@@ -316,7 +317,7 @@ def norm_qsub_params(p):
     ...    'name': 'staggering-fc-run',
     ... }))
     {'extra_qsub_args': [],
-     'mem': '129024MB',
+     'mem': '122880MB',
      'name': 'staggering-fc-run',
      'ncpus': 64,
      'noask': True,
@@ -329,7 +330,7 @@ def norm_qsub_params(p):
      'wd': True}
     >>> # Default params
     >>> norm_qsub_params({})
-    {'ncpus': 16, 'mem': '32256MB', 'walltime': None, 'extra_qsub_args': []}
+    {'ncpus': 16, 'mem': '30720MB', 'walltime': None, 'extra_qsub_args': []}
     >>> # TODO error on unknown args? It seems to explicitly pass through (PASS_THRU_KEYS) some, but not all valid keys?
     >>> # No error currently:
     >>> # norm_qsub_params({'ubermensch': 'understood'})
@@ -345,7 +346,7 @@ def norm_qsub_params(p):
     mem = normalise_mem(p.get('mem', 'small'))
 
     if nodes:
-        mem = int((mem * NUM_CPUS_PER_NODE * 1024 - 2048) * nodes)
+        mem = int((mem * NUM_CPUS_PER_NODE * 1024 - RESERVED_MEM_PER_NODE) * nodes)
     else:
         mem = int(mem * ncpus * 1024)
 

--- a/digitalearthau/qsub.py
+++ b/digitalearthau/qsub.py
@@ -21,7 +21,7 @@ from .runners import celery_environment
 from .runners.model import TaskDescription
 
 NUM_CPUS_PER_NODE = 16
-RESERVED_MEM_PER_NODE = 2048   # in MB
+RESERVED_MEM_PER_NODE = 1024   # in MB
 QSUB_L_FLAGS = 'mem ncpus walltime wd'.split(' ')
 
 # Keys that can be sent as-is to the qsub builder without normalisation (I think?)
@@ -317,7 +317,7 @@ def norm_qsub_params(p):
     ...    'name': 'staggering-fc-run',
     ... }))
     {'extra_qsub_args': [],
-     'mem': '122880MB',
+     'mem': '126976MB',
      'name': 'staggering-fc-run',
      'ncpus': 64,
      'noask': True,
@@ -330,7 +330,7 @@ def norm_qsub_params(p):
      'wd': True}
     >>> # Default params
     >>> norm_qsub_params({})
-    {'ncpus': 16, 'mem': '30720MB', 'walltime': None, 'extra_qsub_args': []}
+    {'ncpus': 16, 'mem': '31744MB', 'walltime': None, 'extra_qsub_args': []}
     >>> # TODO error on unknown args? It seems to explicitly pass through (PASS_THRU_KEYS) some, but not all valid keys?
     >>> # No error currently:
     >>> # norm_qsub_params({'ubermensch': 'understood'})

--- a/digitalearthau/test_qsub.py
+++ b/digitalearthau/test_qsub.py
@@ -44,7 +44,7 @@ def test_norm_qsub_params():
 
     assert p['ncpus'] == 16
     assert p['walltime'] == '0:10:00'
-    assert p['mem'] == '32256MB'
+    assert p['mem'] == '30720MB'
 
     p = qsub.parse_comma_args('ncpus=1, mem=medium, walltime=3h')
     p = qsub.norm_qsub_params(p)

--- a/digitalearthau/test_qsub.py
+++ b/digitalearthau/test_qsub.py
@@ -37,14 +37,14 @@ def test_norm_qsub_params():
 
     assert p['ncpus'] == 16
     assert p['walltime'] == '0:00:10'
-    assert p['mem'] == '30720MB'
+    assert p['mem'] == '31744MB'
 
     p = qsub.parse_comma_args('nodes=1,mem=small,walltime=10m')
     p = qsub.norm_qsub_params(p)
 
     assert p['ncpus'] == 16
     assert p['walltime'] == '0:10:00'
-    assert p['mem'] == '30720MB'
+    assert p['mem'] == '31744MB'
 
     p = qsub.parse_comma_args('ncpus=1, mem=medium, walltime=3h')
     p = qsub.norm_qsub_params(p)

--- a/digitalearthau/test_qsub.py
+++ b/digitalearthau/test_qsub.py
@@ -37,7 +37,7 @@ def test_norm_qsub_params():
 
     assert p['ncpus'] == 16
     assert p['walltime'] == '0:00:10'
-    assert p['mem'] == '32256MB'
+    assert p['mem'] == '30720MB'
 
     p = qsub.parse_comma_args('nodes=1,mem=small,walltime=10m')
     p = qsub.norm_qsub_params(p)


### PR DESCRIPTION
The memory left to the rest of the system per node (currently 512MB)
is perhaps not enough to make sure the job gets scheduled faster
according to @daleroberts.

- Change the memory request to be 1GB less per node than available
- Fix tests to reflect the change