### PR TITLE
Update sync code to detect and index S2 ARD granule

### DIFF
--- a/digitalearthau/collections.py
+++ b/digitalearthau/collections.py
@@ -179,7 +179,7 @@ def get_collections_in_path(p: Path) -> Iterable[Collection]:
     ['ls8_nbar_scene']
     >>> [c.name for c in get_collections_in_path(Path('/g/data/if87/datacube/002/S2_MSI_ARD/packaged/' + \
         '2016-07-27/S2A_OPER_MSI_ARD_TL_SGS__20160727T054920_A005719_T53KRU_N02.04'))]
-    ['s2a_ard_granule', 's2b_ard_granule']
+    ['s2a_ard_granule']
     """
     for c in get_collections():
         for pat in c.file_patterns:
@@ -542,11 +542,8 @@ def init_nci_collections(index: Index):
 
     assert s2_ard_basepath + s2a_ard_granule_offset in get_collection('s2a_ard_granule').file_patterns
     assert s2_ard_basepath + s2b_ard_granule_offset in get_collection('s2b_ard_granule').file_patterns
-    assert list(get_collections_in_path(
-        Path(s2_ard_basepath +
-             '2018-01-25/S2A_OPER_MSI_ARD_TL_SGS__20180125T035411_A013541_T54HUG_N02.06/ARD-METADATA.yaml'))) \
-        is not None
-    assert list(get_collections_in_path(
-        Path(s2_ard_basepath +
-             '2017-11-16/S2B_OPER_MSI_ARD_TL_MPS__20171116T154540_A003632_T52LEQ_N02.06/ARD-METADATA.yaml'))) \
-        is not None
+    s2a_path = '2018-01-25/S2A_OPER_MSI_ARD_TL_SGS__20180125T035411_A013541_T54HUG_N02.06/ARD-METADATA.yaml'
+    assert list(get_collections_in_path(s2_ard_basepath + s2a_path)) is not None
+
+    s2b_path = '2017-11-16/S2B_OPER_MSI_ARD_TL_MPS__20171116T154540_A003632_T52LEQ_N02.06/ARD-METADATA.yaml'
+    assert list(get_collections_in_path(Path(s2_ard_basepath + s2b_path))) is not None

--- a/digitalearthau/collections.py
+++ b/digitalearthau/collections.py
@@ -177,6 +177,9 @@ def get_collections_in_path(p: Path) -> Iterable[Collection]:
     []
     >>> [c.name for c in get_collections_in_path(Path('/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2015/01/output/nbar'))]
     ['ls8_nbar_scene']
+    >>> [c.name for c in get_collections_in_path(Path('/g/data/if87/datacube/002/S2_MSI_ARD/packaged/' + \
+        '2016-07-27/S2A_OPER_MSI_ARD_TL_SGS__20160727T054920_A005719_T53KRU_N02.04'))]
+    ['s2a_ard_granule', 's2b_ard_granule']
     """
     for c in get_collections():
         for pat in c.file_patterns:
@@ -190,7 +193,6 @@ def get_collections_in_path(p: Path) -> Iterable[Collection]:
 
 def init_nci_collections(index: Index):
     # NCI collections. TODO: move these to config file?
-
     _add(
         Collection(
             name='telemetry',
@@ -199,7 +201,7 @@ def init_nci_collections(index: Index):
                 '/g/data/v10/repackaged/rawdata/0/[0-9][0-9][0-9][0-9]/[0-9][0-9]/LS*/ga-metadata.yaml',
                 '/g/data/v10/archived/rawdata/0/[0-9][0-9][0-9][0-9]/[0-9][0-9]/LS*/ga-metadata.yaml',
             ),
-            unique=('time.lower.day', 'platform'),
+            unique=('time', 'platform'),
             index_=index,
             trust=Trust.DISK
         )
@@ -212,7 +214,21 @@ def init_nci_collections(index: Index):
             query,
             file_patterns=file_patterns,
             index_=index,
-            unique=('time.lower.day', 'sat_path.lower', 'sat_row.lower'),
+            unique=('time', 'sat_path', 'sat_row'),
+            delete_archived_after_days=delete_archived_after_days,
+            # Scenes default to trusting disk. They're atomically written to the destination,
+            # and the jobs themselves wont index.
+            trust=Trust.DISK
+        )
+
+    def ard_granule_collection(name, query, file_patterns, delete_archived_after_days=None):
+        """Make a collection with common defaults for scene collections"""
+        return Collection(
+            name,
+            query,
+            file_patterns=file_patterns,
+            index_=index,
+            unique=('time', 'region_code', 'lat', 'lon'),
             delete_archived_after_days=delete_archived_after_days,
             # Scenes default to trusting disk. They're atomically written to the destination,
             # and the jobs themselves wont index.
@@ -251,11 +267,39 @@ def init_nci_collections(index: Index):
     #           LS7_ETM_NBAR_P54_GANBAR01-002_089_078_20040816/ga-metadata.yaml
     # /g/data/rs0/scenes/nbar-scenes-tmp/ls7/2004/07/output/nbart/
     #           LS7_ETM_NBART_P54_GANBART01-002_114_078_20040731/ga-metadata.yaml
-    nbar_scene_offset = '[0-9][0-9][0-9][0-9]/[0-9][0-9]/output/nbar*/LS*/ga-metadata.yaml'
+    nbart_scene_offset = '[0-9][0-9][0-9][0-9]/[0-9][0-9]/output/nbart/LS*/ga-metadata.yaml'
+    _add(
+        scene_collection(
+            name='ls5_nbart_scene',
+            query={'product': 'ls5_nbart_scene'},
+            file_patterns=[
+                '/g/data/rs0/scenes/nbar-scenes-tmp/ls5/' + nbart_scene_offset,
+                '/short/v10/scenes/nbar-scenes-tmp/ls5/' + nbart_scene_offset,
+            ],
+        ),
+        scene_collection(
+            name='ls7_nbart_scene',
+            query={'product': 'ls7_nbart_scene'},
+            file_patterns=[
+                '/g/data/rs0/scenes/nbar-scenes-tmp/ls7/' + nbart_scene_offset,
+                '/short/v10/scenes/nbar-scenes-tmp/ls7/' + nbart_scene_offset,
+            ],
+        ),
+        scene_collection(
+            name='ls8_nbart_scene',
+            query={'product': 'ls8_nbart_scene'},
+            file_patterns=[
+                '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/' + nbart_scene_offset,
+                '/short/v10/scenes/nbar-scenes-tmp/ls8/' + nbart_scene_offset,
+            ],
+        )
+    )
+
+    nbar_scene_offset = '[0-9][0-9][0-9][0-9]/[0-9][0-9]/output/nbar/LS*/ga-metadata.yaml'
     _add(
         scene_collection(
             name='ls5_nbar_scene',
-            query={'product': ['ls5_nbar_scene', 'ls5_nbart_scene']},
+            query={'product': 'ls5_nbar_scene'},
             file_patterns=[
                 '/g/data/rs0/scenes/nbar-scenes-tmp/ls5/' + nbar_scene_offset,
                 '/short/v10/scenes/nbar-scenes-tmp/ls5/' + nbar_scene_offset,
@@ -263,7 +307,7 @@ def init_nci_collections(index: Index):
         ),
         scene_collection(
             name='ls7_nbar_scene',
-            query={'product': ['ls7_nbar_scene', 'ls7_nbart_scene']},
+            query={'product': 'ls7_nbar_scene'},
             file_patterns=[
                 '/g/data/rs0/scenes/nbar-scenes-tmp/ls7/' + nbar_scene_offset,
                 '/short/v10/scenes/nbar-scenes-tmp/ls7/' + nbar_scene_offset,
@@ -271,7 +315,7 @@ def init_nci_collections(index: Index):
         ),
         scene_collection(
             name='ls8_nbar_scene',
-            query={'product': ['ls8_nbar_scene', 'ls8_nbart_scene']},
+            query={'product': 'ls8_nbar_scene'},
             file_patterns=[
                 '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/' + nbar_scene_offset,
                 '/short/v10/scenes/nbar-scenes-tmp/ls8/' + nbar_scene_offset,
@@ -345,7 +389,7 @@ def init_nci_collections(index: Index):
                     'LS5_TM_{name}/*_*/LS5*{name}*.nc'.format(project=project,
                                                               name=name.upper()),
                 ),
-                unique=('time.lower.day', 'lat', 'lon'),
+                unique=('time', 'lat', 'lon'),
                 index_=index,
                 # Tiles default to trusting index over the disk: they were indexed at the end of the job,
                 # so unfinished tiles could be left on disk.
@@ -359,7 +403,7 @@ def init_nci_collections(index: Index):
                     '*_*/LS7*{name}*.nc'.format(project=project,
                                                 name=name.upper()),
                 ),
-                unique=('time.lower.day', 'lat', 'lon'),
+                unique=('time', 'lat', 'lon'),
                 index_=index,
                 # Tiles default to trusting index over the disk: they were indexed at the end of the job,
                 # so unfinished tiles could be left on disk.
@@ -373,7 +417,7 @@ def init_nci_collections(index: Index):
                     '*_*/LS8*{name}*.nc'.format(project=project,
                                                 name=name.upper()),
                 ),
-                unique=('time.lower.day', 'lat', 'lon'),
+                unique=('time', 'lat', 'lon'),
                 index_=index,
                 # Tiles default to trusting index over the disk: they were indexed at the end of the job,
                 # so unfinished tiles could be left on disk.
@@ -390,7 +434,7 @@ def init_nci_collections(index: Index):
                     '/g/data/{project}/datacube/002/FC/'
                     'LS5_TM_FC/*_*/LS5*FC*.nc'.format(project=project),
                 ),
-                unique=('time.lower.day', 'lat', 'lon'),
+                unique=('time', 'lat', 'lon'),
                 index_=index,
                 # Tiles default to trusting index over the disk: they were indexed at the end of the job,
                 # so unfinished tiles could be left on disk.
@@ -403,7 +447,7 @@ def init_nci_collections(index: Index):
                     '/g/data/{project}/datacube/002/FC/'
                     'LS7_ETM_FC/*_*/LS7*FC*.nc'.format(project=project),
                 ),
-                unique=('time.lower.day', 'lat', 'lon'),
+                unique=('time', 'lat', 'lon'),
                 index_=index,
                 # Tiles default to trusting index over the disk: they were indexed at the end of the job,
                 # so unfinished tiles could be left on disk.
@@ -416,7 +460,7 @@ def init_nci_collections(index: Index):
                     '/g/data/{project}/datacube/002/FC/'
                     'LS8_OLI_FC/*_*/LS8*FC*.nc'.format(project=project),
                 ),
-                unique=('time.lower.day', 'lat', 'lon'),
+                unique=('time', 'lat', 'lon'),
                 index_=index,
                 # Tiles default to trusting index over the disk: they were indexed at the end of the job,
                 # so unfinished tiles could be left on disk.
@@ -431,7 +475,7 @@ def init_nci_collections(index: Index):
             name=name,
             query={'product': name},
             file_patterns=['/g/data/fk4/datacube/002/WOfS/WOfS_25_2_1/netcdf/*_*/LS_WATER_3577_*.nc'],
-            unique=('time.lower.day', 'lat', 'lon'),
+            unique=('time', 'lat', 'lon'),
             # Tiles default to trusting index over the disk: they were indexed at the end of the job,
             # so unfinished tiles could be left on disk.
             trust=Trust.INDEX
@@ -456,7 +500,7 @@ def init_nci_collections(index: Index):
             query={'product': 'pq_count_summary'},
             file_patterns=['/g/data/fk4/datacube/002/stats/pq_count/history/LS_PQ_COUNT/*_*/LS_PQ_COUNT_3577_*.nc'],
             index_=index,
-            unique=('time.lower.day', 'lat', 'lon')
+            unique=('time', 'lat', 'lon')
         )
     )
     _add(
@@ -465,7 +509,7 @@ def init_nci_collections(index: Index):
             query={'product': 'pq_count_annual_summary'},
             index_=index,
             file_patterns=['/g/data/fk4/datacube/002/stats/pq_count/annual/LS_PQ_COUNT/*_*/LS_PQ_COUNT_3577_*.nc'],
-            unique=('time.lower.day', 'lat', 'lon')
+            unique=('time', 'lat', 'lon')
         )
     )
 
@@ -473,3 +517,36 @@ def init_nci_collections(index: Index):
     assert get_collection('ls8_nbar_albers').file_patterns == (
         '/g/data/rs0/datacube/002/LS8_OLI_NBAR/*_*/LS8*NBAR*.nc',
     )
+
+    # S2A & S2B ARD products:
+    # /g/data/if87/datacube/002/S2_MSI_ARD/packaged/
+    s2a_ard_granule_offset = '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/S2A_*/ARD-METADATA.yaml'
+    s2b_ard_granule_offset = '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/S2B_*/ARD-METADATA.yaml'
+    s2_ard_basepath = '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
+    _add(
+        ard_granule_collection(
+            name='s2a_ard_granule',
+            query={'product': 's2a_ard_granule'},
+            file_patterns=[
+                s2_ard_basepath + s2a_ard_granule_offset,
+            ],
+        ),
+        ard_granule_collection(
+            name='s2b_ard_granule',
+            query={'product': 's2b_ard_granule'},
+            file_patterns=[
+                s2_ard_basepath + s2b_ard_granule_offset,
+            ],
+        ),
+    )
+
+    assert s2_ard_basepath + s2a_ard_granule_offset in get_collection('s2a_ard_granule').file_patterns
+    assert s2_ard_basepath + s2b_ard_granule_offset in get_collection('s2b_ard_granule').file_patterns
+    assert list(get_collections_in_path(
+        Path(s2_ard_basepath +
+             '2018-01-25/S2A_OPER_MSI_ARD_TL_SGS__20180125T035411_A013541_T54HUG_N02.06/ARD-METADATA.yaml'))) \
+        is not None
+    assert list(get_collections_in_path(
+        Path(s2_ard_basepath +
+             '2017-11-16/S2B_OPER_MSI_ARD_TL_MPS__20171116T154540_A003632_T52LEQ_N02.06/ARD-METADATA.yaml'))) \
+        is not None

--- a/digitalearthau/paths.py
+++ b/digitalearthau/paths.py
@@ -114,9 +114,9 @@ def split_path_from_base(file_path):
     'ls7/2003/something.nc'
     >>> base, offset = split_path_from_base('/g/data/if87/datacube/002/S2_MSI_ARD/2018-11-30/something')
     >>> str(base)
-    '/g/data/if87/datacube/002'
+    '/g/data/if87/datacube'
     >>> offset
-    'S2_MSI_ARD/2018-11-30/something'
+    '002/S2_MSI_ARD/2018-11-30/something'
     >>> split_path_from_base('/short/unknown_location/something.nc')
     Traceback (most recent call last):
     ...

--- a/digitalearthau/paths.py
+++ b/digitalearthau/paths.py
@@ -29,6 +29,7 @@ BASE_DIRECTORIES = [
     '/g/data/rs0/scenes',
     '/short/v10/scenes',
     '/g/data/v10/public/data',
+    '/g/data/if87/datacube',
 ]
 
 # Use a static variable so that trashed items in the same run will be in the same trash bin.
@@ -111,6 +112,11 @@ def split_path_from_base(file_path):
     '/g/data/fk4/datacube'
     >>> offset
     'ls7/2003/something.nc'
+    >>> base, offset = split_path_from_base('/g/data/if87/datacube/002/S2_MSI_ARD/2018-11-30/something')
+    >>> str(base)
+    '/g/data/if87/datacube/002'
+    >>> offset
+    'S2_MSI_ARD/2018-11-30/something'
     >>> split_path_from_base('/short/unknown_location/something.nc')
     Traceback (most recent call last):
     ...
@@ -236,6 +242,8 @@ def get_dataset_paths(metadata_path: Path) -> Tuple[Path, List[Path]]:
         return metadata_path, [metadata_path]
     if metadata_path.name == 'ga-metadata.yaml':
         return metadata_path.parent, list_file_paths(metadata_path.parent)
+    if metadata_path.name == 'ARD-METADATA.yaml':
+        return metadata_path.parent, list_file_paths(metadata_path.parent)
 
     sibling_suffix = '.ga-md.yaml'
     if metadata_path.name.endswith(sibling_suffix):
@@ -269,18 +277,26 @@ def get_metadata_path(dataset_path):
     if dataset_path.is_file() and (is_supported_document_type(dataset_path) or dataset_path.suffix == '.nc'):
         return dataset_path
 
-    # Otherwise there may be a sibling file with appended suffix '.agdc-md.yaml'.
+    # Otherwise there may be a sibling file with appended suffix '.ga-md.yaml'.
     expected_name = dataset_path.parent.joinpath('{}.ga-md'.format(dataset_path.name))
     found = _find_any_metadata_suffix(expected_name)
     if found:
         return found
 
-    # Otherwise if it's a directory, there may be an 'agdc-metadata.yaml' file describing all contained datasets.
+    # Otherwise if it's a directory
     if dataset_path.is_dir():
+        # There may be an 'ga-metadata.yaml' file describing all contained datasets
         expected_name = dataset_path.joinpath('ga-metadata')
         found = _find_any_metadata_suffix(expected_name)
+
+        # There may be an 'ARD-METADATA.yaml' file describing all contained datasets
+        expected_s2ard_name = dataset_path.joinpath('ARD-METADATA')
+        found_s2ard = _find_any_metadata_suffix(expected_s2ard_name)
+
         if found:
             return found
+        elif found_s2ard:
+            return found_s2ard
 
     raise ValueError('No metadata found for input %r' % dataset_path)
 

--- a/digitalearthau/test_paths.py
+++ b/digitalearthau/test_paths.py
@@ -70,3 +70,22 @@ def test_get_data_paths_sibling():
         metadata_path,
         data_path
     }
+
+
+def test_get_data_paths_s2_ard_package():
+    packaged_dataset = paths.write_files({
+        'ARD-METADATA.yaml': '',
+        'package': {
+            'file1.txt': ''
+        }
+    })
+
+    metadata_path = packaged_dataset.joinpath('ARD-METADATA.yaml')
+    assert paths.get_metadata_path(packaged_dataset) == metadata_path
+
+    base_path, all_files = paths.get_dataset_paths(metadata_path)
+    assert base_path == packaged_dataset
+    assert set(all_files) == {
+        metadata_path,
+        packaged_dataset.joinpath('package', 'file1.txt')
+    }

--- a/integration_tests/test_duplicates.py
+++ b/integration_tests/test_duplicates.py
@@ -10,12 +10,12 @@ from digitalearthau.index import add_dataset
 
 import click.testing
 
-_EXPECTED_ALL_DUPLICATES = """product,time_lower_day,platform,count,dataset_refs
+_EXPECTED_ALL_DUPLICATES = """product,time,platform,count,dataset_refs
 ls8_level1_scene,2016-09-26T00:00:00+00:00,114,80,2,86150afc-b7d5-4938-a75e-3445007256d3\
  f882f9c0-a27f-11e7-a89f-185e0f80a5c0
 """
-_EXPECTED_SPECIFIC_DUPS = """product,time_lower_day,sat_path_lower,sat_row_lower,count,dataset_refs
-ls8_level1_scene,2016-09-26T00:00:00+00:00,114,80,2,86150afc-b7d5-4938-a75e-3445007256d3\
+_EXPECTED_SPECIFIC_DUPS = """product,time,sat_path,sat_row,count,dataset_refs
+ls8_level1_scene,2016-09-26T02:16:59+00:00,114,80,2,86150afc-b7d5-4938-a75e-3445007256d3\
  f882f9c0-a27f-11e7-a89f-185e0f80a5c0
 """
 ON_DISK1_ID = uuid.UUID('86150afc-b7d5-4938-a75e-3445007256d3')
@@ -54,12 +54,12 @@ def duplicate_ls8_l1_scene(dea_index: Index, integration_test_data: Path) -> uui
 def test_no_duplicates(global_integration_cli_args,
                        indexed_ls8_l1_scenes: Tuple[uuid.UUID, uuid.UUID]):
     res = _run_cmd(['ls8_level1_scene'], global_integration_cli_args)
-    assert res.output == 'product,time_lower_day,sat_path_lower,sat_row_lower,count,dataset_refs\n'
+    assert res.output == 'product,time,sat_path,sat_row,count,dataset_refs\n'
     assert res.exit_code == 0
 
     res = _run_cmd(['ls8_nbar_albers'], global_integration_cli_args)
     assert res.exit_code == 0
-    assert res.output == 'product,time_lower_day,lat,lon,count,dataset_refs\n'
+    assert res.output == 'product,time,lat,lon,count,dataset_refs\n'
 
     # Error returned, fake product
     res = _run_cmd(['ls8_fake_product'], global_integration_cli_args)


### PR DESCRIPTION
## Request for this pull request
`S2` `ARD` processing automation was turned-on for processing on-going products. Automating Data Cube `sync` and `index` for those `S2` products would help in reducing manual task of indexing.

## Proposed solution
1. Create new records in `digitalearthau/collections.py` for the `S2A` and `S2B` products
2. Update `unique` string for `telemetry` and `scene` collections
3. Split `nbar` and `nbart` scene_collection
4. Update `digitalearthau/paths.py` to include `S2` `ARD` base path
5. Add new test in `digitalearthau/test_paths.py` to test s2_ard_granule collection path.
6. Update `digitalearthau/integration_tests/test_duplicates.py` for changes as part of `unique` string update in `digitalearthau/collections.py`

- [x] Test added
   Note: `dea-env` orchestration test script is updated to test sync and index of `s2 ard granule`