### PR TITLE
Generate sample netcdfs in a style closer to production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_install:
   - export GDAL_DATA="$(gdal-config --datadir)"
   - pip install --upgrade pip
   - pip install --progress-bar off coveralls codecov
-  - pip install NetCDF4==1.3.1
+  - pip install NetCDF4==1.4.1
 
   # Install pygdal bindings compatible with dpkg based gdal libs
   - pip install pygdal>="$(gdal-config --version)"

--- a/integration_tests/test_move.py
+++ b/integration_tests/test_move.py
@@ -33,7 +33,7 @@ def example_nc_dataset(integration_test_data, dea_index):
     assert dataset_file.parent.exists()
     assert not dataset_file.exists()
 
-    make_fake_netcdf_dataset(dataset_file, template)
+    make_fake_netcdf_dataset(dataset_file, template.read_text())
 
     assert dataset_file.exists()
 
@@ -55,14 +55,16 @@ def example_nc_dataset(integration_test_data, dea_index):
     )
 
 
-def test_netcdf_creation(integration_test_data):
-    template = integration_test_data / 'example_nbar_dataset.yaml'
-    dataset_file = integration_test_data.joinpath('test.nc')
+def test_netcdf_creation(destination_path):
+    dataset_file = destination_path.joinpath('test.nc')
 
     assert dataset_file.parent.exists()
     assert not dataset_file.exists()
 
-    make_fake_netcdf_dataset(dataset_file, template)
+    make_fake_netcdf_dataset(dataset_file, '''
+    some text
+    with lines
+    ''')
 
     assert dataset_file.exists()
 
@@ -207,7 +209,7 @@ def _call_move(args, global_integration_cli_args) -> Result:
     return res
 
 
-def make_fake_netcdf_dataset(nc_name, yaml_doc):
+def make_fake_netcdf_dataset(nc_name, doc_text):
     from datacube.drivers.netcdf.writer import (
         Variable,
         create_variable,
@@ -219,8 +221,7 @@ def make_fake_netcdf_dataset(nc_name, yaml_doc):
     import numpy as np
 
     t = np.asarray([parse_time('2001-01-29 07:06:05.432')], dtype=np.datetime64)
-    content = yaml_doc.read_text()
-    npdata = np.asarray([content], dtype='S')
+    npdata = np.asarray([doc_text], dtype='S')
 
     with create_netcdf(nc_name) as nco:
         create_coordinate(nco, 'time', t, 'seconds since 1970-01-01 00:00:00')


### PR DESCRIPTION
This started as investigation of #208, but problem in that issue is due to binary package distributed by `netCDF4`, it has some binary incompatibility with `numpy`, problem goes away if latest `netCDF4` package is compiled on the system rather than pulling in binaries. I'm not fixing that instead just pinning `netCDF4` to the lastest version that works, which is `1.4.1`.

Changes are:

1. Create time axis that contain time
2. Use `datacube.drivers.netcdf.writer.*` helper methods rather than `netCDF4` lib directly
3. Using `netCDF4==1.4.1` in travis



