### PR TITLE
Fix docs build in Travis CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+    - repo: https://github.com/adrienverge/yamllint.git
+      sha: v1.15.0
+      hooks:
+        - id: yamllint
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v2.1.0
+      hooks:
+        - id: end-of-file-fixer
+        - id: flake8
+        - id: check-docstring-first
+        - id: check-json
+        - id: check-yaml
+        - id: debug-statements
+        - id: name-tests-test
+          args: ['--django']
+        - id: requirements-txt-fixer
+        - id: check-added-large-files
+        - id: check-merge-conflict
+    - repo: https://github.com/pre-commit/mirrors-pylint
+      rev: 'v2.3.1'  # Use the sha / tag you want to point at
+      hooks:
+      - id: pylint

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,6 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'sphinx.ext.todo',
-    'jupyter_sphinx.embed_widgets',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -2,6 +2,5 @@ Sphinx
 nbsphinx
 sphinx_rtd_theme
 IPython
-jupyter_sphinx
 recommonmark
 pandoc<2.0.0


### PR DESCRIPTION
Travis CI `develop` branch build is still broken. I think this is because of an old `jupyter_sphinx` package the docs are looking for but not actually using.

The documentation builds correctly on my local machine.

This PR:
- removes the `jupyter_sphinx` package from `docs/conf.py`.
- adds an opt in [pre-commit](https://pre-commit.com) configuration