### PR TITLE
PQ stats collections missing index connection

### DIFF
--- a/digitalearthau/collections.py
+++ b/digitalearthau/collections.py
@@ -431,6 +431,7 @@ def init_nci_collections(index: Index):
             name='pq_count_summary',
             query={'product': 'pq_count_summary'},
             file_patterns=['/g/data/fk4/datacube/002/stats/pq_count/history/LS_PQ_COUNT/*_*/LS_PQ_COUNT_3577_*.nc'],
+            index_=index,
             unique=('time.lower.day', 'lat', 'lon')
         )
     )
@@ -438,6 +439,7 @@ def init_nci_collections(index: Index):
         Collection(
             name='pq_count_annual_summary',
             query={'product': 'pq_count_annual_summary'},
+            index_=index,
             file_patterns=['/g/data/fk4/datacube/002/stats/pq_count/annual/LS_PQ_COUNT/*_*/LS_PQ_COUNT_3577_*.nc'],
             unique=('time.lower.day', 'lat', 'lon')
         )


### PR DESCRIPTION
Not completely understanding the collections API, I forgot to set the index for the PQ summary collections, and `dea-sync` understandably failed. This PR fixes this issue.