### PR TITLE
Update dea-coherence for removing duplicate datasets in 1:1 relationships

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,10 @@ install:
     - popd
     - export CPLUS_INCLUDE_PATH="/usr/include/gdal"
     - export C_INCLUDE_PATH="/usr/include/gdal"
+
     - travis_retry pip install GDAL==1.10.0 codecov
-    # For building documentation
     - travis_retry pip install git+https://github.com/GeoscienceAustralia/eo-datasets.git
-    - travis_retry pip install --pre --extra-index-url https://packages.dea.gadevs.ga/ datacube
+    - travis_retry pip install --extra-index-url https://packages.dea.gadevs.ga/ 'datacube>=0.0.dev0'
     - travis_retry pip install -e .[doc,test]
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
@@ -56,6 +56,7 @@ before_script:
   - ./cc-test-reporter before-build
 
 script:
+    - pip freeze
     - ./check-code.sh integration_tests
     - pushd docs && make fetchnotebooks html && popd
 

--- a/digitalearthau/coherence.py
+++ b/digitalearthau/coherence.py
@@ -67,19 +67,19 @@ def main(expressions, check_locationless, archive_locationless, check_ancestors,
             if check_locationless or archive_locationless:
                 if dataset.uris is not None and len(dataset.uris) == 0:
                     locationless_count += 1
-                    
+
                     if archive_locationless:
                         dc.index.datasets.archive([dataset.id])
                         archive_count += 1
                         _LOG.info("locationless_dataset_id.archived", dataset_id=str(dataset.id))
                     else:
                         _LOG.info("locationless_dataset_id", dataset_id=str(dataset.id))
-            
+
             # If an ancestor is archived, it may have been replaced. This one may need
             # to be reprocessed too.
             if check_ancestors or archive_siblings or check_siblings:
                 archive_count += _check_ancestors(check_ancestors, check_siblings, archive_siblings, dc, dataset)
-        
+
         _LOG.info("coherence.finish",
                   datasets_count=count,
                   locationless_count=locationless_count,
@@ -90,15 +90,15 @@ def main(expressions, check_locationless, archive_locationless, check_ancestors,
 def _archive_dataset_ids(dc, ds_id, sibling_ids):
     # sibling/s indexed_time dictionary
     sb_itime_dict = dict()
-    
+
     # Count of dataset id's archived
     archive_count = 0
-    
+
     # dataset indexed time
     ds_itime = dc.index.datasets.get(ds_id).indexed_time
     for key, s_id in enumerate(sibling_ids):
         sb_itime_dict[s_id] = dc.index.datasets.get(s_id).indexed_time
-    
+
     # new dataset id to retain
     new_id = ds_id
     for id, itime in sb_itime_dict.items():
@@ -106,18 +106,18 @@ def _archive_dataset_ids(dc, ds_id, sibling_ids):
         if ds_itime <= itime:
             ds_id_archive = new_id
             ds_archive_time = ds_itime
-            
+
             # Latest sibling dataset id to retain
             new_id = id
             ds_itime = itime
         else:
             ds_id_archive = id
             ds_archive_time = itime
-        
+
         dc.index.datasets.archive([ds_id_archive])
         _LOG.info("\tarchived_dataset_id", id=str(ds_id_archive), indexed_time=str(ds_archive_time))
         archive_count += 1
-    
+
     _LOG.info("\trecent_dataset_id", id=str(new_id), indexed_time=str(ds_itime))
     return archive_count
 
@@ -144,7 +144,7 @@ def _check_ancestors(check_ancestors: bool,
                 # (this only applies to source products that are 1:1 with
                 # descendants, not pass-to-scene or scene-to-tile conversions)
                 siblings = dc.index.datasets.get_derived(source_dataset.id)
-                
+
                 # Only active siblings of the same type.
                 siblings = [
                     s for s in siblings
@@ -156,11 +156,11 @@ def _check_ancestors(check_ancestors: bool,
                     _LOG.info("dataset.siblings_exist",
                               dataset_id=str(dataset.id),
                               siblings=sibling_ids)
-                    
+
                     # Choose the most recent sibling and archive others
                     if archive_siblings:
                         ancestors_archive_count += _archive_dataset_ids(dc, dataset.id, sibling_ids)
-    
+
     return ancestors_archive_count
 
 

--- a/digitalearthau/coherence.py
+++ b/digitalearthau/coherence.py
@@ -7,15 +7,13 @@ from datacube.ui import click as ui
 from digitalearthau import uiutil
 
 _LOG = structlog.getLogger('archive-locationless')
+_siblings_count = 0
 
 
 @click.command()
-@click.option('--debug',
-              is_flag=True,
-              help='Enable debug logging')
 @click.option('--check-locationless/--no-check-locationless',
               is_flag=True,
-              default=True,
+              default=False,
               help='Check any datasets without locations')
 @click.option('--archive-locationless',
               is_flag=True,
@@ -23,12 +21,21 @@ _LOG = structlog.getLogger('archive-locationless')
               help="Archive datasets with no active locations (forces --check-locationless)")
 @click.option('--check-ancestors',
               is_flag=True,
+              default=False,
               help='Check if ancestor/source datasets are still active/valid')
 @click.option('--check-siblings',
               is_flag=True,
+              default=False,
               help='Check if ancestor datasets have other children of the same type (they may be duplicates)')
+@click.option('--archive-siblings',
+              is_flag=True,
+              default=False,
+              help="Archive sibling datasets (forces --check-ancestors)")
+@click.option('--test-dc-config', '-C',
+              help='Custom datacube config file (testing purpose only)')
 @ui.parsed_search_expressions
-def main(expressions, archive_locationless, debug, check_locationless, check_ancestors, check_siblings):
+def main(expressions, check_locationless, archive_locationless, check_ancestors, check_siblings, archive_siblings,
+         test_dc_config):
     """
     Find problem datasets using the index.
 
@@ -40,15 +47,18 @@ def main(expressions, archive_locationless, debug, check_locationless, check_anc
     you've synced the ancestor collections too.
 
     (the sync tool cannot do these checks "live", as we don't know how many locations there are of a dataset
-    until the entire folder has been synced, and ideally the ancestors synced too.
+    until the entire folder has been synced, and ideally the ancestors synced too.)
     TODO: This could be merged into it as a post-processing step, although it's less safe than sync if
-    the index is being updated concurrently by another)
+    TODO: the index is being updated concurrently by another
     """
+    global _siblings_count
     uiutil.init_logging()
-    with Datacube() as dc:
+    config_file = test_dc_config if test_dc_config else ''
+    with Datacube(config=config_file) as dc:
         _LOG.info('query', query=expressions)
         count = 0
         archive_count = 0
+        locationless_count = 0
         for dataset in dc.index.datasets.search(**expressions):
             count += 1
             # Archive if it has no locations.
@@ -56,47 +66,102 @@ def main(expressions, archive_locationless, debug, check_locationless, check_anc
             # but can't archive datasets as another path may be added later during the sync)
             if check_locationless or archive_locationless:
                 if dataset.uris is not None and len(dataset.uris) == 0:
-                    _LOG.info("dataset.locationless", dataset_id=str(dataset.id))
+                    locationless_count += 1
+                    
                     if archive_locationless:
                         dc.index.datasets.archive([dataset.id])
                         archive_count += 1
-
+                        _LOG.info("locationless_dataset_id.archived", dataset_id=str(dataset.id))
+                    else:
+                        _LOG.info("locationless_dataset_id", dataset_id=str(dataset.id))
+            
             # If an ancestor is archived, it may have been replaced. This one may need
             # to be reprocessed too.
-            if check_ancestors:
-                _check_ancestors(check_siblings, dc, dataset)
+            if check_ancestors or archive_siblings or check_siblings:
+                archive_count += _check_ancestors(check_ancestors, check_siblings, archive_siblings, dc, dataset)
+        
+        _LOG.info("coherence.finish",
+                  datasets_count=count,
+                  locationless_count=locationless_count,
+                  siblings_count=_siblings_count,
+                  archived_count=archive_count)
 
-        _LOG.info("coherence.finish", count=count, archive_count=archive_count)
+
+def _archive_dataset_ids(dc, ds_id, sibling_ids):
+    # sibling/s indexed_time dictionary
+    sb_itime_dict = dict()
+    
+    # Count of dataset id's archived
+    archive_count = 0
+    
+    # dataset indexed time
+    ds_itime = dc.index.datasets.get(ds_id).indexed_time
+    for key, s_id in enumerate(sibling_ids):
+        sb_itime_dict[s_id] = dc.index.datasets.get(s_id).indexed_time
+    
+    # new dataset id to retain
+    new_id = ds_id
+    for id, itime in sb_itime_dict.items():
+        # Check if dataset indexed time is less than or equal to sibling dataset indexed time
+        if ds_itime <= itime:
+            ds_id_archive = new_id
+            ds_archive_time = ds_itime
+            
+            # Latest sibling dataset id to retain
+            new_id = id
+            ds_itime = itime
+        else:
+            ds_id_archive = id
+            ds_archive_time = itime
+        
+        dc.index.datasets.archive([ds_id_archive])
+        _LOG.info("\tarchived_dataset_id", id=str(ds_id_archive), indexed_time=str(ds_archive_time))
+        archive_count += 1
+    
+    _LOG.info("\trecent_dataset_id", id=str(new_id), indexed_time=str(ds_itime))
+    return archive_count
 
 
-def _check_ancestors(check_siblings: bool, dc: Datacube, dataset: Dataset):
+def _check_ancestors(check_ancestors: bool,
+                     check_siblings: bool,
+                     archive_siblings: bool,
+                     dc: Datacube,
+                     dataset: Dataset):
+    global _siblings_count
+    ancestors_archive_count = 0
     dataset = dc.index.datasets.get(dataset.id, include_sources=True)
     if dataset.sources:
         for classifier, source_dataset in dataset.sources.items():
-            if source_dataset.is_archived:
+            if check_ancestors and source_dataset.is_archived:
                 _LOG.info(
-                    "dataset.ancestor_defunct",
+                    "ancestor.dataset_id",
                     dataset_id=str(dataset.id),
                     source_type=classifier,
                     source_dataset_id=str(source_dataset.id)
                 )
-            elif check_siblings:
+            elif check_siblings or archive_siblings:
                 # If a source dataset has other siblings they may be duplicates.
                 # (this only applies to source products that are 1:1 with
                 # descendants, not pass-to-scene or scene-to-tile conversions)
                 siblings = dc.index.datasets.get_derived(source_dataset.id)
+                
                 # Only active siblings of the same type.
                 siblings = [
                     s for s in siblings
                     if s != dataset and not s.is_archived and s.type == dataset.type
                 ]
                 if siblings:
+                    _siblings_count += 1
+                    sibling_ids = [str(d.id) for d in siblings]
                     _LOG.info("dataset.siblings_exist",
                               dataset_id=str(dataset.id),
-                              siblings=[str(d.id) for d in siblings])
-                    # TODO Archive? This is currently purely for reporting, but if we know that a duplicate
-                    #      sibling exists which is better or newer, we could possibly archive this one now.
-                    # (deciding whether "duplicate", "better" and "newer" are all quite nuanced, though)
+                              siblings=sibling_ids)
+                    
+                    # Choose the most recent sibling and archive others
+                    if archive_siblings:
+                        ancestors_archive_count += _archive_dataset_ids(dc, dataset.id, sibling_ids)
+    
+    return ancestors_archive_count
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Reason for this pull request**
When creating derived products in DEA, some have a simple 1:1 relationship with their parent product. 
For example: every NBART Albers Tile, should have 1 and only 1 Fractional Cover tile.

Our current processes cover the case where a tile isn’t generated, and will fill in the gaps.
Sometimes, processing will create more than one tile, and we need to be able to clean these up in a safe and automated manner. At the moment, we have duplicate LS7 FC tiles around the end of 2017 (See https://data.dea.gadevs.ga/ls7_fc_albers/2017 the graph from the data dashboard)

The dea-coherence tool is able to find these 'sibling' datasets, but has no way of dealing with them.

**Proposed changes**
Modify dea-coherence tool to be able to choose the most recent sibling and archive the others.

The command to list FC duplicates:
- `dea-coherence --check-ancestors --check-siblings product=ls7_fc_albers '2017-10-01 < time < 2017-10-15'`
    
The command to archive FC duplicates:
- `dea-coherence --archive-siblings product=ls7_fc_albers '2017-10-01 < time < 2017-10-15'`