### PR TITLE
Configure travis to push built HTML to our s3 bucket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,15 @@ deploy:
         repo: GeoscienceAustralia/digitalearthau
         python: "3.6"
 
+ -  provider: s3
+    bucket: "docs.dea.ga.gov.au"
+    region: "ap-southeast-2"
+    local_dir: docs/_build/html/
+    skip_cleanup: true
+    on: 
+        branch: develop
+        repo: GeoscienceAustralia/digitalearthau
+
  -  provider: pages
     skip-cleanup: true
     github-token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable


### PR DESCRIPTION
Use s3 and cloudfront so we can have more control over the hosted docs.
Infrastructure already exists
travis used has the permissions required to write files to this bucket