### PR TITLE
Add jupyterlab to NCI python environment

### DIFF
--- a/modules/py-environment/environment.yaml
+++ b/modules/py-environment/environment.yaml
@@ -38,6 +38,7 @@ dependencies:
 - jupyter
 - jupyter_contrib_nbextensions
 - jupyter_dashboards
+- jupyterlab
 - line_profiler
 - luigi
 - matplotlib


### PR DESCRIPTION
It's the new cool. Jupyter Notebook is the old faded.