### PR TITLE
Remove unused $version and rename taskfile_version

### DIFF
--- a/digitalearthau/config/ingestion/ls5_nbar_albers.yaml
+++ b/digitalearthau/config/ingestion/ls5_nbar_albers.yaml
@@ -1,6 +1,5 @@
 source_type: ls5_nbar_scene
 output_type: ls5_nbar_albers
-version: ${version}
 metadata_type: eo
 
 description: Landsat 5 Surface Reflectance NBAR 25 metre, 100km tile, Australian Albers Equal Area projection (EPSG:3577)

--- a/digitalearthau/config/ingestion/ls5_nbart_albers.yaml
+++ b/digitalearthau/config/ingestion/ls5_nbart_albers.yaml
@@ -1,6 +1,5 @@
 source_type: ls5_nbart_scene
 output_type: ls5_nbart_albers
-version: ${version}
 metadata_type: eo
 
 description: Landsat 5 Surface Reflectance NBART 25 metre, 100km tile, Australian Albers Equal Area projection (EPSG:3577)

--- a/digitalearthau/config/ingestion/ls5_pq_albers.yaml
+++ b/digitalearthau/config/ingestion/ls5_pq_albers.yaml
@@ -1,6 +1,5 @@
 source_type: ls5_pq_scene
 output_type: ls5_pq_albers
-version: ${version}
 metadata_type: eo
 
 description: Landsat 5 Pixel Quality 25 metre, 100km tile, Australian Albers Equal Area projection (EPSG:3577)

--- a/digitalearthau/config/ingestion/ls7_nbar_albers.yaml
+++ b/digitalearthau/config/ingestion/ls7_nbar_albers.yaml
@@ -1,6 +1,5 @@
 source_type: ls7_nbar_scene
 output_type: ls7_nbar_albers
-version: ${version}
 metadata_type: eo
 
 description: Landsat 7 Surface Reflectance NBAR 25 metre, 100km tile, Australian Albers Equal Area projection (EPSG:3577)

--- a/digitalearthau/config/ingestion/ls7_nbart_albers.yaml
+++ b/digitalearthau/config/ingestion/ls7_nbart_albers.yaml
@@ -1,6 +1,5 @@
 source_type: ls7_nbart_scene
 output_type: ls7_nbart_albers
-version: ${version}
 metadata_type: eo
 
 description: Landsat 7 Surface Reflectance NBART 25 metre, 100km tile, Australian Albers Equal Area projection (EPSG:3577)

--- a/digitalearthau/config/ingestion/ls7_pq_albers.yaml
+++ b/digitalearthau/config/ingestion/ls7_pq_albers.yaml
@@ -1,6 +1,5 @@
 source_type: ls7_pq_scene
 output_type: ls7_pq_albers
-version: ${version}
 metadata_type: eo
 
 description: Landsat 7 Pixel Quality 25 metre, 100km tile, Australian Albers Equal Area projection (EPSG:3577)

--- a/digitalearthau/config/ingestion/ls8_nbar_albers.yaml
+++ b/digitalearthau/config/ingestion/ls8_nbar_albers.yaml
@@ -1,6 +1,5 @@
 source_type: ls8_nbar_scene
 output_type: ls8_nbar_albers
-version: ${version}
 metadata_type: eo
 
 description: Landsat 8 Surface Reflectance NBAR 25 metre, 100km tile, Australian Albers Equal Area projection (EPSG:3577)

--- a/digitalearthau/config/ingestion/ls8_nbar_oli_albers.yaml
+++ b/digitalearthau/config/ingestion/ls8_nbar_oli_albers.yaml
@@ -1,6 +1,5 @@
 source_type: ls8_nbar_oli_scene
 output_type: ls8_nbar_oli_albers
-version: ${version}
 metadata_type: eo
 
 description: Landsat 8 Surface Reflectance NBAR 25 metre, 100km tile, Australian Albers Equal Area projection (EPSG:3577)

--- a/digitalearthau/config/ingestion/ls8_nbart_albers.yaml
+++ b/digitalearthau/config/ingestion/ls8_nbart_albers.yaml
@@ -1,6 +1,5 @@
 source_type: ls8_nbart_scene
 output_type: ls8_nbart_albers
-version: ${version}
 metadata_type: eo
 
 description: Landsat 8 Surface Relfectance NBART 25 metre, 100km tile, Australian Albers Equal Area projection (EPSG:3577)

--- a/digitalearthau/config/ingestion/ls8_nbart_oli_albers.yaml
+++ b/digitalearthau/config/ingestion/ls8_nbart_oli_albers.yaml
@@ -1,6 +1,5 @@
 source_type: ls8_nbart_oli_scene
 output_type: ls8_nbart_oli_albers
-version: ${version}
 metadata_type: eo
 
 description: Landsat 8 Surface Relfectance NBART 25 metre, 100km tile, Australian Albers Equal Area projection (EPSG:3577)

--- a/digitalearthau/config/ingestion/ls8_pq_albers.yaml
+++ b/digitalearthau/config/ingestion/ls8_pq_albers.yaml
@@ -1,6 +1,5 @@
 source_type: ls8_pq_scene
 output_type: ls8_pq_albers
-version: ${version}
 metadata_type: eo
 
 description: Landsat 8 Pixel Quality 25 metre, 100km tile, Australian Albers Equal Area projection (EPSG:3577)

--- a/digitalearthau/config/ingestion/ls8_pq_oli_albers.yaml
+++ b/digitalearthau/config/ingestion/ls8_pq_oli_albers.yaml
@@ -1,6 +1,5 @@
 source_type: ls8_pq_oli_scene
 output_type: ls8_pq_oli_albers
-version: ${version}
 metadata_type: eo
 
 description: Landsat 8 Pixel Quality 25 metre, 100km tile, Australian Albers Equal Area projection (EPSG:3577)

--- a/digitalearthau/stacker.py
+++ b/digitalearthau/stacker.py
@@ -179,7 +179,7 @@ def _make_config_and_description(index: Index, task_desc_path: Path) -> Tuple[di
     config['output_type'] = config['output_type']  # TODO: Temporary until ODC code is updated
     config['app_config_file'] = str(app_config)
     config = stacker.make_stacker_config(index, config)
-    config['taskfile_version'] = make_tag(task_desc)
+    config['taskfile_utctime'] = make_tag(task_desc)
     config['version'] = digitalearthau.__version__ + ' ' + datacube.__version__
 
     return config, task_desc


### PR DESCRIPTION
**Reason for this pull request**
`$version` in the ingestion configuration file is not doing anything and is misleading the user. This can be safely removed from the configuration file. Also, `taskfile_version` from the `stacker.py` file is to be renamed to maintain consistency with similar changes in `datacube-core` repository.

**Proposed solutions**
- Remove `$version` from the ingestion `yaml` file.
- Rename `taskfile_version` to `taskfile_utctime`.