### PR TITLE
Add some extra logging to `run_distributed.sh`

### DIFF
--- a/digitalearthau/run_distributed.sh
+++ b/digitalearthau/run_distributed.sh
@@ -68,6 +68,11 @@ sleep 5s
 
 echo "*** APPLICATION ***"
 echo "${@/DSCHEDULER/${SCHEDULER_ADDR}}"
+echo
+echo "*** Datacube Check ***"
+datacube -vv system check
+set | grep -i datacube
+echo "PATH=$PATH"
 
 "${@/DSCHEDULER/${SCHEDULER_ADDR}}"
 


### PR DESCRIPTION
When running qsub jobs we weren't logging enough information to debug some
issues.

This is a small step in the right direction...