### PR TITLE
Add raw CRS string as an eo3 search field

### DIFF
--- a/digitalearthau/config/eo3/eo3.odc-type.yaml
+++ b/digitalearthau/config/eo3/eo3.odc-type.yaml
@@ -35,8 +35,12 @@ dataset:
         For Sentinel it is MGRS code.
         In general it is a unique string identifier that datasets
         covering roughly the same spatial region share.
-
       offset: [properties, 'odc:region_code']
+
+    crs_raw:
+      description: The raw CRS string as it appears in metadata
+      offset: ['crs']
+      indexed: false
 
     dataset_maturity:
       description: One of - final|interim|nrt  (near real time)

--- a/digitalearthau/config/eo3/eo3_landsat_ard.odc-type.yaml
+++ b/digitalearthau/config/eo3/eo3_landsat_ard.odc-type.yaml
@@ -39,6 +39,11 @@ dataset:
 
       offset: [properties, 'odc:region_code']
 
+    crs_raw:
+      description: The raw CRS string as it appears in metadata
+      offset: ['crs']
+      indexed: false
+
     dataset_maturity:
       description: One of - final|interim|nrt  (near real time)
       offset: [properties, 'dea:dataset_maturity']

--- a/digitalearthau/config/eo3/eo3_landsat_l1.odc-type.yaml
+++ b/digitalearthau/config/eo3/eo3_landsat_l1.odc-type.yaml
@@ -38,6 +38,11 @@ dataset:
 
       offset: [properties, 'odc:region_code']
 
+    crs_raw:
+      description: The raw CRS string as it appears in metadata
+      offset: ['crs']
+      indexed: false
+
     dataset_maturity:
       description: One of - final|interim|nrt  (near real time)
       offset: [properties, 'dea:dataset_maturity']


### PR DESCRIPTION
As requested in #280


Example of updating my local (NCI-clone) datacube:
```
❯ datacube -v metadata update digitalearthau/config/eo3/eo3*.odc-type.yaml  
2021-03-03 17:03:33,217 13549 datacube INFO Running datacube command: /home/jez/dea/venv/bin/datacube -v metadata update eo3_landsat_ard.odc-type.yaml eo3_landsat_l1.odc-type.yaml eo3.odc-type.yaml
2021-03-03 17:03:33,271 13549 datacube.index._metadata_types INFO Safe change in dataset.search_fields.crs_raw from missing to {'description': 'The raw CRS string as appears in metadata', 'offset': ['crs'], 'indexed': False}
2021-03-03 17:03:33,271 13549 datacube.index._metadata_types INFO Updating metadata type eo3_landsat_ard
Updated "eo3_landsat_ard"
2021-03-03 17:03:33,443 13549 datacube.index._metadata_types INFO Safe change in dataset.search_fields.crs_raw from missing to {'description': 'The raw CRS string as appears in metadata', 'offset': ['crs'], 'indexed': False}
2021-03-03 17:03:33,443 13549 datacube.index._metadata_types INFO Updating metadata type eo3_landsat_l1
Updated "eo3_landsat_l1"
2021-03-03 17:03:33,590 13549 datacube.index._metadata_types INFO Safe change in dataset.search_fields.crs_raw from missing to {'description': 'The raw CRS string as appears in metadata', 'offset': ['crs'], 'indexed': False}
2021-03-03 17:03:33,590 13549 datacube.index._metadata_types INFO Updating metadata type eo3
Updated "eo3"
```

- ~Keeping as draft as I want to confirm a search locally, tomorrow morning, before merging~.
- I set `indexed: false` as I believe this will always be used with other, stronger query arguments.