### PR TITLE
Allow multiple product maturities in C3 ARD products

### DIFF
--- a/digitalearthau/config/eo3/products-aws/ard_ls5.odc-product.yaml
+++ b/digitalearthau/config/eo3/products-aws/ard_ls5.odc-product.yaml
@@ -11,7 +11,6 @@ metadata:
   properties:
      eo:platform: landsat-5
      eo:instrument: TM
-     dea:dataset_maturity: final
      odc:product_family: ard
      odc:producer: ga.gov.au
      landsat:collection_number: 1

--- a/digitalearthau/config/eo3/products-aws/ard_ls7.odc-product.yaml
+++ b/digitalearthau/config/eo3/products-aws/ard_ls7.odc-product.yaml
@@ -11,7 +11,6 @@ metadata:
   properties:
      eo:platform: landsat-7
      eo:instrument: ETM
-     dea:dataset_maturity: final
      odc:product_family: ard
      odc:producer: ga.gov.au
      landsat:collection_number: 1

--- a/digitalearthau/config/eo3/products-aws/ard_ls8.odc-product.yaml
+++ b/digitalearthau/config/eo3/products-aws/ard_ls8.odc-product.yaml
@@ -11,7 +11,6 @@ metadata:
   properties:
      eo:platform: landsat-8
      eo:instrument: OLI_TIRS
-     dea:dataset_maturity: final
      odc:product_family: ard
      odc:producer: ga.gov.au
      landsat:collection_number: 1

--- a/digitalearthau/config/eo3/products/ard_ls5.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/ard_ls5.odc-product.yaml
@@ -11,7 +11,6 @@ metadata:
   properties:
      eo:platform: landsat-5
      eo:instrument: TM
-     dea:dataset_maturity: final
      odc:product_family: ard
      odc:producer: ga.gov.au
      landsat:collection_number: 1

--- a/digitalearthau/config/eo3/products/ard_ls7.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/ard_ls7.odc-product.yaml
@@ -11,7 +11,6 @@ metadata:
   properties:
      eo:platform: landsat-7
      eo:instrument: ETM
-     dea:dataset_maturity: final
      odc:product_family: ard
      odc:producer: ga.gov.au
      landsat:collection_number: 1

--- a/digitalearthau/config/eo3/products/ard_ls8.odc-product.yaml
+++ b/digitalearthau/config/eo3/products/ard_ls8.odc-product.yaml
@@ -11,7 +11,6 @@ metadata:
   properties:
      eo:platform: landsat-8
      eo:instrument: OLI_TIRS
-     dea:dataset_maturity: final
      odc:product_family: ard
      odc:producer: ga.gov.au
      landsat:collection_number: 1


### PR DESCRIPTION
As requested by the C3 ARD production group. To put interim datasets into the same product.