### PR TITLE
Replace cleanup commands with simpler location-only cleanup

### DIFF
--- a/digitalearthau/cleanup.py
+++ b/digitalearthau/cleanup.py
@@ -1,3 +1,9 @@
+"""
+Find and clean-up datasets.
+
+On a clean-up, a dataset is moved to a `.trash` folder, and its
+reference is removed from the index.
+"""
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -16,7 +22,7 @@ from digitalearthau import paths, uiutil
 from dateutil import tz
 
 
-@click.group(help='Find and trash archived locations.')
+@click.group(help=__doc__)
 @ui.global_cli_options
 def cli():
     pass
@@ -39,9 +45,12 @@ def archived(index: Index,
              files: List[str],
              min_trash_age_hours: int):
     """
-    Cleanup any datasets within the given file path(s)
+    Clean-up archived locations.
 
-    It will trash any file with a location archived more than min-trash-age-hours ago.
+    Find any locations within the given folders that have been archived in the index.
+
+    It will only trash locations that were archived more than min-trash-age-hours
+    ago (default: 3 days).
     """
     total_count = 0
     total_trash_count = 0

--- a/digitalearthau/cleanup.py
+++ b/digitalearthau/cleanup.py
@@ -87,6 +87,13 @@ def _cleanup_uri(dry_run: bool,
                            file=sys.stderr) as location_iter:
         for uri in location_iter:
             log = log.bind(uri=uri)
+            local_path = uri_to_local_path(uri)
+            if not local_path.exists():
+                # An index record exists, but the file isn't on the disk.
+                # We won't remove the record from the index: maybe the filesystem is temporarily unmounted?
+                log.warning('location.not_exist')
+                continue
+
             # Multiple datasets can point to the same location (eg. a stacked file).
             indexed_datasets = set(index.datasets.get_datasets_for_location(uri))
 

--- a/digitalearthau/cleanup.py
+++ b/digitalearthau/cleanup.py
@@ -1,22 +1,17 @@
+import sys
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import List
 
 import click
 import structlog
-import sys
-
 from click import echo, style
-from dateutil import tz
-from typing import Iterable, List
-
-from sqlalchemy import select, or_, and_
+from sqlalchemy import select, and_
 
 from datacube.index._api import Index
-from datacube.model import DatasetType, Dataset
+from datacube.index.postgres import _api as pgapi
 from datacube.ui import click as ui
 from digitalearthau import paths, uiutil
-
-from datacube.index.postgres import _api as pgapi
 
 TRASH_OPTIONS = ui.compose(
     click.option('--min-trash-age-hours',
@@ -122,181 +117,6 @@ def _get_dataset_where_active(uri, datasets):
         if uri in d.uris:
             return d
     return None
-
-
-@main.command('indexed')
-@TRASH_OPTIONS
-@click.option('--only-redundant/--all',
-              is_flag=True,
-              default=True,
-              help='Only trash locations with a second active location')
-@ui.pass_index()
-@ui.parsed_search_expressions
-def indexed(index: Index,
-            expressions: dict,
-            dry_run: bool,
-            only_redundant: bool,
-            min_trash_age_hours: int):
-    """
-    Find and trash archived locations using an index search.
-
-    But only if they were archived more than  --min-trash-age-hours ago (default: 3 days)
-
-    By default it will also only trash a location if you've got another active location for it (as is
-    the case if the archived location was stacked or dea-move'd)
-    """
-    echo(f"query: {expressions!r}", err=True)
-
-    product_counts = {product.name: count for product, count in index.datasets.count_by_product(**expressions)}
-    echo(f"{len(product_counts)} product(s) to scan; around {sum(product_counts.values())} datasets", err=True)
-
-    # We only support cleaning one product on our pgbouncer, due to this bug:
-    # https://github.com/opendatacube/datacube-core/pull/317
-    # pylint: disable=protected-access
-    if len(product_counts) > 1 and ('6543' in str(index.datasets._db.url)):
-        echo("\nRunning against multiple products will fail on port 6432 at NCI until AGDC 1.5.4 is released.\n"
-             "Change port to 5432 or limit your search arguments to one product.", err=True)
-        sys.exit(1)
-
-    latest_time_to_archive = _as_utc(datetime.utcnow()) - timedelta(hours=min_trash_age_hours)
-
-    total_count = 0
-    total_trash_count = 0
-
-    for product, datasets in index.datasets.search_by_product(**expressions):
-        expected_count = product_counts.get(product.name, 0)
-
-        # Record results to the product's work folder.
-        work_path = paths.get_product_work_directory(product.name, task_type='clean')
-        uiutil.init_logging(work_path.joinpath('log.jsonl').open('a'))
-        log = structlog.getLogger("cleanup-indexed").bind(product=product.name)
-        echo(f"Cleaning {style(product.name, bold=True)}", err=True)
-        echo(f"  Expect {expected_count} datasets", err=True)
-        echo(f"  Output {work_path}", err=True)
-
-        log.info('arguments', arguments=dict(
-            query=expressions,
-            dry_run=dry_run,
-            only_redundant=only_redundant,
-            min_trash_age_hours=min_trash_age_hours
-        ))
-        count, trash_count = _cleanup_datasets(
-            # Yuck. Too many arguments.
-            index, product, datasets, expected_count, dry_run, latest_time_to_archive, only_redundant, log
-        )
-        total_count += count
-        total_trash_count += trash_count
-
-    echo(f"Finished {total_count} datasets; {total_trash_count} trashed.", err=True)
-
-
-def _cleanup_datasets(index: Index,
-                      product: DatasetType,
-                      datasets: Iterable[Dataset],
-                      expected_count: int,
-                      dry_run: bool,
-                      latest_time_to_archive: datetime,
-                      only_redundant: bool,
-                      log):
-    count = 0
-    trash_count = 0
-
-    log.info("cleanup.product.start", expected_count=expected_count, product=product.name)
-
-    with click.progressbar(datasets,
-                           length=expected_count,
-                           # stderr should be used for runtime information, not stdout
-                           file=sys.stderr) as dataset_iter:
-        for dataset in dataset_iter:
-            count += 1
-
-            log = log.bind(dataset_id=str(dataset.id))
-
-            archived_uri_times = index.datasets.get_archived_location_times(dataset.id)
-            if not archived_uri_times:
-                log.debug('dataset.nothing_archived')
-                continue
-
-            if only_redundant:
-                if dataset.uris is not None and len(dataset.uris) == 0:
-                    # This active dataset has no active locations to replace the ones we're archiving.
-                    # Probably a mistake? Don't trash the archived ones yet.
-                    log.warning("dataset.noactive", archived_paths=archived_uri_times)
-                    continue
-
-            for uri, archived_time in archived_uri_times:
-                if _as_utc(archived_time) > latest_time_to_archive:
-                    log.info('dataset.too_recent')
-                    continue
-
-                paths.trash_uri(uri, dry_run=dry_run, log=log)
-                if not dry_run:
-                    index.datasets.remove_location(dataset.id, uri)
-                trash_count += 1
-
-            log = log.unbind('dataset_id')
-
-    log.info("cleanup.product.finish", count=count, trash_count=trash_count)
-    return count, trash_count
-
-
-@main.command('files')
-@ui.pass_index()
-@click.argument('files',
-                type=click.Path(exists=True, readable=True),
-                nargs=-1)
-@TRASH_OPTIONS
-def trash_individual_files(index, dry_run, min_trash_age_hours, files):
-    """
-    Trash the given datasets if they're archived.
-
-    This expects exact dataset paths: *.nc files, or ga-metadata.yaml for scenes.
-
-    But only if they were archived more than  --min-trash-age-hours ago (default: 3 days)
-    """
-    glog = structlog.getLogger('cleanup-paths')
-    glog.info('input_paths', input_paths=files)
-
-    latest_time_to_archive = _as_utc(datetime.utcnow()) - timedelta(hours=min_trash_age_hours)
-
-    count = 0
-    trash_count = 0
-    for file in files:
-        count += 1
-        log = glog.bind(path=(Path(file).resolve()))
-
-        uri = Path(file).resolve().as_uri()
-        datasets = list(index.datasets.get_datasets_for_location(uri))
-
-        if datasets:
-            # Can't trash file if any linked datasets are still active. They should be archived first.
-            active_dataset_ids = [dataset.id for dataset in datasets if dataset.is_active]
-            if active_dataset_ids:
-                log.warning('dataset.is_active', dataset_ids=active_dataset_ids)
-                continue
-
-            assert all(d.is_archived for d in datasets)
-
-            # Otherwise they're indexed and archived. Were they archived long enough ago?
-
-            # It's rare that you'd have two archived datasets with the same location, but we're handling it anyway...
-            archived_times = [dataset.archived_time for dataset in datasets]
-            archived_times.sort()
-            oldest_archived_time = archived_times[0]
-            if _as_utc(oldest_archived_time) > latest_time_to_archive:
-                log.info('dataset.too_recent', archived_time=oldest_archived_time)
-                continue
-
-            if not dry_run:
-                for d in datasets:
-                    log.info('dataset.remove_location', dataset_id=d.id)
-                    index.datasets.remove_location(d.id, uri)
-        else:
-            log.info('path.not_indexed')
-        paths.trash_uri(uri, dry_run=dry_run, log=log)
-        trash_count += 1
-
-    glog.info("cleanup.finish", count=count, trash_count=trash_count)
 
 
 def _as_utc(d):

--- a/digitalearthau/cleanup.py
+++ b/digitalearthau/cleanup.py
@@ -17,11 +17,11 @@ from dateutil import tz
 
 @click.group(help='Find and trash archived locations.')
 @ui.global_cli_options
-def main():
+def cli():
     pass
 
 
-@main.command('archived')
+@cli.command('archived')
 @click.option('--min-trash-age-hours',
               type=int,
               default=72,
@@ -150,4 +150,4 @@ def _as_utc(d):
 
 
 if __name__ == '__main__':
-    main()
+    cli()

--- a/digitalearthau/paths.py
+++ b/digitalearthau/paths.py
@@ -303,12 +303,12 @@ def _find_any_metadata_suffix(path):
     return existing_paths[0]
 
 
-def trash_uri(uri: str, dry_run=False, log=_LOG):
+def trash_uri(uri: str, dry_run=False, log=_LOG) -> bool:
     local_path = uri_to_local_path(uri)
 
     if not local_path.exists():
         log.warning("trash.not_exist", path=local_path)
-        return
+        return False
 
     # TODO: to handle sibling-metadata we should trash "all_dataset_paths" too.
     base_path, all_dataset_files = get_dataset_paths(local_path)
@@ -321,6 +321,8 @@ def trash_uri(uri: str, dry_run=False, log=_LOG):
         if not trash_path.parent.exists():
             os.makedirs(str(trash_path.parent))
         os.rename(str(base_path), str(trash_path))
+
+    return True
 
 
 def get_product_work_directory(

--- a/digitalearthau/paths.py
+++ b/digitalearthau/paths.py
@@ -355,5 +355,6 @@ def _make_work_directory(output_product, work_time, task_type):
         work_time=work_time,
         task_type=task_type,
         output_product=output_product,
+        request_uuid=uuid.uuid4()
     )
     return NCI_WORK_ROOT.joinpath(job_offset)

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -138,6 +138,9 @@ class DatasetForTests(NamedTuple):
     def archive_location_in_index(self, archived_dt: datetime = None):
         archive_location(self.id_, self.uri, self.collection, archived_dt=archived_dt)
 
+    def add_location(self, uri: str) -> bool:
+        return self.collection.index_.datasets.add_location(self.id_, uri)
+
     def get_index_record(self) -> Optional[Dataset]:
         """If this is indexed, return the full Dataset record"""
         return self.collection.index_.datasets.get(self.id_)

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -62,6 +62,8 @@ def load_yaml_file(path):
 def work_path(tmpdir):
     paths.NCI_WORK_ROOT = Path(tmpdir) / 'work'
     paths.NCI_WORK_ROOT.mkdir()
+    # The default use of timestamp will collide when run quickly, as in unit tests.
+    paths._JOB_WORK_OFFSET = '{output_product}-{task_type}-{request_uuid}'
     return paths.NCI_WORK_ROOT
 
 
@@ -135,8 +137,8 @@ class DatasetForTests(NamedTuple):
     def archive_in_index(self, archived_dt: datetime = None):
         archive_dataset(self.id_, self.collection, archived_dt=archived_dt)
 
-    def archive_location_in_index(self, archived_dt: datetime = None):
-        archive_location(self.id_, self.uri, self.collection, archived_dt=archived_dt)
+    def archive_location_in_index(self, archived_dt: datetime = None, uri: str = None):
+        archive_location(self.id_, uri or self.uri, self.collection, archived_dt=archived_dt)
 
     def add_location(self, uri: str) -> bool:
         return self.collection.index_.datasets.add_location(self.id_, uri)

--- a/integration_tests/test_cleanup.py
+++ b/integration_tests/test_cleanup.py
@@ -95,10 +95,13 @@ def test_keep_stacks(run_cleanup,
     assert not test_dataset.path.exists(), "Stack should be cleaned up when all references are archived."
 
 
-@pytest.mark.xfail
 def test_only_clean_up_matching_uuids(run_cleanup,
                                       test_dataset: DatasetForTests,
                                       other_dataset: DatasetForTests):
+    """
+    If the disk location being cleaned up has a UUID that's not in the index, it shouldn't be touched.
+    It may be a newly processed dataset.
+    """
     # Archived, ready to clean up
     test_dataset.add_to_index()
     test_dataset.archive_location_in_index(archived_dt=A_LONG_TIME_AGO)

--- a/integration_tests/test_cleanup.py
+++ b/integration_tests/test_cleanup.py
@@ -1,0 +1,72 @@
+from datetime import datetime, timedelta
+
+from click.testing import CliRunner, Result
+
+from digitalearthau import cleanup
+from integration_tests.conftest import DatasetForTests
+
+
+def test_cleanup_archived(global_integration_cli_args,
+                          test_dataset: DatasetForTests,
+                          other_dataset: DatasetForTests,
+                          integration_test_data):
+    """
+    Two archived datasets, one eligible for cleanup
+    """
+    # Newly archived. Don't do anything.
+    test_dataset.add_to_index()
+    test_dataset.archive_location_in_index()
+
+    # Archived a while ago. Should be cleaned up.
+    other_dataset.add_to_index()
+    other_dataset.archive_location_in_index(archived_dt=datetime.utcnow() - timedelta(days=5))
+
+    # Archive folder
+    _call_cleanup(['archived', str(integration_test_data)], global_integration_cli_args)
+
+    assert not other_dataset.path.exists(), "Dataset was not cleaned up"
+
+    assert test_dataset.path.exists(), "Too-recently-archived dataset shouldn't be cleaned up"
+
+    assert other_dataset.get_index_record() is not None, "A cleaned-up dataset should still be in the index"
+
+    all_indexed_uris = set(test_dataset.collection.iter_index_uris())
+    assert all_indexed_uris == {test_dataset.uri}, "Only one uri should remain. The other was trashed."
+
+
+def test_dont_cleanup(global_integration_cli_args,
+                      test_dataset: DatasetForTests,
+                      other_dataset: DatasetForTests,
+                      integration_test_data):
+    """
+    Active or unindexed datasets should be left alone.
+    """
+    # Still active. Don't clean up!
+    test_dataset.add_to_index()
+
+    # Not indexed. Don't clean up!
+    # other_dataset
+
+    _call_cleanup(['archived', str(integration_test_data)], global_integration_cli_args)
+
+    assert other_dataset.path.exists(), "Dataset shouldn't be touched"
+
+    assert test_dataset.path.exists(), "Unindexed dataset shouldn't be touched"
+
+    all_indexed_uris = set(test_dataset.collection.iter_index_uris())
+
+    # All still there
+    assert all_indexed_uris == {test_dataset.uri}
+
+
+def _call_cleanup(args, global_integration_cli_args) -> Result:
+    # We'll call the cli interface itself, rather than the python api, to get wider coverage in our test.
+    res: Result = CliRunner().invoke(
+        cleanup.cli,
+        global_integration_cli_args + [str(arg) for arg in args],
+        catch_exceptions=False
+    )
+
+    assert res.exit_code == 0, res.output
+    print(res.output)
+    return res

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
 
     entry_points={
         'console_scripts': [
-            'dea-clean = digitalearthau.cleanup:main',
+            'dea-clean = digitalearthau.cleanup:cli',
             'dea-coherence = digitalearthau.coherence:main',
             'dea-duplicates = digitalearthau.duplicates:cli',
             'dea-harvest = digitalearthau.harvest.iso19115:main',


### PR DESCRIPTION
Replaces the multiple (single-purpose) commands with a single "cleanup archived" command.

- It no longer cares whether datasets are archived, only the locations. This removes a lot of the previous complexity, and covers more cases.
- It's no longer run per product, but by folder. For example: run a cleanup of `/short`. This matches how we typically run it, and simplifies the logic.
- It outputs json-parseable logs to a work directory, so that we have a record of what was cleaned up. Shows a "friendly" status bar to the user.
- Includes integration tests

The goal, once we trust it enough, is for this to be triggered and run automatically.