### PR TITLE
fix metadata-type again

### DIFF
--- a/digitalearthau/config/metadata-types.yaml
+++ b/digitalearthau/config/metadata-types.yaml
@@ -1,3 +1,127 @@
+name: dea_eo_v1
+description: EO metadata for DEA products with GQA.
+dataset:
+    id: ['id']
+    creation_dt: ['system_information', 'time_processed']
+    label: ['ga_label']
+    measurements: ['image', 'bands']
+    grid_spatial: ['grid_spatial', 'projection']
+    format: ['format', 'name']
+    sources: ['lineage', 'source_datasets']
+
+    search_fields:
+        region_code:
+            description: Spatial reference code from the provider
+            offset: [provider, reference_code]
+
+        platform:
+            description: Platform code
+            offset: [platform, code]
+
+        instrument:
+            description: Instrument name
+            offset: [instrument, name]
+
+        product_type:
+            description: Product code
+            offset: [product_type]
+
+        format:
+            description: File format (GeoTIFF, NetCDF)
+            offset: [format, name]
+            indexed: false
+
+        lat:
+            description: Latitude range
+            type: double-range
+            max_offset:
+            - [extent, coord, ur, lat]
+            - [extent, coord, lr, lat]
+            - [extent, coord, ul, lat]
+            - [extent, coord, ll, lat]
+            min_offset:
+            - [extent, coord, ur, lat]
+            - [extent, coord, lr, lat]
+            - [extent, coord, ul, lat]
+            - [extent, coord, ll, lat]
+
+        lon:
+            description: Longitude range
+            type: double-range
+            max_offset:
+            - [extent, coord, ul, lon]
+            - [extent, coord, ur, lon]
+            - [extent, coord, ll, lon]
+            - [extent, coord, lr, lon]
+            min_offset:
+            - [extent, coord, ul, lon]
+            - [extent, coord, ur, lon]
+            - [extent, coord, ll, lon]
+            - [extent, coord, lr, lon]
+
+        time:
+            description: Acquisition time
+            type: datetime-range
+            min_offset:
+            - [extent, from_dt]
+            max_offset:
+            - [extent, to_dt]
+
+        gqa:
+            description: GQA circular error probable (90%)
+            type: double
+            offset: [gqa, cep90]
+            indexed: false
+        gqa_error_message:
+            description: GQA error message
+            offset: [gqa, error_message]
+            indexed: false
+        gqa_final_qa_count:
+            description: GQA QA point count
+            offset: [gqa, final_qa_count]
+            type: integer
+            indexed: false
+        gqa_ref_source:
+            description: GQA reference imagery collection name
+            offset: [gqa, ref_source]
+            indexed: false
+        gqa_cep90:
+            description: Circular error probable (90%) of the values of the GCP residuals
+            offset: [gqa, residual, cep90]
+            type: double
+            indexed: false
+        gqa_abs_xy:
+            description: Absolute value of the total GCP residual
+            offset: [gqa, residual, abs, xy]
+            type: double
+            indexed: false
+        gqa_abs_iterative_mean_xy:
+            description: Mean of the absolute values of the GCP residuals after removal of outliers
+            offset: [gqa, residual, abs_iterative_mean, xy]
+            type: double
+            indexed: false
+        gqa_iterative_mean_xy:
+            description: Mean of the values of the GCP residuals after removal of outliers
+            offset: [gqa, residual, iterative_mean, xy]
+            type: double
+            indexed: false
+        gqa_iterative_stddev_xy:
+            description: Standard Deviation of the values of the GCP residuals after removal of outliers
+            offset: [gqa, residual, iterative_stddev, xy]
+            type: double
+            indexed: false
+        gqa_mean_xy:
+            description: Mean of the values of the GCP residuals
+            offset: [gqa, residual, mean, xy]
+            type: double
+            indexed: false
+        gqa_stddev_xy:
+            description: Standard Deviation of the values of the GCP residuals
+            offset: [gqa, residual, stddev, xy]
+            type: double
+            indexed: false
+
+---
 name: gqa_eo
 description: Minimal eo metadata for products with GQA.
 dataset:
@@ -67,13 +191,18 @@ dataset:
             max_offset:
             - [extent, to_dt]
 
+        gqa:
+            description: GQA Circular error probable (90%)
+            type: double
+            offset: [gqa, cep90]
+            indexed: false
         gqa_error_message:
             description: GQA Error Message
             offset: [gqa, error_message]
             indexed: false
-        gqa_final_qa_count:
+        gqa_final_gcp_count:
             description: GQA GCP Count
-            offset: [gqa, final_qa_count]
+            offset: [gqa, final_gcp_count]
             type: integer
             indexed: false
         gqa_ref_source:
@@ -115,6 +244,7 @@ dataset:
             offset: [gqa, residual, stddev, xy]
             type: double
             indexed: false
+
 ---
 name: eo
 description: Minimal eo metadata for products without custom fields.

--- a/digitalearthau/config/metadata-types.yaml
+++ b/digitalearthau/config/metadata-types.yaml
@@ -1,4 +1,4 @@
-name: dea_eo_v1
+name: eo_plus
 description: EO metadata for DEA products with GQA.
 dataset:
     id: ['id']

--- a/integration_tests/test_config.py
+++ b/integration_tests/test_config.py
@@ -11,6 +11,7 @@ def test_dea_config(dea_index: Index):
 
     assert md_names == {
         'eo',
+        'eo_plus',
         'gqa_eo',
         'landsat_l1_scene',
         'landsat_scene',


### PR DESCRIPTION
Turns out that just one metadata type won't do.

The Sentinel-2 ARD products in the current database have their metadata type set to `gqa_eo` whose GQA fields are not yet searchable. This PR fixes that, with the correction over the last one that `gqa_final_qa_count` should actually be `gqa_final_gcp_count` to conform with the existing datasets.

The upgraded collection will however call that field `gqa_final_qa_count` which necessitates another version of the EO metadata type (called `eo_plus` in this PR).