### PR TITLE
Add dumps of FC and WOfS products

### DIFF
--- a/digitalearthau/config/products/fc_albers.yaml
+++ b/digitalearthau/config/products/fc_albers.yaml
@@ -1,0 +1,135 @@
+---
+description: 'Landsat 5 Fractional Cover 25 metre, 100km tile, Australian Albers
+    Equal Area projection (EPSG:3577)'
+managed: true
+measurements:
+  - aliases:
+      - bare
+    dtype: int8
+    name: BS
+    nodata: -1
+    units: percent
+  - aliases:
+      - green_veg
+    dtype: int8
+    name: PV
+    nodata: -1
+    units: percent
+  - aliases:
+      - dead_veg
+    dtype: int8
+    name: NPV
+    nodata: -1
+    units: percent
+  - aliases:
+      - err
+    dtype: int8
+    name: UE
+    nodata: -1
+    units: '1'
+metadata:
+  instrument:
+    name: TM
+  platform:
+    code: LANDSAT_5
+  product_type: fractional_cover
+metadata_type: eo
+name: ls5_fc_albers
+storage:
+  crs: EPSG:3577
+  resolution:
+    x: 25
+    y: -25
+  tile_size:
+    x: 100000.0
+    y: 100000.0
+---
+description: 'Landsat 7 Fractional Cover 25 metre, 100km tile, Australian Albers
+    Equal Area projection (EPSG:3577)'
+managed: true
+measurements:
+  - aliases:
+      - bare
+    dtype: int8
+    name: BS
+    nodata: -1
+    units: percent
+  - aliases:
+      - green_veg
+    dtype: int8
+    name: PV
+    nodata: -1
+    units: percent
+  - aliases:
+      - dead_veg
+    dtype: int8
+    name: NPV
+    nodata: -1
+    units: percent
+  - aliases:
+      - err
+    dtype: int8
+    name: UE
+    nodata: -1
+    units: '1'
+metadata:
+  instrument:
+    name: ETM
+  platform:
+    code: LANDSAT_7
+  product_type: fractional_cover
+metadata_type: eo
+name: ls7_fc_albers
+storage:
+  crs: EPSG:3577
+  resolution:
+    x: 25
+    y: -25
+  tile_size:
+    x: 100000.0
+    y: 100000.0
+---
+description: 'Landsat 8 Fractional Cover 25 metre, 100km tile, Australian Albers
+    Equal Area projection (EPSG:3577)'
+managed: true
+measurements:
+  - aliases:
+      - bare
+    dtype: int8
+    name: BS
+    nodata: -1
+    units: percent
+  - aliases:
+      - green_veg
+    dtype: int8
+    name: PV
+    nodata: -1
+    units: percent
+  - aliases:
+      - dead_veg
+    dtype: int8
+    name: NPV
+    nodata: -1
+    units: percent
+  - aliases:
+      - err
+    dtype: int8
+    name: UE
+    nodata: -1
+    units: '1'
+metadata:
+  instrument:
+    name: OLI_TIRS
+  platform:
+    code: LANDSAT_8
+  product_type: fractional_cover
+metadata_type: eo
+name: ls8_fc_albers
+storage:
+  crs: EPSG:3577
+  resolution:
+    x: 25
+    y: -25
+  tile_size:
+    x: 100000.0
+    y: 100000.0

--- a/digitalearthau/config/products/wofs_albers.yaml
+++ b/digitalearthau/config/products/wofs_albers.yaml
@@ -1,0 +1,95 @@
+---
+description: 'Historic Flood Mapping Water Observations from Space'
+managed: true
+measurements:
+  - dtype: int16
+    flags_definition:
+      cloud:
+        bits: 6
+        description: Cloudy
+        values:
+          0: false
+          1: true
+      cloud_shadow:
+        bits: 5
+        description: 'Cloud shadow'
+        values:
+          0: false
+          1: true
+      dry:
+        bits:
+          - 7
+          - 6
+          - 5
+          - 4
+          - 3
+          - 1
+          - 0
+        description: 'No water detected'
+        values:
+          0: true
+      high_slope:
+        bits: 4
+        description: 'High slope'
+        values:
+          0: false
+          1: true
+      nodata:
+        bits: 0
+        description: 'No data'
+        values:
+          1: true
+      noncontiguous:
+        bits: 1
+        description: 'At least one EO band is missing over over/undersaturated'
+        values:
+          0: false
+          1: true
+      sea:
+        bits: 2
+        description: Sea
+        values:
+          0: false
+          1: true
+      terrain_or_low_angle:
+        bits: 3
+        description: 'terrain shadow or low solar angle'
+        values:
+          0: false
+          1: true
+      wet:
+        bits:
+          - 7
+          - 6
+          - 5
+          - 4
+          - 3
+          - 1
+          - 0
+        description: 'Clear and Wet'
+        values:
+          128: true
+    name: water
+    nodata: 1
+    units: '1'
+metadata:
+  product_type: wofs
+metadata_type: eo
+name: wofs_albers
+storage:
+  chunking:
+    time: 5
+    x: 200
+    y: 200
+  crs: EPSG:3577
+  dimension_order:
+    - time
+    - y
+    - x
+  driver: 'NetCDF CF'
+  resolution:
+    x: 25
+    y: -25
+  tile_size:
+    x: 100000.0
+    y: 100000.0

--- a/integration_tests/test_config.py
+++ b/integration_tests/test_config.py
@@ -77,6 +77,10 @@ def test_dea_config(dea_index: Index):
         'ls5_nbart_geomedian_annual',
         'ls7_nbart_geomedian_annual',
         'ls8_nbart_geomedian_annual',
+        'wofs_albers',
+        'ls5_fc_albers',
+        'ls7_fc_albers',
+        'ls8_fc_albers',
     }
 
 


### PR DESCRIPTION
WOfS and FC apps generate their own product definitions into the production database.

Include a dump of them in the github repo for reference purposes, and for anyone indexing our data into a new database.