### PR TITLE
Update structlog dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,19 +37,17 @@ setup(
         'pytest-runner'
     ],
     install_requires=[
-        'colorama',
+        'colorama',  # Needed for structlog's CLI output.
         'click>=5.0',
         'datacube[celery]',
         'python-dateutil',
         'gdal',
         'eodatasets',
-        # dev module is used automatically when run interactively.
-        'structlog[dev]',
+        'structlog',
         'DAWG',
         'boltons',
         'lxml',
         'pydash',
-        'colorama', # required to work around a structlog issue
     ],
     tests_require=tests_require,
     extras_require=extras_require,


### PR DESCRIPTION
Structlog changed the meaning of their `[dev]` package: it now installs test+doc dependencies that we don't need.

Our build broke when they did this, and we fixed it in two separate branches by adding Colorama (once at the top of the dependencies and once at the bottom), which were later merged together.

This removes `[dev]` from structlog and removes the duplicate Colorama.

See: hynek/structlog@d6b7da7