### PR TITLE
Set click path exists option in dea-submit-ingest qsub as false

### DIFF
--- a/digitalearthau/submit/ingest.py
+++ b/digitalearthau/submit/ingest.py
@@ -48,7 +48,7 @@ def list_products():
               help='Setting job attributes\n'
               '<attribute>=<value>')
 @click.option('--config-file', '-c', default='',
-              type=click.Path(exists=True, readable=True, writable=False, dir_okay=False),
+              type=click.Path(exists=False, readable=True, writable=False, dir_okay=False),
               help='Ingest configuration file')
 @click.argument('product_name')
 @click.argument('year')


### PR DESCRIPTION
Reason for this pull request
Setting dea-submit-ingest qsub path.exists as true would make user to enter the config options as a mandatory argument. 

Proposed solution
Set dea-submit-ingest qsub path.exists option to false