### PR TITLE
Minor docs improvement (VDI guide)

### DIFF
--- a/docs/connect/install.rst
+++ b/docs/connect/install.rst
@@ -7,10 +7,13 @@ Installation and Software Setup
 Required Software
 =================
 
- * TurboVNC - https://sourceforge.net/projects/turbovnc/files/
- * Strudel - https://cvl.massive.org.au/launcher_files/stable/
+Install TurboVNC and Strudel according to the instructions at http://vdi.nci.org.au/help.
 
-For full details on installing the software, see http://vdi.nci.org.au/help.
+.. note::
+   The NCI instructions recommend specific versions of 
+   `TurboVNC <https://sourceforge.net/projects/turbovnc/files/>` and
+   `Strudel <https://cvl.massive.org.au/launcher_files/stable/>`. 
+   More recent versions may or may not be compatible with the VDI.
 
 .. note::
    Your institution may provide this software to be installed via an internal process.
@@ -40,6 +43,10 @@ To connect:
 * Username: Your NCI username (eg `abc123` or `ab1234`)
 * Click **Login**
 
+.. note::
+   If the drop-down site list in Strudel remains empty, it most likely means 
+   that the software is unable to retrieve the strudel.json URL, 
+   such as due to firewall or network proxy configuration.
 
 Setting up DEA
 ==============


### PR DESCRIPTION
We tested the instructions today, and ran into two problems:

The guest wifi was unable to access NCI subdomains, including mancini (for new NCI user account registration) and http://vdi.nci.org.au/help (the VDI user guide). This also lead to the notorios symptom where strudel fails to download its JSON configuration from the server, and so presents an empty drop-down site list -- which is difficult for the uninitiated to diagnose. These were resolved temporarily by switching to mobile broadband.

Next, strudel emitted an "error starting the VNC server". This was resolved by switching to the software versions suggested by the NCI instructions, instead of the latest versions suggested by DEA docs (e.g. TurboVNC 2.2 vs 64-2.1.2). Possibly the 64/32bit confusion may have been a factor.



