### PR TITLE
Fix Package Deployments from Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ language: python
 python:
     - '3.6'
 sudo: true
+git:
+  # We need a deeper depth for 'git descibe' to ensure
+  # we can reach the last tagged version. Defaults to only 50
+  depth: 99999
 addons:
     apt:
         packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ install:
     - travis_retry pip install git+https://github.com/opendatacube/datacube-core.git@develop
     - travis_retry pip install -e .
 before_script:
+  - travis_retry pip install codecov
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
@@ -60,6 +61,7 @@ script:
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 after_success:
+    - codecov
     - pushd docs
     - bash ./deploy.sh
     - popd


### PR DESCRIPTION
Travis-CI by default only clones 50 levels deep of a repository, which means
our fancy version numbering support wasn't working, creating package names 
like digitalearthau-0+untagged.50.g59ebe36.dirty.tar.gz .

This PR makes Travis clone 9999 levels deep so that we always get a version 
number.

It also starts uploading our test coverage results to codecov.io as well
as to coveralls, since I think it's a better service, and we can run
them both in parallel to compare.