### PR TITLE
Add email options, email id, and job attributes to dea-submit-ingest qsub command

### DIFF
--- a/digitalearthau/submit/ingest.py
+++ b/digitalearthau/submit/ingest.py
@@ -63,7 +63,7 @@ def do_qsub(product_name, year, queue, project, nodes, walltime, name, allow_pro
 
     if not config_path.exists():
         raise click.BadParameter("No config found for product {!r}".format(product_name))
- 
+
     subprocess.check_call('datacube -v system check', shell=True)
 
     product_changes_flag = '--allow-product-changes' if allow_product_changes else ''


### PR DESCRIPTION
**Reason for this pull request**

dea-submit-ingest qsub command did not have option to set umask of the output directories and also set email options. These options are helpful during aws lambda serverless deployment.

**Proposed changes**

Add email options, email ID, and job attributes to dea-submit-ingest qsub command.
