### PR TITLE
Product definition updates for C3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,6 @@ before_install:
 install:
   - travis_retry pip install --upgrade pytest
   - travis_retry pip install codecov cython boto3
-  - travis_retry pip install --extra-index-url https://packages.dea.ga.gov.au/ 'datacube>=0.0.dev0'
   - travis_retry pip install -e .[doc,test]
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_install:
   - pip install gdal=="$(gdal-config --version)"'.*'
 
 install:
-  - travis_retry pip install --upgrade pytest
+  - travis_retry pip install --upgrade pytest setuptools pip
   - travis_retry pip install codecov cython boto3
   - travis_retry pip install -e .[doc,test]
 

--- a/digitalearthau/config/eo3/eo3.odc-type.yaml
+++ b/digitalearthau/config/eo3/eo3.odc-type.yaml
@@ -2,8 +2,8 @@
 name: eo3
 description: Default EO3 with no custom fields
 dataset:
-  id: [id] # No longer configurable in newer ODCs.
-  sources: [lineage, source_datasets] # No longer configurable in newer ODCs.
+  id: [id]  # No longer configurable in newer ODCs.
+  sources: [lineage, source_datasets]  # No longer configurable in newer ODCs.
 
   grid_spatial: [grid_spatial, projection]
   measurements: [measurements]

--- a/digitalearthau/config/eo3/eo3_landsat_ard.odc-type.yaml
+++ b/digitalearthau/config/eo3/eo3_landsat_ard.odc-type.yaml
@@ -2,8 +2,8 @@
 name: eo3_landsat_ard
 description: EO3 for ARD Landsat Collection 3
 dataset:
-  id: [id] # No longer configurable in newer ODCs.
-  sources: [lineage, source_datasets] # No longer configurable in newer ODCs.
+  id: [id]  # No longer configurable in newer ODCs.
+  sources: [lineage, source_datasets]  # No longer configurable in newer ODCs.
 
   grid_spatial: [grid_spatial, projection]
   measurements: [measurements]

--- a/digitalearthau/config/eo3/eo3_landsat_ard.odc-type.yaml
+++ b/digitalearthau/config/eo3/eo3_landsat_ard.odc-type.yaml
@@ -278,3 +278,9 @@ dataset:
         - properties
         - gqa:stddev_y
       type: double
+    landsat_scene_id:
+      description: Landsat Scene ID
+      indexed: false
+      offset:
+        - properties
+        - landsat:landsat_scene_id

--- a/digitalearthau/config/eo3/eo3_landsat_l1.odc-type.yaml
+++ b/digitalearthau/config/eo3/eo3_landsat_l1.odc-type.yaml
@@ -127,3 +127,9 @@ dataset:
       offset:
         - properties
         - landsat:landsat_scene_id
+    landsat_data_type:
+      description: "Landsat Data Type (eg. 'L1T')"
+      indexed: false
+      offset:
+        - properties
+        - landsat:data_type

--- a/digitalearthau/config/eo3/eo3_landsat_l1.odc-type.yaml
+++ b/digitalearthau/config/eo3/eo3_landsat_l1.odc-type.yaml
@@ -2,8 +2,8 @@
 name: eo3_landsat_l1
 description: EO3 for Level 1 Landsat, GA Collection 3
 dataset:
-  id: [id] # No longer configurable in newer ODCs.
-  sources: [lineage, source_datasets] # No longer configurable in newer ODCs.
+  id: [id]  # No longer configurable in newer ODCs.
+  sources: [lineage, source_datasets]  # No longer configurable in newer ODCs.
 
   grid_spatial: [grid_spatial, projection]
   measurements: [measurements]

--- a/digitalearthau/config/eo3/products/ard_ls5.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/ard_ls5.odc-product.yaml
@@ -8,6 +8,12 @@ license: CC-BY-4.0
 metadata:
   product:
     name: ga_ls5t_ard_3
+  properties:
+     eo:platform: landsat-5
+     eo:instrument: TM
+     dea:dataset_maturity: final
+     odc:product_family: ard
+     odc:producer: ga.gov.au
 
 measurements:
   # NBAR

--- a/digitalearthau/config/eo3/products/ard_ls5.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/ard_ls5.odc-product.yaml
@@ -14,6 +14,7 @@ metadata:
      dea:dataset_maturity: final
      odc:product_family: ard
      odc:producer: ga.gov.au
+     landsat:collection_number: 1
 
 measurements:
   # NBAR

--- a/digitalearthau/config/eo3/products/ard_ls5.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/ard_ls5.odc-product.yaml
@@ -3,6 +3,8 @@ name: ga_ls5t_ard_3
 description: Geoscience Australia Landsat 5 Thematic Mapper Analysis Ready Data Collection 3
 metadata_type: eo3_landsat_ard
 
+license: CC-BY-4.0
+
 metadata:
   product:
     name: ga_ls5t_ard_3

--- a/digitalearthau/config/eo3/products/ard_ls7.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/ard_ls7.odc-product.yaml
@@ -3,6 +3,8 @@ name: ga_ls7e_ard_3
 description: Geoscience Australia Landsat 7 Enhanced Thematic Mapper Plus Analysis Ready Data Collection 3
 metadata_type: eo3_landsat_ard
 
+license: CC-BY-4.0
+
 metadata:
   product:
     name: ga_ls7e_ard_3

--- a/digitalearthau/config/eo3/products/ard_ls7.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/ard_ls7.odc-product.yaml
@@ -14,6 +14,7 @@ metadata:
      dea:dataset_maturity: final
      odc:product_family: ard
      odc:producer: ga.gov.au
+     landsat:collection_number: 1
 
 measurements:
   # NBAR

--- a/digitalearthau/config/eo3/products/ard_ls7.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/ard_ls7.odc-product.yaml
@@ -8,6 +8,12 @@ license: CC-BY-4.0
 metadata:
   product:
     name: ga_ls7e_ard_3
+  properties:
+     eo:platform: landsat-7
+     eo:instrument: ETM
+     dea:dataset_maturity: final
+     odc:product_family: ard
+     odc:producer: ga.gov.au
 
 measurements:
   # NBAR

--- a/digitalearthau/config/eo3/products/ard_ls8.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/ard_ls8.odc-product.yaml
@@ -8,6 +8,12 @@ license: CC-BY-4.0
 metadata:
   product:
     name: ga_ls8c_ard_3
+  properties:
+     eo:platform: landsat-8
+     eo:instrument: OLI_TIRS
+     dea:dataset_maturity: final
+     odc:product_family: ard
+     odc:producer: ga.gov.au
 
 measurements:
   # NBAR

--- a/digitalearthau/config/eo3/products/ard_ls8.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/ard_ls8.odc-product.yaml
@@ -14,6 +14,7 @@ metadata:
      dea:dataset_maturity: final
      odc:product_family: ard
      odc:producer: ga.gov.au
+     landsat:collection_number: 1
 
 measurements:
   # NBAR

--- a/digitalearthau/config/eo3/products/ard_ls8.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/ard_ls8.odc-product.yaml
@@ -3,6 +3,8 @@ name: ga_ls8c_ard_3
 description: Geoscience Australia Landsat 8 Operational Land Imager and Thermal Infra-Red Scanner Analysis Ready Data Collection 3
 metadata_type: eo3_landsat_ard
 
+license: CC-BY-4.0
+
 metadata:
   product:
     name: ga_ls8c_ard_3

--- a/digitalearthau/config/eo3/products/l1_ls5.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls5.odc-product.yaml
@@ -3,6 +3,8 @@ name: usgs_ls5t_level1_1
 description: United States Geological Survey Landsat 5 Thematic Mapper Level 1 Collection 1
 metadata_type: eo3_landsat_l1
 
+license: CC-BY-4.0
+
 metadata:
   product:
     name: usgs_ls5t_level1_1

--- a/digitalearthau/config/eo3/products/l1_ls5.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls5.odc-product.yaml
@@ -13,6 +13,7 @@ metadata:
      eo:instrument: TM
      odc:product_family: level1
      odc:producer: usgs.gov
+     landsat:collection_number: 1
 
 measurements:
   - name: blue

--- a/digitalearthau/config/eo3/products/l1_ls5.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls5.odc-product.yaml
@@ -8,6 +8,11 @@ license: CC-BY-4.0
 metadata:
   product:
     name: usgs_ls5t_level1_1
+  properties:
+     eo:platform: landsat-5
+     eo:instrument: TM
+     odc:product_family: level1
+     odc:producer: usgs.gov
 
 measurements:
   - name: blue

--- a/digitalearthau/config/eo3/products/l1_ls5_ga.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls5_ga.odc-product.yaml
@@ -1,0 +1,52 @@
+---
+name: ga_ls5t_level1_3
+description: Landsat 5 TM Level 1, GA Collection 3
+metadata_type: eo3_landsat_l1
+
+metadata:
+  product:
+    name: ga_ls5t_level1_3
+
+measurements:
+  - name: blue
+    aliases:
+      - band01
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: green
+    aliases:
+      - band02
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: red
+    aliases:
+      - band03
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: nir
+    aliases:
+      - band04
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: swir_1
+    aliases:
+      - band05
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: swir_2
+    aliases:
+      - band07
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: quality
+    aliases:
+      - bqa
+    dtype: uint16
+    nodata: 65535
+    units: '1'

--- a/digitalearthau/config/eo3/products/l1_ls5_ga.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls5_ga.odc-product.yaml
@@ -3,6 +3,8 @@ name: ga_ls5t_level1_3
 description: Geoscience Australia Landsat 5 Thematic Mapper Level 1 Collection 3
 metadata_type: eo3_landsat_l1
 
+license: CC-BY-4.0
+
 metadata:
   product:
     name: ga_ls5t_level1_3

--- a/digitalearthau/config/eo3/products/l1_ls5_ga.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls5_ga.odc-product.yaml
@@ -8,6 +8,11 @@ license: CC-BY-4.0
 metadata:
   product:
     name: ga_ls5t_level1_3
+  properties:
+     eo:platform: landsat-5
+     eo:instrument: TM
+     odc:product_family: level1
+     odc:producer: ga.gov.au
 
 measurements:
   - name: blue

--- a/digitalearthau/config/eo3/products/l1_ls5_ga.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls5_ga.odc-product.yaml
@@ -13,6 +13,7 @@ metadata:
      eo:instrument: TM
      odc:product_family: level1
      odc:producer: ga.gov.au
+     landsat:collection_number: 1
 
 measurements:
   - name: blue

--- a/digitalearthau/config/eo3/products/l1_ls5_ga.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls5_ga.odc-product.yaml
@@ -1,6 +1,6 @@
 ---
 name: ga_ls5t_level1_3
-description: Landsat 5 TM Level 1, GA Collection 3
+description: Geoscience Australia Landsat 5 Thematic Mapper Level 1 Collection 3
 metadata_type: eo3_landsat_l1
 
 metadata:

--- a/digitalearthau/config/eo3/products/l1_ls7.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls7.odc-product.yaml
@@ -8,7 +8,11 @@ license: CC-BY-4.0
 metadata:
   product:
     name: usgs_ls7e_level1_1
-
+  properties:
+    eo:platform: landsat-7
+    eo:instrument: ETM
+    odc:product_family: level1
+    odc:producer: usgs.gov
 measurements:
   - name: blue
     aliases:

--- a/digitalearthau/config/eo3/products/l1_ls7.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls7.odc-product.yaml
@@ -9,10 +9,12 @@ metadata:
   product:
     name: usgs_ls7e_level1_1
   properties:
-    eo:platform: landsat-7
-    eo:instrument: ETM
-    odc:product_family: level1
-    odc:producer: usgs.gov
+     eo:platform: landsat-7
+     eo:instrument: ETM
+     odc:product_family: level1
+     odc:producer: usgs.gov
+     landsat:collection_number: 1
+
 measurements:
   - name: blue
     aliases:

--- a/digitalearthau/config/eo3/products/l1_ls7.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls7.odc-product.yaml
@@ -3,6 +3,8 @@ name: usgs_ls7e_level1_1
 description: United States Geological Survey Landsat 7 Enhanced Thematic Mapper Plus Level 1 Collection 1
 metadata_type: eo3_landsat_l1
 
+license: CC-BY-4.0
+
 metadata:
   product:
     name: usgs_ls7e_level1_1

--- a/digitalearthau/config/eo3/products/l1_ls7_ga.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls7_ga.odc-product.yaml
@@ -9,10 +9,11 @@ metadata:
   product:
     name: ga_ls7e_level1_3
   properties:
-    eo:platform: landsat-7
-    eo:instrument: ETM
-    odc:product_family: level1
-    odc:producer: ga.gov.au
+     eo:platform: landsat-7
+     eo:instrument: ETM
+     odc:product_family: level1
+     odc:producer: ga.gov.au
+     landsat:collection_number: 1
 
 measurements:
   - name: blue

--- a/digitalearthau/config/eo3/products/l1_ls7_ga.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls7_ga.odc-product.yaml
@@ -1,6 +1,6 @@
 ---
 name: ga_ls7e_level1_3
-description: Landsat 7 ETM+ Level 1, GA Collection 3
+description: Geoscience Australia Landsat 7 Enhanced Thematic Mapper Plus Level 1 Collection 3
 metadata_type: eo3_landsat_l1
 
 metadata:

--- a/digitalearthau/config/eo3/products/l1_ls7_ga.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls7_ga.odc-product.yaml
@@ -3,6 +3,8 @@ name: ga_ls7e_level1_3
 description: Geoscience Australia Landsat 7 Enhanced Thematic Mapper Plus Level 1 Collection 3
 metadata_type: eo3_landsat_l1
 
+license: CC-BY-4.0
+
 metadata:
   product:
     name: ga_ls7e_level1_3

--- a/digitalearthau/config/eo3/products/l1_ls7_ga.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls7_ga.odc-product.yaml
@@ -8,6 +8,11 @@ license: CC-BY-4.0
 metadata:
   product:
     name: ga_ls7e_level1_3
+  properties:
+    eo:platform: landsat-7
+    eo:instrument: ETM
+    odc:product_family: level1
+    odc:producer: ga.gov.au
 
 measurements:
   - name: blue

--- a/digitalearthau/config/eo3/products/l1_ls7_ga.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls7_ga.odc-product.yaml
@@ -1,0 +1,58 @@
+---
+name: ga_ls7e_level1_3
+description: Landsat 7 ETM+ Level 1, GA Collection 3
+metadata_type: eo3_landsat_l1
+
+metadata:
+  product:
+    name: ga_ls7e_level1_3
+
+measurements:
+  - name: blue
+    aliases:
+      - band01
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: green
+    aliases:
+      - band02
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: red
+    aliases:
+      - band03
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: nir
+    aliases:
+      - band04
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: swir_1
+    aliases:
+      - band05
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: swir_2
+    aliases:
+      - band07
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+    #   - name: panchromatic
+    #     aliases:
+    #       - band08
+    #     dtype: uint16
+    #     nodata: 65535
+    #     units: '1'
+  - name: quality
+    aliases:
+      - bqa
+    dtype: uint16
+    nodata: 65535
+    units: '1'

--- a/digitalearthau/config/eo3/products/l1_ls8.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls8.odc-product.yaml
@@ -9,10 +9,11 @@ metadata:
   product:
     name: usgs_ls8c_level1_1
   properties:
-    eo:platform: landsat-8
-    eo:instrument: OLI_TIRS
-    odc:product_family: level1
-    odc:producer: usgs.gov
+     eo:platform: landsat-8
+     eo:instrument: OLI_TIRS
+     odc:product_family: level1
+     odc:producer: usgs.gov
+     landsat:collection_number: 1
 
 measurements:
   - name: coastal_aerosol

--- a/digitalearthau/config/eo3/products/l1_ls8.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls8.odc-product.yaml
@@ -3,6 +3,8 @@ name: usgs_ls8c_level1_1
 description: United States Geological Survey Landsat 8 Operational Land Imager and Thermal Infra-Red Scanner Level 1 Collection 1
 metadata_type: eo3_landsat_l1
 
+license: CC-BY-4.0
+
 metadata:
   product:
     name: usgs_ls8c_level1_1

--- a/digitalearthau/config/eo3/products/l1_ls8.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls8.odc-product.yaml
@@ -8,6 +8,11 @@ license: CC-BY-4.0
 metadata:
   product:
     name: usgs_ls8c_level1_1
+  properties:
+    eo:platform: landsat-8
+    eo:instrument: OLI_TIRS
+    odc:product_family: level1
+    odc:producer: usgs.gov
 
 measurements:
   - name: coastal_aerosol

--- a/digitalearthau/config/eo3/products/l1_ls8_ga.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls8_ga.odc-product.yaml
@@ -3,6 +3,8 @@ name: ga_ls8c_level1_3
 description: Geoscience Australia Landsat 8 Operational Land Imager and Thermal Infra-Red Scanner Level 1 Collection 3
 metadata_type: eo3_landsat_l1
 
+license: CC-BY-4.0
+
 metadata:
   product:
     name: ga_ls8c_level1_3

--- a/digitalearthau/config/eo3/products/l1_ls8_ga.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls8_ga.odc-product.yaml
@@ -9,10 +9,11 @@ metadata:
   product:
     name: ga_ls8c_level1_3
   properties:
-    eo:platform: landsat-8
-    eo:instrument: OLI_TIRS
-    odc:product_family: level1
-    odc:producer: ga.gov.au
+     eo:platform: landsat-8
+     eo:instrument: OLI_TIRS
+     odc:product_family: level1
+     odc:producer: ga.gov.au
+     landsat:collection_number: 1
 
 measurements:
   - name: coastal_aerosol

--- a/digitalearthau/config/eo3/products/l1_ls8_ga.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls8_ga.odc-product.yaml
@@ -8,6 +8,11 @@ license: CC-BY-4.0
 metadata:
   product:
     name: ga_ls8c_level1_3
+  properties:
+    eo:platform: landsat-8
+    eo:instrument: OLI_TIRS
+    odc:product_family: level1
+    odc:producer: ga.gov.au
 
 measurements:
   - name: coastal_aerosol

--- a/digitalearthau/config/eo3/products/l1_ls8_ga.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls8_ga.odc-product.yaml
@@ -1,6 +1,6 @@
 ---
 name: ga_ls8c_level1_3
-description: Landsat 8 OLI-TIRS Level 1, GA Collection 3
+description: Geoscience Australia Landsat 8 Operational Land Imager and Thermal Infra-Red Scanner Level 1 Collection 3
 metadata_type: eo3_landsat_l1
 
 metadata:

--- a/digitalearthau/config/eo3/products/l1_ls8_ga.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/l1_ls8_ga.odc-product.yaml
@@ -1,0 +1,82 @@
+---
+name: ga_ls8c_level1_3
+description: Landsat 8 OLI-TIRS Level 1, GA Collection 3
+metadata_type: eo3_landsat_l1
+
+metadata:
+  product:
+    name: ga_ls8c_level1_3
+
+measurements:
+  - name: coastal_aerosol
+    aliases:
+      - band01
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: blue
+    aliases:
+      - band02
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: green
+    aliases:
+      - band03
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: red
+    aliases:
+      - band04
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: nir
+    aliases:
+      - band05
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: swir_1
+    aliases:
+      - band06
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: swir_2
+    aliases:
+      - band07
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: panchromatic
+    aliases:
+      - band08
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: cirrus
+    aliases:
+      - band09
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: lwir_1
+    aliases:
+      - band10
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: lwir_2
+    aliases:
+      - band11
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: quality
+    aliases:
+      - bqa
+    dtype: uint16
+    nodata: 65535
+    units: '1'

--- a/digitalearthau/config/metadata-types.odc-type.yaml
+++ b/digitalearthau/config/metadata-types.odc-type.yaml
@@ -1,4 +1,4 @@
-
+---
 name: gqa_eo
 description: Minimal eo metadata for products with GQA.
 dataset:

--- a/digitalearthau/config/metadata-types.odc-type.yaml
+++ b/digitalearthau/config/metadata-types.odc-type.yaml
@@ -1,127 +1,4 @@
-name: eo_plus
-description: EO metadata for DEA products with GQA.
-dataset:
-    id: ['id']
-    creation_dt: ['system_information', 'time_processed']
-    label: ['ga_label']
-    measurements: ['image', 'bands']
-    grid_spatial: ['grid_spatial', 'projection']
-    format: ['format', 'name']
-    sources: ['lineage', 'source_datasets']
 
-    search_fields:
-        region_code:
-            description: Spatial reference code from the provider
-            offset: [provider, reference_code]
-
-        platform:
-            description: Platform code
-            offset: [platform, code]
-
-        instrument:
-            description: Instrument name
-            offset: [instrument, name]
-
-        product_type:
-            description: Product code
-            offset: [product_type]
-
-        format:
-            description: File format (GeoTIFF, NetCDF)
-            offset: [format, name]
-            indexed: false
-
-        lat:
-            description: Latitude range
-            type: double-range
-            max_offset:
-            - [extent, coord, ur, lat]
-            - [extent, coord, lr, lat]
-            - [extent, coord, ul, lat]
-            - [extent, coord, ll, lat]
-            min_offset:
-            - [extent, coord, ur, lat]
-            - [extent, coord, lr, lat]
-            - [extent, coord, ul, lat]
-            - [extent, coord, ll, lat]
-
-        lon:
-            description: Longitude range
-            type: double-range
-            max_offset:
-            - [extent, coord, ul, lon]
-            - [extent, coord, ur, lon]
-            - [extent, coord, ll, lon]
-            - [extent, coord, lr, lon]
-            min_offset:
-            - [extent, coord, ul, lon]
-            - [extent, coord, ur, lon]
-            - [extent, coord, ll, lon]
-            - [extent, coord, lr, lon]
-
-        time:
-            description: Acquisition time
-            type: datetime-range
-            min_offset:
-            - [extent, from_dt]
-            max_offset:
-            - [extent, to_dt]
-
-        gqa:
-            description: GQA circular error probable (90%)
-            type: double
-            offset: [gqa, cep90]
-            indexed: false
-        gqa_error_message:
-            description: GQA error message
-            offset: [gqa, error_message]
-            indexed: false
-        gqa_final_qa_count:
-            description: GQA QA point count
-            offset: [gqa, final_qa_count]
-            type: integer
-            indexed: false
-        gqa_ref_source:
-            description: GQA reference imagery collection name
-            offset: [gqa, ref_source]
-            indexed: false
-        gqa_cep90:
-            description: Circular error probable (90%) of the values of the GCP residuals
-            offset: [gqa, residual, cep90]
-            type: double
-            indexed: false
-        gqa_abs_xy:
-            description: Absolute value of the total GCP residual
-            offset: [gqa, residual, abs, xy]
-            type: double
-            indexed: false
-        gqa_abs_iterative_mean_xy:
-            description: Mean of the absolute values of the GCP residuals after removal of outliers
-            offset: [gqa, residual, abs_iterative_mean, xy]
-            type: double
-            indexed: false
-        gqa_iterative_mean_xy:
-            description: Mean of the values of the GCP residuals after removal of outliers
-            offset: [gqa, residual, iterative_mean, xy]
-            type: double
-            indexed: false
-        gqa_iterative_stddev_xy:
-            description: Standard Deviation of the values of the GCP residuals after removal of outliers
-            offset: [gqa, residual, iterative_stddev, xy]
-            type: double
-            indexed: false
-        gqa_mean_xy:
-            description: Mean of the values of the GCP residuals
-            offset: [gqa, residual, mean, xy]
-            type: double
-            indexed: false
-        gqa_stddev_xy:
-            description: Standard Deviation of the values of the GCP residuals
-            offset: [gqa, residual, stddev, xy]
-            type: double
-            indexed: false
-
----
 name: gqa_eo
 description: Minimal eo metadata for products with GQA.
 dataset:
@@ -141,10 +18,12 @@ dataset:
         platform:
             description: Platform code
             offset: [platform, code]
+            indexed: false
 
         instrument:
             description: Instrument name
             offset: [instrument, name]
+            indexed: false
 
         product_type:
             description: Product code
@@ -261,10 +140,12 @@ dataset:
         platform:
             description: Platform code
             offset: [platform, code]
+            indexed: false
 
         instrument:
             description: Instrument name
             offset: [instrument, name]
+            indexed: false
 
         product_type:
             description: Product code
@@ -334,6 +215,7 @@ dataset:
         instrument:
             description: Instrument name
             offset: [instrument, name]
+            indexed: false
 
         product_type:
             description: Product code
@@ -355,7 +237,31 @@ dataset:
         orbit:
             description: Orbit number
             offset: [acquisition, platform_orbit]
+            indexed: False
 
+        sat_path:
+            description: Landsat path
+            indexed: false
+
+            type: integer-range
+            min_offset:
+            - [image, satellite_ref_point_start, x]
+            max_offset:
+            - [image, satellite_ref_point_end, x]
+            # If an end is not specified, use the start.
+            - [image, satellite_ref_point_start, x]
+
+        sat_row:
+            description: Landsat row
+            indexed: false
+
+            type: integer-range
+            min_offset:
+            - [image, satellite_ref_point_start, y]
+            max_offset:
+            - [image, satellite_ref_point_end, y]
+            # If an end is not specified, use the start.
+            - [image, satellite_ref_point_start, y]
 
 ---
 
@@ -484,6 +390,11 @@ dataset:
         product_type:
             description: Product code
             offset: [product_type]
+            indexed: false
+
+        product_level:
+            description: Product Level (eg. L1T)
+            offset: [product_level]
             indexed: false
 
         format:

--- a/digitalearthau/config/products/s2a_s2b_tsmask.odc-product.yaml
+++ b/digitalearthau/config/products/s2a_s2b_tsmask.odc-product.yaml
@@ -25,4 +25,4 @@ metadata:
     platform:
         code: SENTINEL_2A,SENTINEL_2B
     product_type: S2_MSI_TSmask
-metadata_type: eo_plus
+metadata_type: eo

--- a/integration_tests/test_config.py
+++ b/integration_tests/test_config.py
@@ -13,7 +13,6 @@ def test_dea_config(dea_index: Index):
 
     expected_mds = sorted([
         'eo',
-        'eo_plus',
         'gqa_eo',
         'landsat_l1_scene',
         'landsat_scene',

--- a/integration_tests/test_config.py
+++ b/integration_tests/test_config.py
@@ -109,6 +109,9 @@ def test_dea_config(dea_index: Index):
         'ga_ls5t_ard_3',
         'ga_ls7e_ard_3',
         'ga_ls8c_ard_3',
+        'ga_ls5t_level1_3',
+        'ga_ls7e_level1_3',
+        'ga_ls8c_level1_3',
     }
 
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'attrs>=19.2.0',
         'colorama',  # Needed for structlog's CLI output.
         'click>=5.0',
-        'datacube[celery]',
+        'datacube[celery] >= 1.8',
         'python-dateutil',
         'gdal',
         'eodatasets3>=0.4.0',


### PR DESCRIPTION
(see commit messages below: they're clean, so no point repeating here?)

The only potentially-breaking change is increasing the ODC requirement to version 1.8, as its needed for license fields in products. But all DEA environments should now use 1.8, I assume?