### PR TITLE
Fix raijin login node memory issue during two stage PBS job submission

### DIFF
--- a/digitalearthau/submit/ingest.py
+++ b/digitalearthau/submit/ingest.py
@@ -15,7 +15,7 @@ from digitalearthau import INGEST_CONFIG_DIR
 from datacube.ui import click as ui
 
 DISTRIBUTED_SCRIPT = digitalearthau.SCRIPT_DIR / 'run_distributed.sh'
-APP_NAME='dea-submit-ingest'
+APP_NAME = 'dea-submit-ingest'
 
 
 @click.group()
@@ -87,7 +87,7 @@ def do_qsub(queue, project, nodes, walltime, name, allow_product_changes, email_
     else:
         click.echo('Two stage ingest PBS job not requested, hence exiting!')
         click.get_current_context().exit(0)
-    
+
     test = 'qsub -V -q %(queue)s -N ingest_dry_run -P %(project)s -W depend=afterok:%(savetask_job)s ' \
            '-l walltime=05:00:00,mem=31GB ' \
            '-- datacube -v ingest %(product_changes_flag)s --load-tasks "%(taskfile)s" --dry-run'
@@ -158,7 +158,7 @@ def stack(queue, project, nodes, walltime, name, product_name, year):
            '-l walltime=05:00:00,mem=31GB ' \
            '-- datacube-stacker -v --app-config "%(config)s" --year %(year)s ' \
            '--save-tasks "%(taskfile)s"'
-    cmd = prep % dict(queue=queue, project=project, config=config_path,  year=year, taskfile=taskfile)
+    cmd = prep % dict(queue=queue, project=project, config=config_path, year=year, taskfile=taskfile)
     if click.confirm('\n' + cmd + '\nRUN?', default=True):
         savetask_job = subprocess.check_output(cmd, shell=True).decode("utf-8").split('\n')[0]
     else:
@@ -216,7 +216,7 @@ def fix(queue, project, nodes, walltime, name, product_name, year):
     prep = 'qsub -V -q %(queue)s -N fix_save_tasks -P %(project)s ' \
            '-l walltime=05:00:00,mem=31GB ' \
            '-- datacube-fixer -v --app-config "%(config)s" --year %(year)s --save-tasks "%(taskfile)s"'
-    cmd = prep % dict(queue=queue, project=project, config=config_path,  year=year, taskfile=taskfile)
+    cmd = prep % dict(queue=queue, project=project, config=config_path, year=year, taskfile=taskfile)
     if click.confirm('\n' + cmd + '\nRUN?', default=True):
         savetask_job = subprocess.check_output(cmd, shell=True).decode("utf-8").split('\n')[0]
     else:

--- a/digitalearthau/submit/ingest.py
+++ b/digitalearthau/submit/ingest.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -11,7 +12,10 @@ from click import echo
 import digitalearthau
 from digitalearthau import INGEST_CONFIG_DIR
 
+from datacube.ui import click as ui
+
 DISTRIBUTED_SCRIPT = digitalearthau.SCRIPT_DIR / 'run_distributed.sh'
+APP_NAME='dea-submit-ingest'
 
 
 @click.group()
@@ -27,6 +31,8 @@ def list_products():
 
 
 @cli.command('qsub')
+@ui.config_option
+@ui.verbose_option
 @click.option('--queue', '-q', default='normal',
               type=click.Choice(['normal', 'express']))
 @click.option('--project', '-P', default='v10')
@@ -47,19 +53,19 @@ def list_products():
 @click.option('--job_attributes', '-W', default='umask=33',
               help='Setting job attributes\n'
               '<attribute>=<value>')
-@click.option('--config-file', '-c', default='',
+@click.option('--app-config', '-c', default='',
               type=click.Path(exists=False, readable=True, writable=False, dir_okay=False),
               help='Ingest configuration file')
 @click.option('--queue-size', type=click.IntRange(1, 100000), default=40000, help='Ingest task queue size')
 @click.argument('product_name')
 @click.argument('year')
-def do_qsub(product_name, year, queue, project, nodes, walltime, name, allow_product_changes, email_options, email_id,
-            job_attributes, config_file, queue_size):
-    """Submits an ingest job to qsub."""
-    if not config_file:
+def do_qsub(queue, project, nodes, walltime, name, allow_product_changes, email_options, email_id,
+            job_attributes, app_config, queue_size, product_name, year):
+    """Submits an ingest job, using a two stage PBS job submission."""
+    if not app_config:
         config_path = INGEST_CONFIG_DIR / '{}.yaml'.format(product_name)
     else:
-        config_path = Path(config_file).absolute()
+        config_path = Path(app_config).absolute()
     taskfile = Path(product_name + '_' + year.replace('-', '_') + '.bin').absolute()
 
     if not config_path.exists():
@@ -69,44 +75,63 @@ def do_qsub(product_name, year, queue, project, nodes, walltime, name, allow_pro
 
     product_changes_flag = '--allow-product-changes' if allow_product_changes else ''
 
-    prep = 'datacube -v ingest -c "%(config)s" %(product_changes_flag)s --year %(year)s ' \
+    prep = 'qsub -V -q %(queue)s -N ingest_save_tasks -P %(project)s ' \
+           '-l walltime=05:00:00,mem=31GB ' \
+           '-- datacube -v ingest -c "%(config)s" %(product_changes_flag)s --year %(year)s ' \
            '--save-tasks "%(taskfile)s"'
-    cmd = prep % dict(config=config_path, taskfile=taskfile, year=year,
-                      product_changes_flag=product_changes_flag)
+    cmd = prep % dict(queue=queue, project=project, config=config_path,
+                      product_changes_flag=product_changes_flag,
+                      year=year, taskfile=taskfile)
     if click.confirm('\n' + cmd + '\nRUN?', default=True):
-        subprocess.check_call(cmd, shell=True)
-
-    test = 'datacube -v ingest %(product_changes_flag)s --load-tasks "%(taskfile)s" --dry-run'
-    cmd = test % dict(taskfile=taskfile, product_changes_flag=product_changes_flag)
+        savetask_job = subprocess.check_output(cmd, shell=True).decode("utf-8").split('\n')[0]
+    else:
+        click.echo('Two stage ingest PBS job not requested, hence exiting!')
+        click.get_current_context().exit(0)
+    
+    test = 'qsub -V -q %(queue)s -N ingest_dry_run -P %(project)s -W depend=afterok:%(savetask_job)s ' \
+           '-l walltime=05:00:00,mem=31GB ' \
+           '-- datacube -v ingest %(product_changes_flag)s --load-tasks "%(taskfile)s" --dry-run'
+    cmd = test % dict(queue=queue, project=project, savetask_job=savetask_job,
+                      product_changes_flag=product_changes_flag, taskfile=taskfile)
     if click.confirm('\n' + cmd + '\nRUN?', default=False):
         subprocess.check_call(cmd, shell=True)
+    else:
+        click.echo('Dry run not requested!')
 
+    datacube_config = os.environ.get('DATACUBE_CONFIG_PATH')
     name = name or taskfile.stem
-    qsub = 'qsub -V -q %(queue)s -N %(name)s -P %(project)s ' \
+    qsub = 'qsub -V -q %(queue)s -N %(name)s -P %(project)s -W depend=afterok:%(savetask_job)s ' \
            '-m %(email_options)s -M %(email_id)s -W %(job_attributes)s ' \
            '-l ncpus=%(ncpus)d,mem=%(mem)dgb,walltime=%(walltime)d:00:00 ' \
-           '-- /bin/bash "%(distr)s" "%(dea_module)s" --ppn 16 ' \
-           'datacube -v ingest %(product_changes_flag)s --load-tasks "%(taskfile)s" ' \
+           '-- "%(distr)s" "%(dea_module)s" --ppn 16 ' \
+           'datacube -v -C %(datacube_config)s ingest %(product_changes_flag)s --load-tasks "%(taskfile)s" ' \
            '--queue-size %(queue_size)s --executor distributed DSCHEDULER'
-    cmd = qsub % dict(taskfile=taskfile,
-                      distr=DISTRIBUTED_SCRIPT,
-                      dea_module=digitalearthau.MODULE_NAME,
-                      queue=queue,
+    cmd = qsub % dict(queue=queue,
                       name=name,
                       project=project,
-                      ncpus=nodes * 16,
-                      mem=nodes * 20,
-                      walltime=walltime,
+                      savetask_job=savetask_job,
                       email_options=email_options,
-                      job_attributes=job_attributes,
                       email_id=email_id,
-                      queue_size=queue_size,
-                      product_changes_flag=product_changes_flag)
+                      job_attributes=job_attributes,
+                      ncpus=nodes * 16,
+                      mem=nodes * 31,
+                      walltime=walltime,
+                      distr=DISTRIBUTED_SCRIPT,
+                      dea_module=digitalearthau.MODULE_NAME,
+                      datacube_config=datacube_config,
+                      product_changes_flag=product_changes_flag,
+                      taskfile=taskfile,
+                      queue_size=queue_size)
     if click.confirm('\n' + cmd + '\nRUN?', default=True):
         subprocess.check_call(cmd, shell=True)
+    else:
+        click.echo('Load task for datacube ingest not requested, hence exiting.')
+        click.get_current_context().exit(0)
 
 
 @cli.command()
+@ui.config_option
+@ui.verbose_option
 @click.option('--queue', '-q', default='normal',
               type=click.Choice(['normal', 'express']))
 @click.option('--project', '-P', default='v10')
@@ -119,8 +144,8 @@ def do_qsub(product_name, year, queue, project, nodes, walltime, name, allow_pro
 @click.option('--name', help='Job name to use')
 @click.argument('product_name')
 @click.argument('year')
-def stack(product_name, year, queue, project, nodes, walltime, name):
-    """Stacks a year of tiles into a single NetCDF."""
+def stack(queue, project, nodes, walltime, name, product_name, year):
+    """Stacks a year of tiles into a single NetCDF, using a two stage PBS job submission."""
     config_path = INGEST_CONFIG_DIR / '{}.yaml'.format(product_name)
     if not config_path.exists():
         raise click.BadParameter("No config found for product {!r}".format(product_name))
@@ -129,37 +154,44 @@ def stack(product_name, year, queue, project, nodes, walltime, name):
 
     subprocess.check_call('datacube -v system check', shell=True)
 
-    prep = 'datacube-stacker -v --app-config "%(config)s" --year %(year)s --save-tasks "%(taskfile)s"'
-    cmd = prep % dict(config=config_path, taskfile=taskfile, year=year)
+    prep = 'qsub -V -q %(queue)s -N stack_save_tasks -P %(project)s ' \
+           '-l walltime=05:00:00,mem=31GB ' \
+           '-- datacube-stacker -v --app-config "%(config)s" --year %(year)s ' \
+           '--save-tasks "%(taskfile)s"'
+    cmd = prep % dict(queue=queue, project=project, config=config_path,  year=year, taskfile=taskfile)
     if click.confirm('\n' + cmd + '\nRUN?', default=True):
-        try:
-            subprocess.check_call(cmd, shell=True)
-        except subprocess.CalledProcessError as e:
-            if e.returncode == 2:
-                click.echo('No tasks found - nothing to do!')
-                click.get_current_context().exit(e.returncode)
-            else:
-                raise e
+        savetask_job = subprocess.check_output(cmd, shell=True).decode("utf-8").split('\n')[0]
+    else:
+        click.echo('Two stage datacube-stacker PBS job not requested, hence exiting!')
+        click.get_current_context().exit(0)
 
+    datacube_config = os.environ.get('DATACUBE_CONFIG_PATH')
     name = name or taskfile.stem
-    qsub = 'qsub -q %(queue)s -N %(name)s -P %(project)s ' \
+    qsub = 'qsub -V -q %(queue)s -N %(name)s -P %(project)s ' \
            '-l ncpus=%(ncpus)d,mem=%(mem)dgb,walltime=%(walltime)d:00:00 ' \
-           '-- /bin/bash "%(distr)s" "%(dea_module)s" --ppn 16 ' \
-           'datacube-stacker -v --load-tasks "%(taskfile)s" --executor distributed DSCHEDULER'
-    cmd = qsub % dict(taskfile=taskfile,
-                      distr=DISTRIBUTED_SCRIPT,
-                      dea_module=digitalearthau.MODULE_NAME,
-                      queue=queue,
+           '-W depend=afterok:%(savetask_job)s -- "%(distr)s" "%(dea_module)s" --ppn 16 ' \
+           'datacube-stacker -v -C %(datacube_config)s --load-tasks "%(taskfile)s" --executor distributed DSCHEDULER'
+    cmd = qsub % dict(queue=queue,
                       name=name,
                       project=project,
                       ncpus=nodes * 16,
                       mem=nodes * 31,
-                      walltime=walltime)
+                      walltime=walltime,
+                      savetask_job=savetask_job,
+                      distr=DISTRIBUTED_SCRIPT,
+                      dea_module=digitalearthau.MODULE_NAME,
+                      datacube_config=datacube_config,
+                      taskfile=taskfile)
     if click.confirm('\n' + cmd + '\nRUN?', default=True):
         subprocess.check_call(cmd, shell=True)
+    else:
+        click.echo('Load task for datacube-stacker not requested, hence exiting.')
+        click.get_current_context().exit(0)
 
 
 @cli.command()
+@ui.config_option
+@ui.verbose_option
 @click.option('--queue', '-q', default='normal',
               type=click.Choice(['normal', 'express']))
 @click.option('--project', '-P', default='v10')
@@ -172,8 +204,8 @@ def stack(product_name, year, queue, project, nodes, walltime, name):
 @click.option('--name', help='Job name to use')
 @click.argument('product_name')
 @click.argument('year')
-def fix(product_name, year, queue, project, nodes, walltime, name):
-    """Rewrites files with metadata from the config."""
+def fix(queue, project, nodes, walltime, name, product_name, year):
+    """Rewrites files with metadata from the config, using a two stage PBS job submission."""
     taskfile = Path(product_name + '_' + year.replace('-', '_') + '.bin').absolute()
     config_path = INGEST_CONFIG_DIR / '{}.yaml'.format(product_name)
     if not config_path.exists():
@@ -181,27 +213,38 @@ def fix(product_name, year, queue, project, nodes, walltime, name):
 
     subprocess.check_call('datacube -v system check', shell=True)
 
-    prep = 'datacube-fixer -v --app-config "%(config)s" --year %(year)s --save-tasks "%(taskfile)s"'
-    cmd = prep % dict(config=config_path, taskfile=taskfile, year=year)
+    prep = 'qsub -V -q %(queue)s -N fix_save_tasks -P %(project)s ' \
+           '-l walltime=05:00:00,mem=31GB ' \
+           '-- datacube-fixer -v --app-config "%(config)s" --year %(year)s --save-tasks "%(taskfile)s"'
+    cmd = prep % dict(queue=queue, project=project, config=config_path,  year=year, taskfile=taskfile)
     if click.confirm('\n' + cmd + '\nRUN?', default=True):
-        subprocess.check_call(cmd, shell=True)
+        savetask_job = subprocess.check_output(cmd, shell=True).decode("utf-8").split('\n')[0]
+    else:
+        click.echo('Two stage datacube-fixer PBS job not requested, hence exiting!')
+        click.get_current_context().exit(0)
 
+    datacube_config = os.environ.get('DATACUBE_CONFIG_PATH')
     name = name or taskfile.stem
-    qsub = 'qsub -q %(queue)s -N %(name)s -P %(project)s ' \
+    qsub = 'qsub -V -q %(queue)s -N %(name)s -P %(project)s ' \
            '-l ncpus=%(ncpus)d,mem=%(mem)dgb,walltime=%(walltime)d:00:00 ' \
-           '-- /bin/bash "%(distr)s" "%(dea_module)s" --ppn 16 ' \
-           'datacube-fixer -v --load-tasks "%(taskfile)s" --executor distributed DSCHEDULER'
-    cmd = qsub % dict(taskfile=taskfile,
-                      distr=DISTRIBUTED_SCRIPT,
-                      dea_module=digitalearthau.MODULE_NAME,
-                      queue=queue,
+           '-W depend=afterok:%(savetask_job)s -- "%(distr)s" "%(dea_module)s" --ppn 16 ' \
+           'datacube-fixer -v -C %(datacube_config)s --load-tasks "%(taskfile)s" --executor distributed DSCHEDULER'
+    cmd = qsub % dict(queue=queue,
                       name=name,
                       project=project,
                       ncpus=nodes * 16,
                       mem=nodes * 31,
-                      walltime=walltime)
+                      walltime=walltime,
+                      savetask_job=savetask_job,
+                      distr=DISTRIBUTED_SCRIPT,
+                      dea_module=digitalearthau.MODULE_NAME,
+                      datacube_config=datacube_config,
+                      taskfile=taskfile)
     if click.confirm('\n' + cmd + '\nRUN?', default=True):
         subprocess.check_call(cmd, shell=True)
+    else:
+        click.echo('Load task for datacube-fixer not requested, hence exiting.')
+        click.get_current_context().exit(0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Reason for this pull request
1) During ingest submission of NBAR product, it was observed that pbs job submission on the raijin login was too large for the login node and was killed by the process due to insufficient memory.
2) Click command option to include test datacube configuration file was missing.

Proposed solution
1) Update the two stage PBS job submission logic for ingest, stack, and fixer by submitting the jobs to the PBS scheduler and add dependency between qsub jobs.
2) Add datacube config file options to the click options


 - [x] Tests added / passed
Note: Tests were added in NCI environment test scripts.
 - [ ] Fully documented, including `docs/about/whats_new.rst` for all changes