### PR TITLE
Increase the allowed cache age to 23hrs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - '3.6'
 sudo: true
 git:
-  # We need a deeper depth for 'git desc
+  # We need a deeper depth for 'git describe' to ensure
   # we can reach the last tagged version. Defaults to only 50
   depth: 99999
 addons:

--- a/digitalearthau/sync/scan.py
+++ b/digitalearthau/sync/scan.py
@@ -25,8 +25,8 @@ from .differences import ArchivedDatasetOnDisk, Mismatch, LocationMissingOnDisk,
 
 _LOG = structlog.get_logger()
 
-# 24 hours (roughly the same day)
-CACHE_TIMEOUT_SECS = 60 * 60 * 24
+# 23 hours (roughly the same day)
+CACHE_TIMEOUT_SECS = 60 * 60 * 23
 
 
 def cache_is_too_old(path):

--- a/digitalearthau/sync/scan.py
+++ b/digitalearthau/sync/scan.py
@@ -25,8 +25,8 @@ from .differences import ArchivedDatasetOnDisk, Mismatch, LocationMissingOnDisk,
 
 _LOG = structlog.get_logger()
 
-# 12 hours (roughly the same workday)
-CACHE_TIMEOUT_SECS = 60 * 60 * 12
+# 24 hours (roughly the same day)
+CACHE_TIMEOUT_SECS = 60 * 60 * 24
 
 
 def cache_is_too_old(path):

--- a/digitalearthau/testing/testing-default.conf
+++ b/digitalearthau/testing/testing-default.conf
@@ -1,4 +1,3 @@
 [datacube]
-db_hostname: agdcdev-db.nci.org.au
-db_port: 6432
-db_database: ncitest_datacube_db
+db_hostname: localhost
+db_database: dea_integration

--- a/digitalearthau/testing/testing-default.conf
+++ b/digitalearthau/testing/testing-default.conf
@@ -1,3 +1,4 @@
 [datacube]
-db_hostname: localhost
-db_database: dea_integration
+db_hostname: agdcdev-db.nci.org.au
+db_port: 6432
+db_database: ncitest_datacube_db

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'boltons',
         'lxml',
         'pydash',
+        'colorama', # required to work around a structlog issue
     ],
     tests_require=tests_require,
     extras_require=extras_require,


### PR DESCRIPTION
# Reason for this pull request
Multiple `dea-sync` jobs for a given product try to access the same `cache` file, after the `cache` age time has elapsed. 

# Proposed solution
Increase `cache` file age to 24 hours from 12 hours. This would give sufficient time while the jobs wait for execution in the `pbs` queue.

- Fixes #201 