### PR TITLE
Monitor pbs job status via email

### DIFF
--- a/digitalearthau/run_distributed.sh
+++ b/digitalearthau/run_distributed.sh
@@ -8,7 +8,7 @@ shift
 
 ppn=1
 tpp=1
-mem=4e9 # Ten gigabytes per worker process.
+mem=4e9 # Four gigabytes per worker process
 umask=0027
 
 while [[ $# -gt 0 ]]
@@ -57,12 +57,12 @@ n0ppn=$(( n0ppn > 0 ? n0ppn : 1 ))
 pbsdsh -n 0 -- /bin/bash -c "${init_env}; dask-scheduler --port $SCHEDULER_PORT"&
 sleep 5s
 
-pbsdsh -n 0 -- /bin/bash -c "${init_env}; dask-worker $SCHEDULER_ADDR --nprocs ${n0ppn} --nthreads ${tpp} --memory-limit ${mem} --local-directory $PBS_O_WORKDIR --name worker-0-$PBS_JOBNAME"&
-sleep 0.5s
+pbsdsh -n 0 -- /bin/bash -c "${init_env}; dask-worker $SCHEDULER_ADDR --nprocs ${n0ppn} --nthreads ${tpp} --memory-limit ${mem} --name worker-0-$PBS_JOBNAME"&
+sleep 1s
 
 for ((i=NCPUS; i<PBS_NCPUS; i+=NCPUS)); do
-  pbsdsh -n $i -- /bin/bash -c "${init_env}; dask-worker $SCHEDULER_ADDR --nprocs ${ppn} --nthreads ${tpp} --memory-limit ${mem} --local-directory $PBS_O_WORKDIR --name worker-$i-$PBS_JOBNAME"&
-  sleep 0.5s
+  pbsdsh -n $i -- /bin/bash -c "${init_env}; dask-worker $SCHEDULER_ADDR --nprocs ${ppn} --nthreads ${tpp} --memory-limit ${mem} --name worker-$i-$PBS_JOBNAME"&
+  sleep 1s
 done
 sleep 5s
 

--- a/digitalearthau/submit/ingest.py
+++ b/digitalearthau/submit/ingest.py
@@ -17,6 +17,36 @@ from datacube.ui import click as ui
 DISTRIBUTED_SCRIPT = digitalearthau.SCRIPT_DIR / 'run_distributed.sh'
 APP_NAME = 'dea-submit-ingest'
 
+# pylint: disable=invalid-name
+queue_options = click.option('--queue', '-q', default='normal',
+                             type=click.Choice(['normal', 'express']))
+
+# pylint: disable=invalid-name
+project_options = click.option('--project', '-P', default='v10')
+
+# pylint: disable=invalid-name
+node_options = click.option('--nodes', '-n', required=True,
+                            help='Number of nodes to request',
+                            type=click.IntRange(1, 100))
+
+# pylint: disable=invalid-name
+walltime_options = click.option('--walltime', '-t', default=10,
+                                help='Number of hours (range: 1-48hrs) to request',
+                                type=click.IntRange(1, 48))
+
+# pylint: disable=invalid-name
+name_option = click.option('--name', help='Job name to use')
+
+# pylint: disable=invalid-name
+mail_options = click.option('--email-options', '-m', default='abe',
+                            type=click.Choice(['a', 'b', 'e', 'n', 'ae', 'ab', 'be', 'abe']),
+                            help='Send Email when execution is, \n'
+                            '[a = aborted | b = begins | e = ends | n = do not send email]')
+
+# pylint: disable=invalid-name
+email_id_options = click.option('--email-id', '-M', default='nci.monitor@dea.ga.gov.au',
+                                help='Email Recipient List')
+
 
 @click.group()
 def cli():
@@ -33,24 +63,15 @@ def list_products():
 @cli.command('qsub')
 @ui.config_option
 @ui.verbose_option
-@click.option('--queue', '-q', default='normal',
-              type=click.Choice(['normal', 'express']))
-@click.option('--project', '-P', default='v10')
-@click.option('--nodes', '-n', required=True,
-              help='Number of nodes to request',
-              type=click.IntRange(1, 100))
-@click.option('--walltime', '-t', default=10,
-              help='Number of hours (range: 1-48hrs) to request',
-              type=click.IntRange(1, 48))
-@click.option('--name', help='Job name to use')
+@queue_options
+@project_options
+@node_options
+@walltime_options
+@name_option
 @click.option('--allow-product-changes', help='allow changes to product definition', is_flag=True)
-@click.option('--email_options', '-m', default='ae',
-              type=click.Choice(['a', 'b', 'e', 'n', 'ae', 'ab', 'be', 'abe']),
-              help='Send Email when execution is, \n'
-              '[a = aborted | b = begins | e = ends | n = do not send email]')
-@click.option('--email_id', '-M', default='nci.monitor@dea.ga.gov.au',
-              help='Email Recipient List')
-@click.option('--job_attributes', '-W', default='umask=33',
+@mail_options
+@email_id_options
+@click.option('--job-attributes', '-W', default='umask=33',
               help='Setting job attributes\n'
               '<attribute>=<value>')
 @click.option('--app-config', '-c', default='',
@@ -135,22 +156,13 @@ def do_qsub(queue, project, nodes, walltime, name, allow_product_changes, email_
 @cli.command()
 @ui.config_option
 @ui.verbose_option
-@click.option('--queue', '-q', default='normal',
-              type=click.Choice(['normal', 'express']))
-@click.option('--project', '-P', default='v10')
-@click.option('--nodes', '-n', required=True,
-              help='Number of nodes to request',
-              type=click.IntRange(1, 100))
-@click.option('--walltime', '-t', default=10,
-              help='Number of hours to request',
-              type=click.IntRange(1, 48))
-@click.option('--name', help='Job name to use')
-@click.option('--email_options', '-m', default='ae',
-              type=click.Choice(['a', 'b', 'e', 'n', 'ae', 'ab', 'be', 'abe']),
-              help='Send Email when execution is, \n'
-              '[a = aborted | b = begins | e = ends | n = do not send email]')
-@click.option('--email_id', '-M', default='nci.monitor@dea.ga.gov.au',
-              help='Email Recipient List')
+@queue_options
+@project_options
+@node_options
+@walltime_options
+@name_option
+@mail_options
+@email_id_options
 @click.argument('product_name')
 @click.argument('year')
 def stack(queue, project, nodes, walltime, name, email_options, email_id, product_name, year):
@@ -204,22 +216,13 @@ def stack(queue, project, nodes, walltime, name, email_options, email_id, produc
 @cli.command()
 @ui.config_option
 @ui.verbose_option
-@click.option('--queue', '-q', default='normal',
-              type=click.Choice(['normal', 'express']))
-@click.option('--project', '-P', default='v10')
-@click.option('--nodes', '-n', required=True,
-              help='Number of nodes to request',
-              type=click.IntRange(1, 100))
-@click.option('--walltime', '-t', default=10,
-              help='Number of hours to request',
-              type=click.IntRange(1, 48))
-@click.option('--name', help='Job name to use')
-@click.option('--email_options', '-m', default='ae',
-              type=click.Choice(['a', 'b', 'e', 'n', 'ae', 'ab', 'be', 'abe']),
-              help='Send Email when execution is, \n'
-              '[a = aborted | b = begins | e = ends | n = do not send email]')
-@click.option('--email_id', '-M', default='nci.monitor@dea.ga.gov.au',
-              help='Email Recipient List')
+@queue_options
+@project_options
+@node_options
+@walltime_options
+@name_option
+@mail_options
+@email_id_options
 @click.argument('product_name')
 @click.argument('year')
 def fix(queue, project, nodes, walltime, name, email_options, email_id, product_name, year):

--- a/digitalearthau/submit/ingest.py
+++ b/digitalearthau/submit/ingest.py
@@ -44,10 +44,10 @@ def list_products():
               type=click.IntRange(1, 48))
 @click.option('--name', help='Job name to use')
 @click.option('--allow-product-changes', help='allow changes to product definition', is_flag=True)
-@click.option('--email_options', '-m', default='abe',
-              type=click.Choice(['a', 'b', 'e', 'n']),
+@click.option('--email_options', '-m', default='ae',
+              type=click.Choice(['a', 'b', 'e', 'n', 'ae', 'ab', 'be', 'abe']),
               help='Send Email when execution is, \n'
-              '[aborted | begins | ends | do not send email]')
+              '[a = aborted | b = begins | e = ends | n = do not send email]')
 @click.option('--email_id', '-M', default='nci.monitor@dea.ga.gov.au',
               help='Email Recipient List')
 @click.option('--job_attributes', '-W', default='umask=33',
@@ -95,14 +95,14 @@ def do_qsub(queue, project, nodes, walltime, name, allow_product_changes, email_
                       email_options=email_options, email_id=email_id,
                       product_changes_flag=product_changes_flag, taskfile=taskfile)
     if click.confirm('\n' + cmd + '\nRUN?', default=False):
-        dryrun_job = subprocess.check_call(cmd, shell=True)
+        dryrun_job = subprocess.check_output(cmd, shell=True).decode("utf-8").split('\n')[0]
     else:
         click.echo('Dry run not requested!')
         dryrun_job = savetask_job
 
     datacube_config = os.environ.get('DATACUBE_CONFIG_PATH')
     name = name or taskfile.stem
-    qsub = 'qsub -V -q %(queue)s -N %(name)s -P %(project)s -W depend=afterok:%(dryrun_job)s ' \
+    qsub = 'qsub -V -q %(queue)s -N %(name)s -P %(project)s -W depend=afterok:%(savetask_job)s:%(dryrun_job)s: ' \
            '-m %(email_options)s -M %(email_id)s -W %(job_attributes)s ' \
            '-l ncpus=%(ncpus)d,mem=%(mem)dgb,walltime=%(walltime)d:00:00 ' \
            '-- "%(distr)s" "%(dea_module)s" --ppn 16 ' \
@@ -111,6 +111,7 @@ def do_qsub(queue, project, nodes, walltime, name, allow_product_changes, email_
     cmd = qsub % dict(queue=queue,
                       name=name,
                       project=project,
+                      savetask_job=savetask_job,
                       dryrun_job=dryrun_job,
                       email_options=email_options,
                       email_id=email_id,
@@ -144,10 +145,10 @@ def do_qsub(queue, project, nodes, walltime, name, allow_product_changes, email_
               help='Number of hours to request',
               type=click.IntRange(1, 48))
 @click.option('--name', help='Job name to use')
-@click.option('--email_options', '-m', default='abe',
-              type=click.Choice(['a', 'b', 'e', 'n']),
+@click.option('--email_options', '-m', default='ae',
+              type=click.Choice(['a', 'b', 'e', 'n', 'ae', 'ab', 'be', 'abe']),
               help='Send Email when execution is, \n'
-              '[aborted | begins | ends | do not send email]')
+              '[a = aborted | b = begins | e = ends | n = do not send email]')
 @click.option('--email_id', '-M', default='nci.monitor@dea.ga.gov.au',
               help='Email Recipient List')
 @click.argument('product_name')
@@ -213,10 +214,10 @@ def stack(queue, project, nodes, walltime, name, email_options, email_id, produc
               help='Number of hours to request',
               type=click.IntRange(1, 48))
 @click.option('--name', help='Job name to use')
-@click.option('--email_options', '-m', default='abe',
-              type=click.Choice(['a', 'b', 'e', 'n']),
+@click.option('--email_options', '-m', default='ae',
+              type=click.Choice(['a', 'b', 'e', 'n', 'ae', 'ab', 'be', 'abe']),
               help='Send Email when execution is, \n'
-              '[aborted | begins | ends | do not send email]')
+              '[a = aborted | b = begins | e = ends | n = do not send email]')
 @click.option('--email_id', '-M', default='nci.monitor@dea.ga.gov.au',
               help='Email Recipient List')
 @click.argument('product_name')

--- a/digitalearthau/sync/submit_job.py
+++ b/digitalearthau/sync/submit_job.py
@@ -149,6 +149,10 @@ class SyncSubmission(object):
             qsub_opts.extend([
                 '-M', notify_email
             ])
+        else:
+            qsub_opts.extend([
+                '-M', 'nci.monitor@dea.ga.gov.au'
+            ])
 
         command = [
             'qsub', '-V',
@@ -157,7 +161,7 @@ class SyncSubmission(object):
             '-l', 'walltime=20:00:00,mem=1GB,ncpus=4,jobfs=256MB,other=gdata',
             '-l', 'wd',
             '-N', 'sync-{}'.format(job_name),
-            '-m', 'a',
+            '-m', 'ae',
             *qsub_opts,
             '-e', str(error_file),
             '-o', str(output_file),

--- a/digitalearthau/test_qsub.py
+++ b/digitalearthau/test_qsub.py
@@ -39,12 +39,13 @@ def test_norm_qsub_params():
     assert p['walltime'] == '0:00:10'
     assert p['mem'] == '31744MB'
 
-    p = qsub.parse_comma_args('nodes=1,mem=small,walltime=10m')
+    p = qsub.parse_comma_args('nodes=1,mem=small,walltime=10m,extra_qsub_args=-M test@email.com.au -m ae')
     p = qsub.norm_qsub_params(p)
 
     assert p['ncpus'] == 16
     assert p['walltime'] == '0:10:00'
     assert p['mem'] == '31744MB'
+    assert p['extra_qsub_args'] == ['-M', 'test@email.com.au', '-m', 'ae']
 
     p = qsub.parse_comma_args('ncpus=1, mem=medium, walltime=3h')
     p = qsub.norm_qsub_params(p)


### PR DESCRIPTION
**Reason for this pull request**
`Qsub` job status monitoring via email was only working when a job was `aborted`. Existing code needs to be updated to notify via email whenever a `pbs` job is `successfully executed` or `failed to execute`, in addition to a pbs job being `aborted`.

**Proposed solutions**
- Update the following apps to notify `success`/`failure`/`aborted` status via email:
    -  `dea-submit-ingest` app
    - `dea-submit-sync` app
- Update `run_distributed.sh` script to log additional `pbs` info.

- [x] Tests passed (no update to tests required, as the test scenarios were already written as part of `dea-env` testing)