### PR TITLE
Fix wofs configuration document mismatch

### DIFF
--- a/digitalearthau/config/products/wofs_albers.yaml
+++ b/digitalearthau/config/products/wofs_albers.yaml
@@ -2,76 +2,51 @@
 description: 'Historic Flood Mapping Water Observations from Space'
 managed: true
 measurements:
-  - dtype: int16
-    flags_definition:
-      cloud:
-        bits: 6
-        description: Cloudy
-        values:
-          0: false
-          1: true
-      cloud_shadow:
-        bits: 5
-        description: 'Cloud shadow'
-        values:
-          0: false
-          1: true
-      dry:
-        bits:
-          - 7
-          - 6
-          - 5
-          - 4
-          - 3
-          - 1
-          - 0
-        description: 'No water detected'
-        values:
-          0: true
-      high_slope:
-        bits: 4
-        description: 'High slope'
-        values:
-          0: false
-          1: true
-      nodata:
-        bits: 0
-        description: 'No data'
-        values:
-          1: true
-      noncontiguous:
-        bits: 1
-        description: 'At least one EO band is missing over over/undersaturated'
-        values:
-          0: false
-          1: true
-      sea:
-        bits: 2
-        description: Sea
-        values:
-          0: false
-          1: true
-      terrain_or_low_angle:
-        bits: 3
-        description: 'terrain shadow or low solar angle'
-        values:
-          0: false
-          1: true
-      wet:
-        bits:
-          - 7
-          - 6
-          - 5
-          - 4
-          - 3
-          - 1
-          - 0
-        description: 'Clear and Wet'
-        values:
-          128: true
-    name: water
-    nodata: 1
-    units: '1'
+      - name: water
+        dtype: int16
+        nodata: 1
+        units: '1'
+        flags_definition:
+            dry:
+              bits: [7, 6, 5, 4, 3, 1, 0]  # Ignore sea mask
+              description: Clear and dry
+              values: {0: true}
+            nodata:
+              bits: 0
+              description: No data
+              values: {1: true}
+            noncontiguous:
+              bits: 1
+              description: At least one EO band is missing over over/undersaturated
+              values: {0: false, 1: true}
+            sea:
+              bits: 2
+              description: Sea
+              values: {0: false, 1: true}
+            terrain_or_low_angle:
+              bits: 3
+              description: Terrain shadow or low solar angle
+              values: {0: false, 1: true}
+            high_slope:
+              bits: 4
+              description: High slope
+              values: {0: false, 1: true}
+            cloud_shadow:
+              bits: 5
+              description: Cloud shadow
+              values: {0: false, 1: true}
+            cloud:
+              bits: 6
+              description: Cloudy
+              values: {0: false, 1: true}
+            water_observed:
+              bits: 7
+              description: Classified as water by the decision tree
+              values: {0: false, 1: true}
+            wet:
+              bits: [7, 6, 5, 4, 3, 1, 0]  # Ignore sea mask
+              description: Clear and Wet
+              values: {128: true}
 metadata:
   product_type: wofs
   format:


### PR DESCRIPTION
Update to match the configuration file in production db to that of `wofs/config/wofs_albers.yaml` file from the `wofs` repository.