### PR TITLE
No more submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,8 @@ docs/html/
 
 # Generated Documentation
 docs/dev/generate/
+# Notebooks are pulled from the dea-notebooks repo
+docs/notebooks
 
 # MYPY static type checker cache
 .mypy_cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "docs/notebooks"]
-	path = docs/notebooks
-	url = https://github.com/GeoscienceAustralia/dea-notebooks.git
-	branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,7 @@ before_script:
 
 script:
     - ./check-code.sh integration_tests
-    - pushd docs
-    - make html
-    - popd
+    - pushd docs && make fetchnotebooks html && popd
 
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,5 +19,11 @@ help:
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+fetchnotebooks:
+	[ -d notebooks ] || git clone https://github.com/GeoscienceAustralia/dea-notebooks.git notebooks
+	cd notebooks && git pull
+#	rm -rf notebooks
+#	git clone --depth 1 
+
 livehtml:
 	sphinx-autobuild -b html -p 8123 --watch . --ignore _build --ignore "*_tmp_*" --ignore "*_old_*" . $(ALLSPHINXOPTS) $(BUILDDIR)/html


### PR DESCRIPTION
`git submodules` weren't really the right choice for including the `dea-notebooks` repo when building the documentation. They point to a specific commit, whereas we always want to pull in `HEAD`. They just add complexity without us benefitting from them.

This PR replaces the `git submodule` for `dea-notebooks` with an additional target in `docs/Makefile` called `fetchnotebooks` which clones the `dea-notebooks` repo into the correct location. It can be called when building the documentation like `make fetchnotebooks html`.

I've also added `docs/notebooks/` to the `.gitignore` so that it doesn't accidentally get checked in, and updated the build on Travis-CI to use the new `Makefile` target.