### PR TITLE
fix travis build libudunits2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
             - libxslt-dev
             - pandoc
             - shellcheck
+            - libudunits2-dev
     postgresql: "9.6"
     services:
         - postgresql


### PR DESCRIPTION
It seems to have worked.

- Add `libudunits2-dev` to the list of `apt` packages