### PR TITLE
Core develop fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ install:
     # Dask.array seems to need this?
     - travis_retry pip install cloudpickle
     - travis_retry pip install git+https://github.com/GeoscienceAustralia/eo-datasets.git
+    - travis_retry pip install git+https://github.com/opendatacube/datacube-core.git@develop
     - travis_retry pip install -e .
 
 script:

--- a/digitalearthau/cleanup.py
+++ b/digitalearthau/cleanup.py
@@ -14,7 +14,7 @@ import structlog
 from click import echo, style
 from sqlalchemy import select, and_
 
-from datacube.index._api import Index
+from datacube.index import Index
 from datacube.index.postgres import _api as pgapi
 from datacube.ui import click as ui
 from datacube.utils import uri_to_local_path

--- a/digitalearthau/cleanup.py
+++ b/digitalearthau/cleanup.py
@@ -15,7 +15,7 @@ from click import echo, style
 from sqlalchemy import select, and_
 
 from datacube.index import Index
-from datacube.index.postgres import _api as pgapi
+from datacube.drivers.postgres import _api as pgapi
 from datacube.ui import click as ui
 from datacube.utils import uri_to_local_path
 from digitalearthau import paths, uiutil

--- a/digitalearthau/collections.py
+++ b/digitalearthau/collections.py
@@ -12,7 +12,7 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import Iterable, Optional, List, Dict, NamedTuple, Sequence
 
-from datacube.index._api import Index
+from datacube.index import Index
 
 
 class Trust(Enum):

--- a/digitalearthau/duplicates.py
+++ b/digitalearthau/duplicates.py
@@ -11,7 +11,7 @@ import click
 from dateutil import tz
 from psycopg2._range import Range
 
-from datacube.index._api import Index
+from datacube.index import Index
 from datacube.index.fields import Field
 from datacube.model import DatasetType, MetadataType
 from datacube.ui.click import global_cli_options, pass_index

--- a/digitalearthau/index.py
+++ b/digitalearthau/index.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from functools import lru_cache
 from typing import Iterable
 
-from datacube.index._api import Index
+from datacube.index import Index
 from datacube.model import Dataset
 from datacube.scripts import dataset as dataset_script
 from datacube.utils import uri_to_local_path

--- a/digitalearthau/move.py
+++ b/digitalearthau/move.py
@@ -14,7 +14,7 @@ import structlog
 from boltons import fileutils
 from eodatasets import verify
 
-from datacube.index._api import Index
+from datacube.index import Index
 from datacube.model import Dataset
 from datacube.ui import click as ui
 from digitalearthau.collections import init_nci_collections, get_collections_in_path

--- a/digitalearthau/stacker.py
+++ b/digitalearthau/stacker.py
@@ -36,7 +36,7 @@ import click
 import datacube
 import digitalearthau
 from datacube.api.query import Query
-from datacube.index._api import Index
+from datacube.index import Index
 from datacube.ui import click as ui
 from datacube.ui import task_app
 from datacube_apps.stacker import stacker

--- a/digitalearthau/sync/__init__.py
+++ b/digitalearthau/sync/__init__.py
@@ -12,7 +12,7 @@ import click
 import structlog
 
 import digitalearthau.collections as cs
-from datacube.index._api import Index
+from datacube.index import Index
 from datacube.ui import click as ui
 from digitalearthau import uiutil
 from digitalearthau.sync import scan

--- a/digitalearthau/sync/fixes.py
+++ b/digitalearthau/sync/fixes.py
@@ -5,7 +5,7 @@ from typing import Iterable, Callable
 import structlog
 from dateutil import tz
 
-from datacube.index._api import Index
+from datacube.index import Index
 from digitalearthau.index import add_dataset, get_datasets_for_uri
 from digitalearthau.paths import trash_uri
 from digitalearthau.sync.differences import UnreadableDataset

--- a/digitalearthau/sync/scan.py
+++ b/digitalearthau/sync/scan.py
@@ -84,6 +84,7 @@ def _find_uri_mismatches(index_url: str, uri: str, validate_data=True) -> Iterab
     yielding Mismatches of any differences.
     """
 
+    # pylint: disable=protected-access
     index = Index(PostgresDb(PostgresDb._create_engine(index_url)))
 
     def ids(datasets):

--- a/digitalearthau/sync/scan.py
+++ b/digitalearthau/sync/scan.py
@@ -73,7 +73,7 @@ def build_pathset(
 # It's usually warned against to prevent datacube clients hitting the index from every worker, but it's a valid
 # use case with this sync tool, where we have a handful of small workers.
 # TODO: Push only the connection setup information? Or have a dedicated process for index info.
-logging.getLogger('datacube.index.postgres._connections').setLevel(logging.ERROR)
+logging.getLogger('datacube.drivers.postgres._connections').setLevel(logging.ERROR)
 
 
 def _find_uri_mismatches(index: Index, uri: str, validate_data=True) -> Iterable[Mismatch]:

--- a/digitalearthau/sync/scan.py
+++ b/digitalearthau/sync/scan.py
@@ -11,7 +11,7 @@ import structlog
 from boltons import fileutils
 from boltons import strutils
 
-from datacube.index._api import Index
+from datacube.index import Index
 from datacube.utils import uri_to_local_path, InvalidDocException
 from digitalearthau import paths
 from digitalearthau.collections import Collection

--- a/digitalearthau/sync/scan.py
+++ b/digitalearthau/sync/scan.py
@@ -11,7 +11,9 @@ import structlog
 from boltons import fileutils
 from boltons import strutils
 
-from datacube.index import Index
+from datacube.index.index import Index  # DEA index
+from datacube.drivers.postgres import PostgresDb
+
 from datacube.utils import uri_to_local_path, InvalidDocException
 from digitalearthau import paths
 from digitalearthau.collections import Collection
@@ -76,11 +78,13 @@ def build_pathset(
 logging.getLogger('datacube.drivers.postgres._connections').setLevel(logging.ERROR)
 
 
-def _find_uri_mismatches(index: Index, uri: str, validate_data=True) -> Iterable[Mismatch]:
+def _find_uri_mismatches(index_url: str, uri: str, validate_data=True) -> Iterable[Mismatch]:
     """
     Compare the index and filesystem contents for the given uris,
     yielding Mismatches of any differences.
     """
+
+    index = Index(PostgresDb(PostgresDb._create_engine(index_url)))
 
     def ids(datasets):
         return [d.id for d in datasets]
@@ -146,10 +150,11 @@ def mismatches_for_collection(collection: Collection,
 
     # Clean up any open connections before we fork.
     collection.index_.close()
+    index_url = collection.index_.url
 
     with multiprocessing.Pool(processes=workers) as pool:
         result = pool.imap_unordered(
-            partial(_find_uri_mismatches_eager, collection.index_),
+            partial(_find_uri_mismatches_eager, index_url),
             path_dawg.iterkeys(uri_prefix),
             chunksize=work_chunksize
         )
@@ -161,8 +166,8 @@ def mismatches_for_collection(collection: Collection,
         pool.join()
 
 
-def _find_uri_mismatches_eager(index: Index, uri: str) -> List[Mismatch]:
-    return list(_find_uri_mismatches(index, uri))
+def _find_uri_mismatches_eager(index_url: str, uri: str) -> List[Mismatch]:
+    return list(_find_uri_mismatches(index_url, uri))
 
 
 def query_name(query: Mapping[str, Any]) -> str:

--- a/digitalearthau/system.py
+++ b/digitalearthau/system.py
@@ -8,6 +8,7 @@ from datacube.index import Index
 from datacube.scripts import ingest
 from datacube.ui.click import pass_index, global_cli_options
 from datacube.utils import read_documents
+from datacube.drivers import storage_writer_by_name
 
 DEA_MD_TYPES = digitalearthau.CONFIG_DIR / 'metadata-types.yaml'
 DEA_PRODUCTS_DIR = digitalearthau.CONFIG_DIR / 'products'
@@ -63,8 +64,13 @@ def init_dea(
     for path in DEA_INGESTION_DIR.glob('*.yaml'):
         ingest_config = ingest.load_config_from_file(index, path)
 
+        driver_name = ingest_config['storage']['driver']
+        driver = storage_writer_by_name(driver_name)
+        if driver is None:
+            raise ValueError("No driver found for {}".format(driver_name))
+
         source_type, output_type = ingest.ensure_output_type(
-            index, ingest_config, allow_product_changes=True
+            index, ingest_config, driver.format, allow_product_changes=True
         )
         log(f"{output_type.name:<20}\t\t← {source_type.name}")
 

--- a/digitalearthau/system.py
+++ b/digitalearthau/system.py
@@ -4,7 +4,7 @@ import logging
 import click
 
 import digitalearthau
-from datacube.index._api import Index
+from datacube.index import Index
 from datacube.scripts import ingest
 from datacube.ui.click import pass_index, global_cli_options
 from datacube.utils import read_documents

--- a/digitalearthau/testing.py
+++ b/digitalearthau/testing.py
@@ -10,7 +10,7 @@ import pytest
 import digitalearthau
 import digitalearthau.system
 from datacube.config import LocalConfig
-from datacube.index._api import Index
+from datacube.index import Index
 from datacube.index.postgres import PostgresDb
 from datacube.index.postgres import _dynamic
 from datacube.index.postgres.tables import _core

--- a/digitalearthau/testing.py
+++ b/digitalearthau/testing.py
@@ -95,7 +95,7 @@ def db(local_config: LocalConfig):
 @pytest.fixture
 def index(db: PostgresDb):
     """
-    :type db: datacube.index.postgres._api.PostgresDb
+    :type db: datacube.drivers.postgres.PostgresDb
     """
     return Index(db)
 

--- a/digitalearthau/testing.py
+++ b/digitalearthau/testing.py
@@ -11,9 +11,9 @@ import digitalearthau
 import digitalearthau.system
 from datacube.config import LocalConfig
 from datacube.index import Index
-from datacube.index.postgres import PostgresDb
-from datacube.index.postgres import _dynamic
-from datacube.index.postgres.tables import _core
+from datacube.drivers.postgres import PostgresDb
+from datacube.drivers.postgres import _dynamic
+from datacube.drivers.postgres import _core
 
 # These are unavoidable in pytests due to fixtures
 # pylint: disable=redefined-outer-name,protected-access,invalid-name

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -11,7 +11,7 @@ import yaml
 from sqlalchemy import and_
 
 import digitalearthau.system
-from datacube.index._api import Index
+from datacube.index import Index
 from datacube.index.postgres import _api
 from datacube.model import Dataset
 from digitalearthau import paths, collections

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -12,7 +12,7 @@ from sqlalchemy import and_
 
 import digitalearthau.system
 from datacube.index import Index
-from datacube.index.postgres import _api
+from datacube.drivers.postgres import _api
 from datacube.model import Dataset
 from digitalearthau import paths, collections
 from digitalearthau.collections import Collection

--- a/integration_tests/test_config.py
+++ b/integration_tests/test_config.py
@@ -1,4 +1,4 @@
-from datacube.index._api import Index
+from datacube.index import Index
 
 
 def test_dea_config(dea_index: Index):

--- a/integration_tests/test_duplicates.py
+++ b/integration_tests/test_duplicates.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from typing import Tuple
 
-from datacube.index._api import Index
+from datacube.index import Index
 from digitalearthau import duplicates
 from digitalearthau.index import add_dataset
 

--- a/integration_tests/test_full_sync.py
+++ b/integration_tests/test_full_sync.py
@@ -10,7 +10,7 @@ import pytest
 import structlog
 from dateutil import tz
 
-from datacube.index._api import Index
+from datacube.index import Index
 from datacube.utils import uri_to_local_path
 from digitalearthau import paths
 from digitalearthau.collections import Collection

--- a/scripts/restore-if-active.py
+++ b/scripts/restore-if-active.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import click
 import structlog
 
-from datacube.index._api import Index
+from datacube.index import Index
 from datacube.ui import click as ui
 from digitalearthau import paths
 


### PR DESCRIPTION
## Reason for this pull request
The public API of `datacube-core` has changed since `release-1.5.5`.
This pull request addresses those.

## Proposed changes
- Pull the `develop` branch from GitHub repo for `datacube-core`
- `datacube.index.Index` as a soft link to `datacube.index.index.Index` (DEA index)
- `datacube.index.postgres` -> `datacube.drivers.postgres`
- Fix `sync` tool to avoid serializing an `Index` object
- Supply `driver.format` to the ingest script