### PR TITLE
Add voluptuous to the python env on the NCI

### DIFF
--- a/modules/py-environment/environment.yaml
+++ b/modules/py-environment/environment.yaml
@@ -79,6 +79,7 @@ dependencies:
 - sqlalchemy
 - tqdm
 - xarray
+- voluptuous
 - pip:
   - autopep8
   - boltons


### PR DESCRIPTION
It's now required for datacube stats.

Closes #69