### PR TITLE
Making `install_pip_packages` accept `prefix` or `target`

### DIFF
--- a/modules/build_environment_module.py
+++ b/modules/build_environment_module.py
@@ -143,11 +143,20 @@ def fix_module_permissions(module_path):
 def install_pip_packages(pip_conf, variables):
     fill_templates_from_variables(pip_conf, variables)
     pip = pip_conf['pip_cmd']
-    dest = pip_conf['dest']
+    prefix = pip_conf.get('prefix',pip_conf.get('dest'))  # 'dest' for backwards compatibility
+    target = pip_conf.get('target')
     requirements = pip_conf['requirements']
-    LOG.debug('Installing pip packages from "%s" into directory "%s"',
-              requirements, dest)
-    run(f'{pip} install -v --no-deps --prefix {dest} --compile --requirement {requirements}')
+    if prefix and target is None:
+        dest = prefix
+        arg = f'--prefix {prefix}'
+    elif target and prefix is None:
+        dest = target
+        arg = f'--target {target}'
+    else:  # Either no target or prefix OR target and prefix were in the conf
+        raise Exception('Either prefix: <prefix path> or target: <target path> is required by install_pip_packages:')
+
+    LOG.debug(f'Installing pip packages from "{requirements}" into directory "{dest}"')
+    run(f'{pip} install -v --no-deps {arg} --compile --requirement {requirements}')
 
 
 def find_default_version(module_name):

--- a/modules/dea/modulespec.yaml
+++ b/modules/dea/modulespec.yaml
@@ -15,7 +15,7 @@ stable_module_deps:
 
 install_pip_packages:
   requirements: requirements.txt
-  dest: "{module_path}"
+  prefix: "{module_path}"
   pip_cmd: "module load dea-env; pip "
 
 copy_files:


### PR DESCRIPTION
Make` install_pip_packages` a little more generic by supporting either `target` or `prefix` keys.

This allows a non-standard install location to be specified by the target key which is needed by lpinner/dea-datacube-qgis to install the datacube-qgis plugin to the $QGIS_PLUGINPATH folder via `pip install --target <path> etc...`.

Changes:

- Add  `target` key and replace `dest` key with `prefix` in `install_pip_packages`.
- Retain `dest` for backwards compatibility.
- Raise Exception if neither target or prefix or both target and prefix in config.

Notes:

 - Tested building dea and dea-env modules on Ubuntu 17.10 with environment-modules 3.2.10. Not tested on NCI.
 - I couldn't find any tests or docs for the modules (other than how to run them), so haven't added/updated that side of things.
- No checks are made to ensure `target` path exists, pip does that for us - https://github.com/pypa/pip/blob/master/src/pip/_internal/commands/install.py#L363



Closes GeoscienceAustralia/digitalearthau#88