### PR TITLE
Remove format in geomedian product definition

### DIFF
--- a/digitalearthau/config/products/geomedian_nbart_annual.yaml
+++ b/digitalearthau/config/products/geomedian_nbart_annual.yaml
@@ -7,8 +7,6 @@ metadata:
     code: LANDSAT_8
   statistics:
     period: '1y'
-  format:
-    name: GeoTIFF
   instrument:
     name: OLI
 storage:
@@ -58,8 +56,6 @@ metadata:
     code: LANDSAT_7
   statistics:
     period: '1y'
-  format:
-    name: GeoTIFF
   instrument:
     name: ETM
 storage:
@@ -109,8 +105,6 @@ metadata:
     code: LANDSAT_5
   statistics:
     period: '1y'
-  format:
-    name: GeoTIFF
   instrument:
     name: TM
 storage:


### PR DESCRIPTION
Remove `format` in metadata column to index netcdfs for geomedian annual product 