### PR TITLE
Add cloud_cover to EO3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ docs/notebooks
 
 # MYPY static type checker cache
 .mypy_cache
+
+.vscode

--- a/digitalearthau/config/eo3/eo3.odc-type.yaml
+++ b/digitalearthau/config/eo3/eo3.odc-type.yaml
@@ -47,6 +47,7 @@ dataset:
       description: Cloud cover percentage [0, 100]
       type: double
       offset: [properties, 'eo:cloud_cover']
+      indexed: false
 
     time:
       description: Acquisition time range

--- a/digitalearthau/config/eo3/eo3.odc-type.yaml
+++ b/digitalearthau/config/eo3/eo3.odc-type.yaml
@@ -43,6 +43,11 @@ dataset:
       offset: [properties, 'dea:dataset_maturity']
       indexed: false
 
+    cloud_cover:
+      description: Cloud cover percentage [0, 100]
+      type: double
+      offset: [properties, 'eo:cloud_cover']
+
     time:
       description: Acquisition time range
       type: datetime-range


### PR DESCRIPTION
Doing `datacube metadata update` applies instantly and immediately makes this field queryable.