### PR TITLE
Revert dsm1sv10 to match its prod data

### DIFF
--- a/digitalearthau/config/products/dsm1sv10.yaml
+++ b/digitalearthau/config/products/dsm1sv10.yaml
@@ -6,12 +6,11 @@ metadata_type: eo
 metadata:
     platform:
         code: SRTM
+    format:
+        name: GeoTIFF
     instrument:
         name: SIR
     product_type: DEM
-    format:
-        name: ENVI
-
 storage:
     crs: EPSG:4326
     resolution:


### PR DESCRIPTION
Despite "ENVI" format being correct, the product does not match our current datasets.  This is causing [indexing of our current WOfS data to fail](https://travis-ci.org/jeremyh/dea-dashboard/builds/415243654#L1258), which has dsm1sv10 as a source dataset (with "format: GeoTIFF").

(when/if the datasets are corrected, we can change it here and in prod together)