### PR TITLE
Add metadata.format name to wofs_albers

### DIFF
--- a/digitalearthau/config/products/wofs_albers.yaml
+++ b/digitalearthau/config/products/wofs_albers.yaml
@@ -74,6 +74,8 @@ measurements:
     units: '1'
 metadata:
   product_type: wofs
+  format:
+    name: NetCDF
 metadata_type: eo
 name: wofs_albers
 storage:


### PR DESCRIPTION
Add metadata format name to wofs_albers.yaml to match production database product definition.