### PR TITLE
Do not specify tablespace

### DIFF
--- a/digitalearthau/test_env.py
+++ b/digitalearthau/test_env.py
@@ -21,7 +21,6 @@ CREATE DATABASE {db_database}
 WITH
 OWNER = agdc_admin
 ENCODING = 'UTF8'
-TABLESPACE = pg_default
 CONNECTION LIMIT = -1;
 
 GRANT ALL ON DATABASE {db_database} TO agdc_admin;


### PR DESCRIPTION
Database creation on the dev db was OK but failed on staging.

Not specifying a tablespace works fine.