### PR TITLE
Jupyterlab extensions

### DIFF
--- a/modules/dea-env/environment.yaml
+++ b/modules/dea-env/environment.yaml
@@ -97,6 +97,7 @@ dependencies:
   - gunicorn
   - hdmedians
   - ipython-sql
+  - jupyterlab-git
   - jupyterlab_github
   - meinheld
   - modernize

--- a/modules/dea-env/environment.yaml
+++ b/modules/dea-env/environment.yaml
@@ -101,6 +101,7 @@ dependencies:
   - meinheld
   - modernize
   - mypy
+  - nbdime
   - opencv-python
   - perf
   - pudb

--- a/modules/dea-env/modulespec.yaml
+++ b/modules/dea-env/modulespec.yaml
@@ -26,5 +26,6 @@ finalise_commands:
 - jupyter labextension install --no-build jupyterlab_bokeh
 - jupyter labextension install --no-build @jupyterlab/github
 - jupyter labextension install --no-build @jupyterlab/geojson-extension
+- jupyter labextension install --no-build @jupyter-widgets/jupyterlab-manager
 - jupyter labextension install --no-build jupyter-leaflet
 - jupyter lab build

--- a/modules/dea-env/modulespec.yaml
+++ b/modules/dea-env/modulespec.yaml
@@ -28,4 +28,8 @@ finalise_commands:
 - jupyter labextension install --no-build @jupyterlab/geojson-extension
 - jupyter labextension install --no-build @jupyter-widgets/jupyterlab-manager
 - jupyter labextension install --no-build jupyter-leaflet
+- jupyter labextension install --no-build nbdime-jupyterlab
+- jupyter nbextension install --py nbdime --system
+- jupyter nbextension enable --py nbdime --system
+- jupyter serverextension enable --py nbdime --system
 - jupyter lab build

--- a/modules/dea-env/modulespec.yaml
+++ b/modules/dea-env/modulespec.yaml
@@ -28,8 +28,10 @@ finalise_commands:
 - jupyter labextension install --no-build @jupyterlab/geojson-extension
 - jupyter labextension install --no-build @jupyter-widgets/jupyterlab-manager
 - jupyter labextension install --no-build jupyter-leaflet
+- jupyter labextension install --no-build @jupyterlab/git
 - jupyter labextension install --no-build nbdime-jupyterlab
 - jupyter nbextension install --py nbdime --system
 - jupyter nbextension enable --py nbdime --system
+- jupyter serverextension enable --py jupyterlab_git --system
 - jupyter serverextension enable --py nbdime --system
 - jupyter lab build


### PR DESCRIPTION
Adding 3 more lab extensions:

- git: stage commit from jupyterlab 
- nbdime: visual diff of notebooks
- ipywidgets for jupyterlab: work with ipywidgets in jupyterlab

I have tried these extensions with manual install and that worked fine, but not sure how this is supposed to be tested.

