### PR TITLE
add water_observed bit definition

### DIFF
--- a/digitalearthau/config/eo3/products-aws/ga_ls_wo_3.odc-product.yaml
+++ b/digitalearthau/config/eo3/products-aws/ga_ls_wo_3.odc-product.yaml
@@ -49,6 +49,10 @@ measurements:
         bits: 6
         description: Cloudy
         values: {0: false, 1: true}
+      water_observed:
+        bits: 7
+        description: Classified as water by the decision tree
+        values: {0: false, 1: true}
       wet:
         bits: [7, 6, 5, 4, 3, 2, 1, 0]
         description: Clear and Wet


### PR DESCRIPTION
As title. The bit `water_observed` exists in `c2`, which gives the flexibility to make mask. Would like it to be in `c3` to keep consistency.