### PR TITLE
Fix creation time field for Sentinel 2 ARD

### DIFF
--- a/digitalearthau/config/metadata-types.yaml
+++ b/digitalearthau/config/metadata-types.yaml
@@ -2,7 +2,7 @@ name: gqa_eo
 description: Minimal eo metadata for products with GQA.
 dataset:
     id: ['id']
-    creation_dt: ['creation_dt']
+    creation_dt: ['system_information', 'time_processed']
     label: ['ga_label']
     measurements: ['image', 'bands']
     grid_spatial: ['grid_spatial', 'projection']


### PR DESCRIPTION
The products coming from wagl have their dataset creation time in `system_information → time_processed`, rather than `creation_dt`. Update the relevant metadata type.

(The field has no indexes so can be updated in-place.)

Note that this metadata type is called `gqa_eo` but is only used by wagl products (and doesn't have any gqa fields?). I'd prefer to rename it to `wagl` too (it has other wagl fields), but that will have to be a different pull request as renaming a metadata type affects more things.
