### PR TITLE
Add metadata storage format type to the fc product config

### DIFF
--- a/digitalearthau/config/products/fc_albers.yaml
+++ b/digitalearthau/config/products/fc_albers.yaml
@@ -28,6 +28,8 @@ measurements:
     nodata: -1
     units: '1'
 metadata:
+  format:
+    name: NetCDF
   instrument:
     name: TM
   platform:
@@ -73,6 +75,8 @@ measurements:
     nodata: -1
     units: '1'
 metadata:
+  format:
+    name: NetCDF
   instrument:
     name: ETM
   platform:
@@ -118,6 +122,8 @@ measurements:
     nodata: -1
     units: '1'
 metadata:
+  format:
+    name: NetCDF
   instrument:
     name: OLI_TIRS
   platform:


### PR DESCRIPTION
### **Reason for this pull request**
Fractional cover application depends on metadata storage data type in the source product definition. Dea-test-env setup adds metadata_type to the database without metadata storage data type for fractional cover products.

This issue was detected when we perform dea-test-env teardown and then perform dea-test-env setup.
Once database is setup and nbart products are ingested, any attempt to perform fractional cover on ingested nbart products would raise source and new product definition document mismatch.

### **Proposed solution**
Add metadata format name in fc_albers.yaml file