### PR TITLE
Fix dea-env build: Split private/pypi reqs

### DIFF
--- a/nci_environment/dea/modulespec.yaml
+++ b/nci_environment/dea/modulespec.yaml
@@ -15,7 +15,7 @@ stable_module_deps:
 - dea-env
 
 install_pip_packages:
-  pip_cmd: "module load {fixed_dea_env}; pip install --no-warn-script-location --prefix {module_path} --requirement requirements.txt"
+  pip_cmd: "module load {fixed_dea_env}; pip install --no-warn-script-location --prefix {module_path} --requirement requirements.txt; pip install --no-warn-script-location --prefix {module_path} --requirement requirements-private.txt"
 
 copy_files:
 - src: requirements.txt

--- a/nci_environment/dea/requirements-private.txt
+++ b/nci_environment/dea/requirements-private.txt
@@ -1,0 +1,5 @@
+--extra-index-url https://packages.dea.ga.gov.au/
+datacube-stats
+fc
+hdstats
+wofs

--- a/nci_environment/dea/requirements.txt
+++ b/nci_environment/dea/requirements.txt
@@ -1,19 +1,7 @@
---extra-index-url https://packages.dea.ga.gov.au/
-datacube-alchemist
-datacube-stats
-dea_cogger
-digitalearthau
 eodatasets3
-fc
-hdstats
 odc-algo
 odc-apps-dc-tools
-odc-aws
 odc-dscache
-odc-dtools
 odc-geom
-odc-index
 odc-io
-odc-ppt
 odc-ui
-wofs


### PR DESCRIPTION
We're having ongoing troubles with pip insisting on installing new packages, that we don't want it to. Lets try this approach.