### PR TITLE
in sync pass url to processes

### DIFF
--- a/digitalearthau/sync/scan.py
+++ b/digitalearthau/sync/scan.py
@@ -84,6 +84,7 @@ def _find_uri_mismatches(index_url: str, uri: str, validate_data=True) -> Iterab
     yielding Mismatches of any differences.
     """
 
+    # pylint: disable=protected-access
     index = Index(PostgresDb(PostgresDb._create_engine(index_url)))
 
     def ids(datasets):

--- a/digitalearthau/sync/scan.py
+++ b/digitalearthau/sync/scan.py
@@ -11,7 +11,9 @@ import structlog
 from boltons import fileutils
 from boltons import strutils
 
-from datacube.index import Index
+from datacube.index.index import Index  # DEA index
+from datacube.drivers.postgres import PostgresDb
+
 from datacube.utils import uri_to_local_path, InvalidDocException
 from digitalearthau import paths
 from digitalearthau.collections import Collection
@@ -76,11 +78,13 @@ def build_pathset(
 logging.getLogger('datacube.drivers.postgres._connections').setLevel(logging.ERROR)
 
 
-def _find_uri_mismatches(index: Index, uri: str, validate_data=True) -> Iterable[Mismatch]:
+def _find_uri_mismatches(index_url: str, uri: str, validate_data=True) -> Iterable[Mismatch]:
     """
     Compare the index and filesystem contents for the given uris,
     yielding Mismatches of any differences.
     """
+
+    index = Index(PostgresDb(PostgresDb._create_engine(index_url)))
 
     def ids(datasets):
         return [d.id for d in datasets]
@@ -146,10 +150,11 @@ def mismatches_for_collection(collection: Collection,
 
     # Clean up any open connections before we fork.
     collection.index_.close()
+    index_url = collection.index_.url
 
     with multiprocessing.Pool(processes=workers) as pool:
         result = pool.imap_unordered(
-            partial(_find_uri_mismatches_eager, collection.index_),
+            partial(_find_uri_mismatches_eager, index_url),
             path_dawg.iterkeys(uri_prefix),
             chunksize=work_chunksize
         )
@@ -161,8 +166,8 @@ def mismatches_for_collection(collection: Collection,
         pool.join()
 
 
-def _find_uri_mismatches_eager(index: Index, uri: str) -> List[Mismatch]:
-    return list(_find_uri_mismatches(index, uri))
+def _find_uri_mismatches_eager(index_url: str, uri: str) -> List[Mismatch]:
+    return list(_find_uri_mismatches(index_url, uri))
 
 
 def query_name(query: Mapping[str, Any]) -> str:


### PR DESCRIPTION
Since the `Index` object should not in general be serializable (and currently it is not),
do not pass it to the forked processes in the `sync` tool. Pass the URL instead, and
recreate the `Index` inside the processes.