### PR TITLE
Fix dc config file access for production database

### DIFF
--- a/digitalearthau/coherence.py
+++ b/digitalearthau/coherence.py
@@ -1,3 +1,4 @@
+import os
 import click
 import structlog
 import collections
@@ -54,7 +55,7 @@ def main(expressions, check_locationless, archive_locationless, check_ancestors,
     """
     global _siblings_count
     uiutil.init_logging()
-    config_file = test_dc_config if test_dc_config else ''
+    config_file = test_dc_config if test_dc_config else os.environ.get('DATACUBE_CONFIG_PATH')
     with Datacube(config=config_file) as dc:
         _LOG.info('query', query=expressions)
         count = 0

--- a/digitalearthau/coherence.py
+++ b/digitalearthau/coherence.py
@@ -1,4 +1,3 @@
-import os
 import click
 import structlog
 import collections
@@ -34,6 +33,7 @@ _siblings_count = 0
               default=False,
               help="Archive sibling datasets (forces --check-ancestors)")
 @click.option('--test-dc-config', '-C',
+              default=None,
               help='Custom datacube config file (testing purpose only)')
 @ui.parsed_search_expressions
 def main(expressions, check_locationless, archive_locationless, check_ancestors, check_siblings, archive_siblings,
@@ -55,8 +55,7 @@ def main(expressions, check_locationless, archive_locationless, check_ancestors,
     """
     global _siblings_count
     uiutil.init_logging()
-    config_file = test_dc_config if test_dc_config else os.environ.get('DATACUBE_CONFIG_PATH')
-    with Datacube(config=config_file) as dc:
+    with Datacube(config=test_dc_config) as dc:
         _LOG.info('query', query=expressions)
         count = 0
         archive_count = 0


### PR DESCRIPTION
## Request for this pull request
Production datacube config file was not correctly retrieved in dea-coherence app.

## Proposed solution
Read datacube config file from the dc environment path and assign that to config_file variable.

- [x] Tests added in NCI test script to test these changes