### PR TITLE
Update test datacube configuration path

### DIFF
--- a/scripts/nci_env_deatest/Test_DEA_Module.sh
+++ b/scripts/nci_env_deatest/Test_DEA_Module.sh
@@ -60,7 +60,7 @@ echo "
 ==================================================================="
 echo ""
 # shellcheck source=/dev/null
-source "$HOMEDIR"/dea_testscripts/setup_deamodule_env.sh "$MODULE" "$DCCONF"
+source "$HOMEDIR"/dea_testscripts/setup_deamodule_env.sh "$MODULE" "$CONFIGFILE"
 
 # Delete previous database (If any)
 dea-test-env -C "$CONFIGFILE" teardown

--- a/scripts/nci_env_deatest/dea_testscripts/dea-stacker.sh
+++ b/scripts/nci_env_deatest/dea_testscripts/dea-stacker.sh
@@ -11,7 +11,6 @@ echo "
   ********************************************************************" > "$HOMEDIR"/output_files/deastacker/DEA_Stacker.log
 
 CONFIGFILE=$HOMEDIR/datacube_config.conf
-DCCONF="datacube_config.conf"
 
 if [ "$1" == "--help" ] || [ "$#" -ne 2 ] || [ "$1" == "-help" ]; then
   echo "       Usage: $(basename "$0") [--help] [DEA_MODULE_TO_TEST] [YEAR_TO_STACK]
@@ -48,7 +47,7 @@ echo "
 echo "" >> "$HOMEDIR"/output_files/deastacker/DEA_Stacker.log
 
 # shellcheck source=/dev/null
-source "$HOMEDIR"/dea_testscripts/setup_deamodule_env.sh "$MODULE" "$DCCONF"
+source "$HOMEDIR"/dea_testscripts/setup_deamodule_env.sh "$MODULE" "$CONFIGFILE"
 
 ##################################################################################################
 # Run a test index and ingest on NCI and Raijin system

--- a/scripts/nci_env_deatest/dea_testscripts/index_and_ingest.sh
+++ b/scripts/nci_env_deatest/dea_testscripts/index_and_ingest.sh
@@ -28,38 +28,52 @@ datacube -vv -C "$2" system check
 # To disable globstar: shopt -u globstar
 shopt -s globstar
 
+declare -a nbart_scene_folders=("LS8_OLITIRS_NBART_P54_GANBART01-032_088_076_20180504"
+                                "LS8_OLITIRS_NBART_P54_GANBART01-032_088_077_20180504"
+                                "LS8_OLITIRS_NBART_P54_GANBART01-032_088_078_20180504"
+                                "LS8_OLITIRS_NBART_P54_GANBART01-032_088_079_20180504"
+                                "LS8_OLITIRS_NBART_P54_GANBART01-032_088_080_20180504"
+                                "LS8_OLITIRS_NBART_P54_GANBART01-032_088_081_20180504"
+                                "LS8_OLITIRS_NBART_P54_GANBART01-032_088_082_20180504"
+                                "LS8_OLITIRS_NBART_P54_GANBART01-032_088_083_20180504")
+                             
+declare -a nbar_scene_folders=("LS8_OLITIRS_NBAR_P54_GANBAR01-032_088_076_20180504"
+                               "LS8_OLITIRS_NBAR_P54_GANBAR01-032_088_077_20180504"
+                               "LS8_OLITIRS_NBAR_P54_GANBAR01-032_088_078_20180504"
+                               "LS8_OLITIRS_NBAR_P54_GANBAR01-032_088_079_20180504"
+                               "LS8_OLITIRS_NBAR_P54_GANBAR01-032_088_080_20180504"
+                               "LS8_OLITIRS_NBAR_P54_GANBAR01-032_088_081_20180504"
+                               "LS8_OLITIRS_NBAR_P54_GANBAR01-032_088_082_20180504"
+                               "LS8_OLITIRS_NBAR_P54_GANBAR01-032_088_083_20180504")
+
+declare -a pq_scene_folders=("LS8_OLITIRS_PQ_P55_GAPQ01-032_088_076_20180504"
+                             "LS8_OLITIRS_PQ_P55_GAPQ01-032_088_077_20180504"
+                             "LS8_OLITIRS_PQ_P55_GAPQ01-032_088_078_20180504"
+                             "LS8_OLITIRS_PQ_P55_GAPQ01-032_088_079_20180504"
+                             "LS8_OLITIRS_PQ_P55_GAPQ01-032_088_080_20180504"
+                             "LS8_OLITIRS_PQ_P55_GAPQ01-032_088_081_20180504"
+                             "LS8_OLITIRS_PQ_P55_GAPQ01-032_088_082_20180504"
+                             "LS8_OLITIRS_PQ_P55_GAPQ01-032_088_083_20180504")
+
 # LS8_OLITIRS_NBAR/NBART/PQ Scenes
-#sh "$3"/../dea_testscripts/dea-sync.sh "$1" 2018 ls8_nbart_scene no /g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/05/output/nbart "$3"
-#sleep 10s
+for i in "${nbart_scene_folders[@]}"
+do
+    sh "$3"/../dea_testscripts/dea-sync.sh "$1" 2018 ls8_nbart_scene no "/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/05/output/nbart/$i" "$3"
+    sleep 10s
+done
 
-sh "$3"/../dea_testscripts/dea-sync.sh "$1" 2018 ls8_pq_scene no /g/data/rs0/scenes/pq-scenes-tmp/ls8/2018/05/output/pqa/LS8_OLITIRS_PQ_P55_GAPQ01-032_088_076_20180504 "$3"
-sleep 10s
-sh "$3"/../dea_testscripts/dea-sync.sh "$1" 2018 ls8_pq_scene no /g/data/rs0/scenes/pq-scenes-tmp/ls8/2018/05/output/pqa/LS8_OLITIRS_PQ_P55_GAPQ01-032_088_077_20180504 "$3"
-sleep 10s
-sh "$3"/../dea_testscripts/dea-sync.sh "$1" 2018 ls8_pq_scene no /g/data/rs0/scenes/pq-scenes-tmp/ls8/2018/05/output/pqa/LS8_OLITIRS_PQ_P55_GAPQ01-032_088_078_20180504 "$3"
-sleep 10s
-sh "$3"/../dea_testscripts/dea-sync.sh "$1" 2018 ls8_pq_scene no /g/data/rs0/scenes/pq-scenes-tmp/ls8/2018/05/output/pqa/LS8_OLITIRS_PQ_P55_GAPQ01-032_088_079_20180504 "$3"
-sleep 10s
-sh "$3"/../dea_testscripts/dea-sync.sh "$1" 2018 ls8_pq_scene no /g/data/rs0/scenes/pq-scenes-tmp/ls8/2018/05/output/pqa/LS8_OLITIRS_PQ_P55_GAPQ01-032_088_080_20180504 "$3"
-sleep 10s
-sh "$3"/../dea_testscripts/dea-sync.sh "$1" 2018 ls8_pq_scene no /g/data/rs0/scenes/pq-scenes-tmp/ls8/2018/05/output/pqa/LS8_OLITIRS_PQ_P55_GAPQ01-032_088_081_20180504 "$3"
-sleep 10s
-sh "$3"/../dea_testscripts/dea-sync.sh "$1" 2018 ls8_pq_scene no /g/data/rs0/scenes/pq-scenes-tmp/ls8/2018/05/output/pqa/LS8_OLITIRS_PQ_P55_GAPQ01-032_088_082_20180504 "$3"
-sleep 10s
-sh "$3"/../dea_testscripts/dea-sync.sh "$1" 2018 ls8_pq_scene no /g/data/rs0/scenes/pq-scenes-tmp/ls8/2018/05/output/pqa/LS8_OLITIRS_PQ_P55_GAPQ01-032_088_083_20180504 "$3"
-sleep 10s
+for i in "${pq_scene_folders[@]}"
+do
+    sh "$3"/../dea_testscripts/dea-sync.sh "$1" 2018 ls8_pq_scene no "/g/data/rs0/scenes/pq-scenes-tmp/ls8/2018/05/output/pqa/$i" "$3"
+    sleep 10s
+done
 
-cd /g/data/u46/users/dra547/dea_odc_testing/LS8_OLITIRS_NBAR_P54_GANBAR01-032_099_077_20180110 || exit 0
-datacube -vv -C "$2" dataset add ./**/ga-metadata.yaml
-
-cd /g/data/u46/users/dra547/dea_odc_testing/LS8_OLITIRS_NBAR_P54_GANBAR01-032_099_077_20180126 || exit 0
-datacube -vv -C "$2" dataset add ./**/ga-metadata.yaml
-
-cd /g/data/u46/users/dra547/dea_odc_testing/LS8_OLITIRS_NBART_P54_GANBART01-032_099_077_20180110 || exit 0
-datacube -vv -C "$2" dataset add ./**/ga-metadata.yaml
-
-cd /g/data/u46/users/dra547/dea_odc_testing/LS8_OLITIRS_NBART_P54_GANBART01-032_099_077_20180126 || exit 0
-datacube -vv -C "$2" dataset add ./**/ga-metadata.yaml
+for i in "${nbar_scene_folders[@]}"
+do
+    cd "/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/05/output/nbar/$i" || exit 0
+    datacube -vv -C "$2" dataset add ./**/ga-metadata.yaml
+    sleep 10s
+done
 
 sleep 60s  
 

--- a/scripts/nci_env_deatest/dea_testscripts/pbs_nbconvert_script.sh
+++ b/scripts/nci_env_deatest/dea_testscripts/pbs_nbconvert_script.sh
@@ -48,7 +48,7 @@ cd "$TEST_BASE" || exit 0
 
 # Load DEA module
 # shellcheck source=/dev/null
-source "$TEST_BASE"/../dea_testscripts/setup_deamodule_env.sh "$MUT" "$DC_CONF"
+source "$TEST_BASE"/../dea_testscripts/setup_deamodule_env.sh "$MUT" "$TEST_BASE"/../"$DC_CONF"
 
 ## Convert a notebook to an python script and print the stdout
 ## To remove code cells from the output, use templateExporter

--- a/scripts/nci_env_deatest/dea_testscripts/pbs_script.sh
+++ b/scripts/nci_env_deatest/dea_testscripts/pbs_script.sh
@@ -48,5 +48,5 @@ echo "
 echo "" >> "$SUBMISSION_LOG"
 
 # shellcheck source=/dev/null
-source "$TESTBASE"/../dea_testscripts/setup_deamodule_env.sh "$MUT" "$TESTBASE"/../"$(basename "$CONFIG_FILE")"
+source "$TESTBASE"/../dea_testscripts/setup_deamodule_env.sh "$MUT" "$CONFIG_FILE"
 sh "$TESTBASE"/../dea_testscripts/index_and_ingest.sh "$MUT" "$CONFIG_FILE" "$TESTBASE" "$DATABASENAME" >> "$SUBMISSION_LOG"

--- a/scripts/nci_env_deatest/dea_testscripts/setup_deamodule_env.sh
+++ b/scripts/nci_env_deatest/dea_testscripts/setup_deamodule_env.sh
@@ -4,12 +4,12 @@ LANG=en_AU.UTF-8
 
 if [ "$#" -eq 2 ]
 then
-   DC_CONFIG_PATH=$(pwd)/../"$2"
+   DC_CONFIG_PATH="$2"
 else
   echo "       Usage: $(basename "$0") [--help] [DEA_MODULE_TO_TEST] [DATACUBE_CONFIG_FILE]
                  where:
                        DEA_MODULE_TO_TEST  Module under test (ex. dea/20180503 or dea-env or dea)
-                       DATACUBE_CONFIG_FILE  Datacube Config Filename"
+                       DATACUBE_CONFIG_FILE  Datacube Config file path"
   echo
   exit 0
 fi


### PR DESCRIPTION
**Reason for this pull request**
Test datacube configuration path used in some of the scripts were hard-coded. Update is required to make it more generic so that scripts can be executed from any directory.

**Proposed solutions**
1. Remove dc configuration paths that are hard-coded.
