### PR TITLE
Add Ops' new "archived" folder for telemetry

### DIFF
--- a/digitalearthau/collections.py
+++ b/digitalearthau/collections.py
@@ -197,6 +197,7 @@ def init_nci_collections(index: Index):
             query={'metadata_type': 'telemetry'},
             file_patterns=(
                 '/g/data/v10/repackaged/rawdata/0/[0-9][0-9][0-9][0-9]/[0-9][0-9]/LS*/ga-metadata.yaml',
+                '/g/data/v10/archived/rawdata/0/[0-9][0-9][0-9][0-9]/[0-9][0-9]/LS*/ga-metadata.yaml',
             ),
             unique=('time.lower.day', 'platform'),
             index_=index,

--- a/digitalearthau/paths.py
+++ b/digitalearthau/paths.py
@@ -25,6 +25,7 @@ BASE_DIRECTORIES = [
     '/g/data/fk4/datacube',
     '/g/data/rs0/datacube',
     '/g/data/v10/reprocess',
+    '/g/data/v10/archived',
     '/g/data/rs0/scenes',
     '/short/v10/scenes',
     '/g/data/v10/public/data',


### PR DESCRIPTION
Ops have manually moved many telemetry files to an "archived" directory, so the current index is out of date.

(the name "archived" here refers to being copied onto tape, not datacube's definition of archived)
