### PR TITLE
Add world readable check and fix pbs task scheduling

### DIFF
--- a/scripts/nci_env_deatest/Test_DEA_Module.sh
+++ b/scripts/nci_env_deatest/Test_DEA_Module.sh
@@ -5,6 +5,7 @@ MODULE="$1"
 HOMEDIR=$(pwd)
 modname=$(echo "$MODULE" | sed -r "s/[/]+/_/g")
 WORKDIR="$HOMEDIR"/test"$modname"-$(date '+%d%m%yT%H%M')
+LOGFILE="$WORKDIR"/'Not_World_Readable_Files.log'
 
 CONFIGFILE="$HOMEDIR/datacube_config.conf"
 DCCONF="datacube_config.conf"
@@ -15,6 +16,16 @@ if [ "$1" == "--help" ] || [ "$#" -ne 1 ] || [ "$1" == "-help" ]; then
                        DEA_MODULE_TO_TEST  Module under test (ex. dea/20180503 or dea-env or dea)"
   echo
   exit 0
+fi
+
+# Ensure that all files are world readable
+if [[ $(find "/g/data/v10/public/modules/$MODULE" ! -perm -o=r) ]]; then
+    echo "Error: Some files in $MODULE are not world readable"
+    echo "
+Following files in $MODULE are not world readable:
+-----------------------------------------------------------------
+$(find /g/data/v10/public/modules/"$MODULE" ! -perm -o=r)" > "$LOGFILE"
+    exit 0
 fi
 
 # Function to wait till pbs job is completed

--- a/scripts/nci_env_deatest/dea_testscripts/index_and_ingest.sh
+++ b/scripts/nci_env_deatest/dea_testscripts/index_and_ingest.sh
@@ -59,13 +59,15 @@ declare -a pq_scene_folders=("LS8_OLITIRS_PQ_P55_GAPQ01-032_088_076_20180504"
 for i in "${nbart_scene_folders[@]}"
 do
     sh "$3"/../dea_testscripts/dea-sync.sh "$1" 2018 ls8_nbart_scene no "/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/05/output/nbart/$i" "$3"
-    sleep 10s
+    sleep 60s
+    wait_pbs_job "NBART Index"
 done
 
 for i in "${pq_scene_folders[@]}"
 do
     sh "$3"/../dea_testscripts/dea-sync.sh "$1" 2018 ls8_pq_scene no "/g/data/rs0/scenes/pq-scenes-tmp/ls8/2018/05/output/pqa/$i" "$3"
-    sleep 10s
+    sleep 60s
+    wait_pbs_job "PQ Index"
 done
 
 for i in "${nbar_scene_folders[@]}"
@@ -74,8 +76,6 @@ do
     datacube -vv -C "$2" dataset add ./**/ga-metadata.yaml
     sleep 10s
 done
-
-sleep 60s  
 
 # Wait till sync and nbconvert job is completed
 wait_pbs_job "Dea-Sync and NBConvert"
@@ -105,13 +105,14 @@ declare -a albers_yaml_array=("ls8_nbart_albers.yaml"
                               "ls8_pq_albers.yaml")
 
 DC_PATH="$3"/../"$(basename "$2")"
-export DATACUBE_CONFIG_PATH="$DC_PATH"
 
 cd "$3"/work/ingest || exit 0
+export DATACUBE_CONFIG_PATH="$DC_PATH"
 for i in "${albers_yaml_array[@]}"
 do
   productname=$(echo "$i" | cut -f 1 -d '.')
   yes Y | dea-submit-ingest qsub --project u46 --queue express -n 5 -t 10 -m a -M santosh.mohan@ga.gov.au -W umask=33 --name ingest_"$productname" -c "$3"/ingest_configfiles/"$i" --allow-product-changes "$productname" 2018
+  wait_pbs_job "dea-submit-ingest"
 done
 
 sleep 60s


### PR DESCRIPTION
Reason for this pull request:
1) World readable check was missing in the test script. 
2) **dea-sync** pbs jobs and **dea-submit-ingest** pbs jobs did not run in parallel. Out of 8 **dea-sync** jobs, 3 were successful and the rest failed due to conflict in accessing a cache file or accessing database.
**dea-submit-ingest** pbs jobs failed to index the created storage units due to database access permission issue.