### PR TITLE
Fix dea-submit-sync

### DIFF
--- a/digitalearthau/__init__.py
+++ b/digitalearthau/__init__.py
@@ -16,6 +16,7 @@ def _get_module_name():
 
 
 MODULE_NAME = _get_module_name()
+MODULES_PATH = '/g/data/v10/public/modules/modulefiles'
 
 BASE_DIR = Path(__file__).absolute().parent
 SCRIPT_DIR = BASE_DIR

--- a/digitalearthau/sync/submit_job.py
+++ b/digitalearthau/sync/submit_job.py
@@ -18,7 +18,7 @@ from boltons import fileutils
 from click import style
 
 from datacube.index import index_connect
-from digitalearthau import collections
+from digitalearthau import collections, MODULE_NAME, MODULES_PATH
 from digitalearthau.collections import Trust
 from digitalearthau.paths import get_dataset_paths
 from digitalearthau.sync import scan
@@ -163,6 +163,8 @@ class SyncSubmission(object):
             '-o', str(output_file),
             '-W', ','.join(attributes),
             '--',
+            'module use %s; ' % MODULES_PATH,
+            'module load %s; ' % MODULE_NAME,
             *sync_command
         ]
 


### PR DESCRIPTION
It was hard coded to expect an environment to be already set up inside
PBS jobs. Presumably expecting that `module load` commands were run inside
shell init scripts?

Either way, hopefully this isn't too hard coded, but it has the benefit of being simple.